### PR TITLE
Distributed tclean+feather imaging dispatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ shadow-test/
 # Reference PDFs (local-only, not versioned)
 reference/
 
+# Operational scripts (deployment-specific, not part of the public package)
+scripts/
+
 # Handoff / internal docs (personal reference only)
 docs/
 

--- a/panta_rei/casa/tclean_feather.py
+++ b/panta_rei/casa/tclean_feather.py
@@ -96,10 +96,17 @@ def main():
     canonical = spec["canonical_paths"]
     unit = spec["unit"]
 
+    # Aux QA products to also export to FITS alongside the science cubes.
+    # Each entry maps a CASA image suffix (relative to ``imagename``) to
+    # the canonical FITS suffix used in the published file name.  Best
+    # effort: a missing or failing export does NOT fail the whole job.
+    aux_products = spec.get("aux_products") or ["mask", "residual", "pb"]
+
     result = {
         "success": False,
         "feathered_fits": None,
         "tclean_fits": None,
+        "aux_fits": {},
         "error_message": None,
     }
     result_path = run_dir / "result.json"
@@ -169,6 +176,35 @@ def main():
         log.info("Exporting feathered FITS: %s", feathered_fits_name)
         exportfits(imagename=feathered_image, fitsimage=local_feathered_fits, overwrite=True)
         result["feathered_fits"] = local_feathered_fits
+
+        # Best-effort export of QA aux products (mask/residual/pb).  The
+        # canonical paths come from the spec (so the runner controls
+        # filenames); we just produce the local FITS in run_dir and
+        # report each path under ``aux_fits[kind]``.  Failure of one
+        # aux export must not fail the job.
+        aux_canonical = spec.get("canonical_paths", {}).get("aux", {})
+        for kind in aux_products:
+            casa_image = f"{imagename}.{kind}"
+            if not Path(casa_image).exists():
+                log.warning("aux %s: CASA image not found at %s — skipping",
+                            kind, casa_image)
+                continue
+            canonical_aux = aux_canonical.get(kind)
+            if not canonical_aux:
+                log.warning("aux %s: no canonical path in spec — skipping",
+                            kind)
+                continue
+            local_aux_fits = str(run_dir / Path(canonical_aux).name)
+            try:
+                log.info("Exporting aux FITS: %s", Path(local_aux_fits).name)
+                exportfits(
+                    imagename=casa_image,
+                    fitsimage=local_aux_fits,
+                    overwrite=True,
+                )
+                result["aux_fits"][kind] = local_aux_fits
+            except Exception as aux_e:
+                log.warning("aux %s export failed: %s", kind, aux_e)
 
         result["success"] = True
         log.info("SUCCESS: %s", feathered_fits_name)

--- a/panta_rei/cli/run_calibration.py
+++ b/panta_rei/cli/run_calibration.py
@@ -150,22 +150,39 @@ def _ensure_db_success_for_existing_outputs(
 def _discover_scriptforpi(
     base_dir: Path,
 ) -> Iterator[Tuple[str, Path, Path, Dict[str, Optional[str]]]]:
-    for script_path in base_dir.rglob("script/*.py"):
-        if not _SCRIPT_NAME_RE.search(script_path.name):
-            continue
-        mous_dir = script_path.parent.parent
+    """Mirror of :func:`panta_rei.workflows.calibration.discover_scriptforpi`
+    using bounded globs (avoids the rglob hang on large projects)."""
+    from panta_rei.workflows.calibration import _SCRIPT_PATTERNS
 
-        uid = (
-            canonical_uid(script_path.name)
-            or _last_uid_in(str(mous_dir))
-            or canonical_uid(str(mous_dir))
-        )
-        if not uid:
-            log.debug("Skipping script with no parseable UID: %s", script_path)
-            continue
+    seen_uids: set[str] = set()
+    for pat in _SCRIPT_PATTERNS:
+        for script_path in sorted(base_dir.glob(pat)):
+            if not script_path.is_file():
+                continue
+            if not _SCRIPT_NAME_RE.search(script_path.name):
+                continue
+            mous_dir = script_path.parent.parent
 
-        hierarchy = _parse_hierarchy_from_path(mous_dir)
-        yield (uid.lower(), script_path.resolve(), mous_dir.resolve(), hierarchy)
+            uid = (
+                canonical_uid(script_path.name)
+                or _last_uid_in(str(mous_dir))
+                or canonical_uid(str(mous_dir))
+            )
+            if not uid:
+                log.debug("Skipping script with no parseable UID: %s", script_path)
+                continue
+
+            uid_lower = uid.lower()
+            if uid_lower in seen_uids:
+                log.warning(
+                    "Duplicate MOUS %s discovered at %s; using shallower copy",
+                    uid_lower, script_path,
+                )
+                continue
+            seen_uids.add(uid_lower)
+
+            hierarchy = _parse_hierarchy_from_path(mous_dir)
+            yield (uid_lower, script_path.resolve(), mous_dir.resolve(), hierarchy)
 
 
 # ---------------------------------------------------------------------------

--- a/panta_rei/cli/run_imaging_dispatch.py
+++ b/panta_rei/cli/run_imaging_dispatch.py
@@ -1,0 +1,207 @@
+"""CLI entry point for distributed tclean+feather imaging.
+
+Usage::
+
+    panta-rei-imaging-dispatch \\
+        --base-dir <project-base> \\
+        --output-dir <project-base>/imaging/output \\
+        --machines-config <project-base>/machines.json
+
+See ``--help`` for filters, transfer-method, overwrite, and reconcile flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from panta_rei.config import PipelineConfig
+from panta_rei.core.logging import setup_logging
+from panta_rei.db.connection import DatabaseManager
+from panta_rei.imaging.dispatch import (
+    load_machines_config,
+    run_dispatch,
+    reconcile_prior,
+)
+from panta_rei.imaging.unit_selection import SelectionFilters
+
+log = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description="Distributed tclean+feather imaging dispatcher.",
+    )
+    ap.add_argument("--base-dir", required=True,
+                    help="Project base dir (e.g. ./2025.1.00383.L)")
+    ap.add_argument("--output-dir", required=True,
+                    help="Canonical NAS publish dir for output FITS")
+    ap.add_argument("--machines-config", required=True,
+                    help="Path to machines.json")
+    ap.add_argument("--db", default=None,
+                    help="Path to SQLite DB (default: <base-dir>/imaging.sqlite3)")
+    ap.add_argument("--obs-csv", default=None,
+                    help="Path to targets_by_array.csv (default: <base-dir>/targets_by_array.csv)")
+
+    # Filters (forwarded to selection)
+    ap.add_argument("--match", default=None, help="Regex on source_name/gous_uid")
+    ap.add_argument("--include-sources", nargs="+", default=None)
+    ap.add_argument("--include-line-groups", nargs="+", default=None)
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--re-run", action="store_true",
+                    help="Bypass success_exists() filter; requires --overwrite "
+                         "to actually publish over existing FITS")
+    ap.add_argument("--machines", nargs="+", default=None,
+                    help="Subset of machines.json entries to use")
+
+    # Imaging knobs
+    ap.add_argument("--method", default="tclean_feather",
+                    choices=["tclean_feather"],
+                    help="MVP supports tclean_feather only")
+    ap.add_argument("--deconvolver", default="multiscale")
+    ap.add_argument("--scales", default=None,
+                    help="JSON list, e.g. '[0,5,10,15,20]'")
+
+    # Transport / publish
+    ap.add_argument("--transfer-method", default="tar",
+                    choices=["tar", "rsync", "cp"])
+    ap.add_argument("--overwrite", action="store_true",
+                    help="Allow publish to overwrite existing FITS "
+                         "(default: fail_if_exists)")
+
+    # Lifecycle
+    ap.add_argument("--reconcile-only", action="store_true",
+                    help="Run reconciliation pass and exit")
+    ap.add_argument("--abandon-prior", action="store_true",
+                    help="Mark in-flight prior runs FAILED instead of adopting")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Show what would be dispatched, no SSH, no DB writes "
+                         "for new rows")
+
+    return ap
+
+
+def _validate_re_run_overwrite(args) -> Optional[str]:
+    """`--re-run` without `--overwrite` would be a publish-time surprise."""
+    if args.re_run and not args.overwrite:
+        return (
+            "--re-run bypasses the success_exists() filter, but the "
+            "dispatcher's default publish policy is fail_if_exists. "
+            "Pass --overwrite to actually replace existing FITS, or drop "
+            "--re-run."
+        )
+    return None
+
+
+def main(argv=None) -> int:
+    setup_logging()
+    ap = _build_parser()
+    args = ap.parse_args(argv)
+
+    base_dir = Path(args.base_dir).resolve()
+    publish_dir = Path(args.output_dir).resolve()
+
+    err = _validate_re_run_overwrite(args)
+    if err:
+        log.error("%s", err)
+        return 2
+
+    # DB resolution
+    if args.db:
+        db_path = Path(args.db)
+    else:
+        try:
+            env_config = PipelineConfig.from_env()
+            db_path = env_config.imaging_db_path
+        except Exception:
+            db_path = base_dir / "imaging.sqlite3"
+    db_manager = DatabaseManager(db_path)
+
+    # machines.json
+    cfg = load_machines_config(Path(args.machines_config))
+    if args.machines:
+        keep = {m: cfg.machines[m] for m in args.machines if m in cfg.machines}
+        missing = [m for m in args.machines if m not in cfg.machines]
+        if missing:
+            log.error("--machines references entries not in config: %s", missing)
+            return 2
+        cfg.machines = keep
+
+    if not cfg.machines:
+        log.error("no machines selected")
+        return 2
+
+    # Reconcile-only mode
+    if args.reconcile_only:
+        adoptable = reconcile_prior(
+            db_manager, base_dir, cfg.global_cfg,
+            abandon=args.abandon_prior,
+        )
+        log.info("reconcile-only complete; adoptable=%d", len(adoptable))
+        return 0
+
+    # data_dir matches what JointImagingStep / PipelineConfig use:
+    # <base_dir.parent>/<project_code>/<project_code>, where base_dir
+    # is itself the project_dir.  See panta_rei/config.py:85.
+    try:
+        env_config = PipelineConfig.from_env()
+        config = PipelineConfig(
+            panta_rei_base=base_dir.parent,
+            weblog_dir=env_config.weblog_dir,
+            casa_path=env_config.casa_path,
+            project_code=base_dir.name,
+        )
+    except Exception:
+        config = PipelineConfig(
+            panta_rei_base=base_dir.parent,
+            project_code=base_dir.name,
+        )
+    data_dir = config.data_dir
+
+    obs_csv = (Path(args.obs_csv).resolve() if args.obs_csv
+               else base_dir / "targets_by_array.csv")
+    scales = json.loads(args.scales) if args.scales else [0, 5, 10, 15, 20]
+    filters = SelectionFilters(
+        match=args.match,
+        include_sources=args.include_sources,
+        include_line_groups=args.include_line_groups,
+        limit=args.limit,
+        method=args.method,
+        deconvolver=args.deconvolver,
+        scales=scales,
+        re_run=args.re_run,
+        exclude_active=True,
+    )
+
+    publish_policy = "overwrite" if args.overwrite else "fail_if_exists"
+    cli_args = " ".join(sys.argv[1:])
+
+    summary = run_dispatch(
+        base_dir=base_dir,
+        publish_dir=publish_dir,
+        cfg=cfg,
+        db_manager=db_manager,
+        selection_filters=filters,
+        obs_csv=obs_csv,
+        data_dir=data_dir,
+        transfer_method=args.transfer_method,
+        publish_policy=publish_policy,
+        deconvolver=args.deconvolver,
+        scales=scales,
+        cli_args=cli_args,
+        abandon_prior=args.abandon_prior,
+        dry_run=args.dry_run,
+    )
+    log.info("dispatch summary: %s", json.dumps(summary, indent=2))
+    return 0
+
+
+# Imported lazily so this module can be imported without matplotlib etc.
+from typing import Optional  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/panta_rei/cli/run_pipeline.py
+++ b/panta_rei/cli/run_pipeline.py
@@ -126,9 +126,21 @@ def main() -> int:
     # IMPORTANT: --base-dir is the PROJECT directory (e.g. .../2025.1.00383.L),
     # not panta_rei_base.  Legacy: db, csv, and weblogs all live at this level.
     from panta_rei.config import PipelineConfig
+    from panta_rei.core.errors import ConfigError
 
     base_dir = Path(args.base_dir or f"./{args.project_code}").resolve()
     base_dir.mkdir(parents=True, exist_ok=True)
+
+    # Friendly user-facing check: if the user accidentally passed the
+    # data_dir (= <project_dir>/<project_code>/) instead of the
+    # project_dir, --base-dir would be doubled-named and we'd silently
+    # extract another nesting level.  See the "two data layers" incident.
+    if base_dir.name == args.project_code and base_dir.parent.name == args.project_code:
+        raise ConfigError(
+            f"--base-dir ({base_dir}) appears to be the data_dir, not the "
+            f"project_dir.  Pass .../{args.project_code}, not "
+            f".../{args.project_code}/{args.project_code}."
+        )
 
     db_path = Path(args.db) if args.db else (base_dir / "alma_retrieval_state.sqlite3")
     csv_out = Path(args.csv_out) if args.csv_out else (base_dir / "targets_by_array.csv")

--- a/panta_rei/config.py
+++ b/panta_rei/config.py
@@ -78,6 +78,20 @@ class PipelineConfig:
 
     def __post_init__(self) -> None:
         # frozen=True requires object.__setattr__ for post-init
+        # Guard against the doubled-down misconfiguration where
+        # panta_rei_base already ends with project_code (e.g. caller
+        # passed project_dir where panta_rei_base was expected).
+        # Without this, ``data_dir`` silently becomes
+        # ``<base>/<project>/<project>/<project>/`` and tarball extracts
+        # land in a third nesting level.  See the "two data layers"
+        # incident in docs/distributed-imaging-handoff.md (2026-05-01).
+        if self.panta_rei_base.name == self.project_code:
+            raise ConfigError(
+                f"panta_rei_base ({self.panta_rei_base}) already ends in the "
+                f"project_code ({self.project_code!r}). This usually means the "
+                f"caller passed project_dir where panta_rei_base was expected. "
+                f"panta_rei_base must be the PARENT of <project_code>/."
+            )
         object.__setattr__(
             self, "project_dir", self.panta_rei_base / self.project_code
         )

--- a/panta_rei/db/connection.py
+++ b/panta_rei/db/connection.py
@@ -54,10 +54,25 @@ class DatabaseManager:
 
         For in-memory databases, returns the single persistent connection.
         For file databases, returns a new connection each call.
+
+        Sets ``timeout=30`` and ``PRAGMA busy_timeout=30000`` so concurrent
+        writers (e.g. multi-host calibration fan-out, the imaging
+        dispatcher's DBWriter thread + per-worker MARK_RUNNING events)
+        wait politely instead of crashing on ``database is locked``.
+        SQLite's busy handler retries silently up to the timeout; only
+        truly stuck contention surfaces as ``OperationalError``.
         """
         if self._memory_con is not None:
             return self._memory_con
-        return sqlite3.connect(self._db_path)
+        con = sqlite3.connect(self._db_path, timeout=30.0)
+        try:
+            con.execute("PRAGMA busy_timeout=30000")
+        except sqlite3.OperationalError:
+            # Best-effort — if PRAGMA fails for some reason, the
+            # ``timeout=30`` arg above still gives us 30s of polite
+            # retry on lock acquisition.
+            pass
+        return con
 
     def _bootstrap(self, con: sqlite3.Connection) -> None:
         """Run migration bootstrap: create schema_version, probe, apply."""

--- a/panta_rei/db/models.py
+++ b/panta_rei/db/models.py
@@ -417,6 +417,12 @@ class ImagingRunStatus:
     FAILED = "failed"
 
 
+class DispatchState:
+    RUNNING = "running"
+    DONE = "done"
+    ABORTED = "aborted"
+
+
 # ---------------------------------------------------------------------------
 # Imaging params table queries
 # ---------------------------------------------------------------------------
@@ -657,3 +663,180 @@ class ImagingRunsQueries:
             f"{k}={v}" for k, v in sorted(totals.items())
         ]
         return " | ".join(parts)
+
+    # --- distributed dispatch helpers (migration #14) -----------------
+
+    @staticmethod
+    def set_dispatch_meta(
+        con: sqlite3.Connection,
+        run_id: int,
+        *,
+        dispatch_id: Optional[str] = None,
+        remote_workdir: Optional[str] = None,
+        worker_pid: Optional[int] = None,
+        worker_pgid: Optional[int] = None,
+        hostname: Optional[str] = None,
+    ) -> None:
+        """Record dispatch identity + remote location for a run row."""
+        con.execute(
+            """
+            UPDATE imaging_runs
+               SET dispatch_id    = COALESCE(?, dispatch_id),
+                   remote_workdir = COALESCE(?, remote_workdir),
+                   worker_pid     = COALESCE(?, worker_pid),
+                   worker_pgid    = COALESCE(?, worker_pgid),
+                   hostname       = COALESCE(?, hostname)
+             WHERE id = ?
+            """,
+            (dispatch_id, remote_workdir, worker_pid, worker_pgid,
+             hostname, run_id),
+        )
+
+    @staticmethod
+    def update_heartbeat(
+        con: sqlite3.Connection, run_id: int, ts: str,
+    ) -> None:
+        """Bump last_heartbeat for a run row."""
+        con.execute(
+            "UPDATE imaging_runs SET last_heartbeat=? WHERE id=?",
+            (ts, run_id),
+        )
+
+    @staticmethod
+    def set_error_message(
+        con: sqlite3.Connection, run_id: int, msg: Optional[str],
+    ) -> None:
+        """Persist a (possibly truncated) error message."""
+        con.execute(
+            "UPDATE imaging_runs SET error_message=? WHERE id=?",
+            (msg, run_id),
+        )
+
+    @staticmethod
+    def list_active_for_params(
+        con: sqlite3.Connection, params_id: int,
+    ) -> list[dict]:
+        """Return queued/running runs for a params_id, joined to dispatch state.
+
+        Used to filter selection so a new dispatch never enqueues a unit
+        whose previous run is still active under an unfinished dispatch.
+        """
+        con.row_factory = sqlite3.Row
+        try:
+            rows = con.execute(
+                """
+                SELECT r.id, r.status, r.dispatch_id, d.state AS dispatch_state
+                  FROM imaging_runs r
+                  LEFT JOIN dispatches d ON d.dispatch_id = r.dispatch_id
+                 WHERE r.params_id = ?
+                   AND r.status IN (?, ?)
+                """,
+                (params_id, ImagingRunStatus.QUEUED, ImagingRunStatus.RUNNING),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            con.row_factory = None
+
+    @staticmethod
+    def list_running_for_dispatch(
+        con: sqlite3.Connection, dispatch_id: str,
+    ) -> list[dict]:
+        """Return imaging_runs rows in non-terminal state for a dispatch."""
+        con.row_factory = sqlite3.Row
+        try:
+            rows = con.execute(
+                """
+                SELECT * FROM imaging_runs
+                 WHERE dispatch_id = ?
+                   AND status IN (?, ?)
+                """,
+                (dispatch_id, ImagingRunStatus.QUEUED,
+                 ImagingRunStatus.RUNNING),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            con.row_factory = None
+
+    @staticmethod
+    def get_by_id(con: sqlite3.Connection, run_id: int) -> Optional[dict]:
+        con.row_factory = sqlite3.Row
+        try:
+            row = con.execute(
+                "SELECT * FROM imaging_runs WHERE id = ?", (run_id,),
+            ).fetchone()
+            return dict(row) if row else None
+        finally:
+            con.row_factory = None
+
+
+# ---------------------------------------------------------------------------
+# Dispatches table queries (distributed imaging coordination)
+# ---------------------------------------------------------------------------
+
+class DispatchesQueries:
+    """Query helpers for the dispatches table (migration #14)."""
+
+    @staticmethod
+    def insert(
+        con: sqlite3.Connection,
+        *,
+        dispatch_id: str,
+        coordinator_host: str,
+        coordinator_pid: int,
+        machines_json: str,
+        cli_args: str,
+        git_commit: Optional[str] = None,
+        git_dirty: bool = False,
+    ) -> None:
+        con.execute(
+            """
+            INSERT INTO dispatches (
+                dispatch_id, started_at, coordinator_host, coordinator_pid,
+                git_commit, git_dirty, machines_json, cli_args, state
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                dispatch_id, now_iso(), coordinator_host, int(coordinator_pid),
+                git_commit, 1 if git_dirty else 0,
+                machines_json, cli_args, DispatchState.RUNNING,
+            ),
+        )
+
+    @staticmethod
+    def list_running(con: sqlite3.Connection) -> list[dict]:
+        con.row_factory = sqlite3.Row
+        try:
+            rows = con.execute(
+                "SELECT * FROM dispatches WHERE state = ?",
+                (DispatchState.RUNNING,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            con.row_factory = None
+
+    @staticmethod
+    def mark_terminal(
+        con: sqlite3.Connection,
+        dispatch_id: str,
+        state: str = DispatchState.DONE,
+    ) -> None:
+        con.execute(
+            """
+            UPDATE dispatches
+               SET state=?, finished_at=?
+             WHERE dispatch_id=?
+            """,
+            (state, now_iso(), dispatch_id),
+        )
+
+    @staticmethod
+    def get(con: sqlite3.Connection, dispatch_id: str) -> Optional[dict]:
+        con.row_factory = sqlite3.Row
+        try:
+            row = con.execute(
+                "SELECT * FROM dispatches WHERE dispatch_id = ?",
+                (dispatch_id,),
+            ).fetchone()
+            return dict(row) if row else None
+        finally:
+            con.row_factory = None

--- a/panta_rei/db/schema.py
+++ b/panta_rei/db/schema.py
@@ -389,4 +389,52 @@ MIGRATIONS: list[Migration] = [
             ("imaging_runs", "parallel", "INTEGER DEFAULT 0"),
         ],
     ),
+
+    # --- distributed dispatch tracking ---
+    Migration(
+        version=14,
+        description="add dispatch tracking columns + dispatches table",
+        probe=lambda con: (
+            all(
+                column_exists(con, "imaging_runs", c)
+                for c in [
+                    "dispatch_id", "remote_workdir", "error_message",
+                    "last_heartbeat", "worker_pid", "worker_pgid",
+                ]
+            )
+            and table_exists(con, "dispatches")
+        ),
+        conditional_columns=[
+            ("imaging_runs", "dispatch_id", "TEXT"),
+            ("imaging_runs", "remote_workdir", "TEXT"),
+            ("imaging_runs", "error_message", "TEXT"),
+            ("imaging_runs", "last_heartbeat", "TEXT"),
+            ("imaging_runs", "worker_pid", "INTEGER"),
+            ("imaging_runs", "worker_pgid", "INTEGER"),
+        ],
+        sql=[
+            """\
+CREATE TABLE IF NOT EXISTS dispatches (
+    dispatch_id      TEXT PRIMARY KEY,
+    started_at       TEXT NOT NULL,
+    finished_at      TEXT,
+    coordinator_host TEXT NOT NULL,
+    coordinator_pid  INTEGER NOT NULL,
+    git_commit       TEXT,
+    git_dirty        INTEGER NOT NULL DEFAULT 0,
+    machines_json    TEXT NOT NULL,
+    cli_args         TEXT NOT NULL,
+    state            TEXT NOT NULL
+)""",
+        ],
+    ),
+    Migration(
+        version=15,
+        description="add idx_runs_dispatch index on imaging_runs.dispatch_id",
+        probe=lambda con: index_exists(con, "idx_runs_dispatch"),
+        sql=[
+            "CREATE INDEX IF NOT EXISTS idx_runs_dispatch "
+            "ON imaging_runs(dispatch_id)",
+        ],
+    ),
 ]

--- a/panta_rei/imaging/dispatch.py
+++ b/panta_rei/imaging/dispatch.py
@@ -1,0 +1,2130 @@
+"""Distributed-imaging coordinator.
+
+Dispatches tclean+feather imaging jobs across a configurable set of
+remote machines, staging MS inputs to fast local /raid/ storage and
+publishing canonical FITS back to NAS.  See
+``docs/`` and the project plan for the full design rationale.
+
+Public entry point: :func:`run_dispatch` (called by the
+``panta-rei-imaging-dispatch`` CLI).
+
+The coordinator runs entirely in one Python process with the following
+threads:
+
+- 1 main thread — startup, reconciliation, scheduler kickoff, shutdown.
+- 1 DB-writer thread — single SQLite owner; consumes a queue of events.
+- N machine-worker threads (one per slot per machine) — pull units from
+  a GOUS-affinity scheduler, SSH-launch the detached worker, poll the
+  unit's NAS state file, enqueue DB events.
+- 1 token-reaper thread — wipes staging tokens whose holder PID is gone.
+- 1 cleanup thread — coordinator-driven per-(machine, GOUS) cleanup.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import random
+import re
+import shlex
+import socket
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from queue import Empty, Queue
+from typing import Any, Optional
+
+from panta_rei.core.text import now_iso
+from panta_rei.db.connection import DatabaseManager
+from panta_rei.db.models import (
+    DispatchesQueries,
+    DispatchState,
+    ImagingRunsQueries,
+    ImagingRunStatus,
+)
+from panta_rei.imaging.matching import ImagingUnit
+from panta_rei.imaging.staging import list_held_tokens
+from panta_rei.imaging.unit_selection import (
+    SelectionFilters,
+    SelectionResult,
+    select_units_to_image,
+)
+
+log = logging.getLogger("panta_rei.dispatch")
+
+WORKER_MODULE = "panta_rei.imaging.remote_worker"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GlobalCfg:
+    max_concurrent_staging: int = 4
+    heartbeat_interval_sec: int = 30
+    heartbeat_stale_threshold_sec: int = 300
+    max_stale_alive_sec: int = 3600
+    state_appeared_timeout_sec: int = 60
+    poll_interval_sec: int = 10
+    cleanup_interval_sec: int = 30
+    token_reaper_interval_sec: int = 60
+    ssh_timeout_sec: int = 30
+
+
+@dataclass
+class MachineCfg:
+    name: str
+    raid: str
+    slots: int = 1
+    nproc: int = 4
+    # Cross-dispatch staging cache (see staging.py "Cross-dispatch
+    # staging cache" section).  ``None`` disables the cache for this
+    # machine; an int value is the per-host minimum free space (in GB)
+    # the worker maintains by evicting oldest entries before each
+    # populate.  Default 1 TB matches typical large /raid sizes; hosts
+    # with smaller drives (e.g. 2 TB total) should override to ~512 GB
+    # or disable.
+    cache_min_free_gb: Optional[int] = 1024
+
+
+@dataclass
+class MachinesConfig:
+    conda_env: str
+    repo_path: str
+    casa_path: Optional[str]
+    global_cfg: GlobalCfg
+    machines: dict[str, MachineCfg]
+
+
+def load_machines_config(path: Path) -> MachinesConfig:
+    """Parse + validate a machines.json file."""
+    raw = json.loads(Path(path).read_text())
+    if "conda_env" not in raw or "repo_path" not in raw:
+        raise ValueError("machines.json missing 'conda_env' or 'repo_path'")
+    if "machines" not in raw or not isinstance(raw["machines"], dict):
+        raise ValueError("machines.json missing 'machines' dict")
+    g_raw = raw.get("global", {})
+    g = GlobalCfg(**{k: v for k, v in g_raw.items() if k in GlobalCfg().__dict__})
+    machines: dict[str, MachineCfg] = {}
+    for name, m in raw["machines"].items():
+        if "raid" not in m:
+            raise ValueError(f"machine {name!r}: missing 'raid' path")
+        cache_free = m.get("cache_min_free_gb", 1024)
+        # Allow ``"cache_min_free_gb": null`` to disable the cache per host.
+        cache_free_val = (None if cache_free is None
+                          else int(cache_free))
+        machines[name] = MachineCfg(
+            name=name,
+            raid=m["raid"],
+            slots=int(m.get("slots", 1)),
+            nproc=int(m.get("nproc", 4)),
+            cache_min_free_gb=cache_free_val,
+        )
+    return MachinesConfig(
+        conda_env=raw["conda_env"],
+        repo_path=raw["repo_path"],
+        casa_path=raw.get("casa_path"),
+        global_cfg=g,
+        machines=machines,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch lock (per-base-dir flock)
+# ---------------------------------------------------------------------------
+
+class DispatcherLock:
+    """Exclusive non-blocking flock on a base-dir lockfile."""
+
+    def __init__(self, lock_path: Path) -> None:
+        self.lock_path = Path(lock_path)
+        self._fp = None
+
+    def acquire(self) -> None:
+        import fcntl
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._fp = open(self.lock_path, "w")
+        try:
+            fcntl.flock(self._fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            holder = self.lock_path.read_text() if self.lock_path.exists() else "?"
+            self._fp.close()
+            self._fp = None
+            raise RuntimeError(
+                f"dispatcher lock held by {holder.strip()}; "
+                f"another panta-rei-imaging-dispatch may be running"
+            )
+        self._fp.write(f"host={socket.gethostname()} pid={os.getpid()}\n")
+        self._fp.flush()
+
+    def release(self) -> None:
+        import fcntl
+        if self._fp is not None:
+            try:
+                fcntl.flock(self._fp.fileno(), fcntl.LOCK_UN)
+            finally:
+                self._fp.close()
+                self._fp = None
+
+
+# ---------------------------------------------------------------------------
+# DB-writer thread
+# ---------------------------------------------------------------------------
+
+DB_SHUTDOWN = object()
+
+
+class DBWriter(threading.Thread):
+    """Single-owner SQLite writer fed by a Queue.
+
+    All other threads drop dicts with ``{"op": "...", **kwargs}`` onto
+    the queue.  The writer applies them serially using one long-lived
+    sqlite3 connection.  Workers never touch SQLite.
+    """
+
+    def __init__(self, db_manager: DatabaseManager, dispatch_id: str) -> None:
+        super().__init__(name="db-writer", daemon=True)
+        self.q: Queue = Queue()
+        self.db_manager = db_manager
+        self.dispatch_id = dispatch_id
+        self._stop = threading.Event()
+
+    def stop(self) -> None:
+        self.q.put(DB_SHUTDOWN)
+        self._stop.set()
+
+    def run(self) -> None:
+        con = self.db_manager.connect()
+        con.execute("PRAGMA busy_timeout=10000")
+        try:
+            while True:
+                item = self.q.get()
+                try:
+                    if item is DB_SHUTDOWN:
+                        return
+                    try:
+                        self._apply(con, item)
+                        con.commit()
+                    except Exception:
+                        log.exception("DB writer failed on event: %r", item)
+                finally:
+                    # task_done() balances every q.put() so callers can
+                    # use q.join() as a synchronous drain barrier.
+                    self.q.task_done()
+        finally:
+            try:
+                con.close()
+            except sqlite3_close_silently:
+                pass
+
+    def _apply(self, con, ev: dict) -> None:
+        op = ev["op"]
+        if op == "INSERT_QUEUED":
+            run_id = ImagingRunsQueries.insert_row(con, **ev["row"])
+            ev["row_id_holder"]["id"] = run_id
+        elif op == "MARK_RUNNING":
+            ImagingRunsQueries.mark_running(con, ev["run_id"])
+            ImagingRunsQueries.set_dispatch_meta(
+                con, ev["run_id"],
+                dispatch_id=self.dispatch_id,
+                remote_workdir=ev.get("remote_workdir"),
+                worker_pid=ev.get("worker_pid"),
+                worker_pgid=ev.get("worker_pgid"),
+                hostname=ev.get("hostname"),
+            )
+        elif op == "HEARTBEAT":
+            ImagingRunsQueries.update_heartbeat(con, ev["run_id"], ev["ts"])
+        elif op == "MARK_DONE":
+            status = ev["status"]
+            if ev.get("spw_selection") or ev.get("field_selection"):
+                ImagingRunsQueries.update_resolved(
+                    con, ev["run_id"],
+                    spw_selection=ev.get("spw_selection"),
+                    field_selection=ev.get("field_selection"),
+                )
+            if "job_json_path" in ev and ev["job_json_path"]:
+                con.execute(
+                    "UPDATE imaging_runs SET job_json_path=? WHERE id=?",
+                    (ev["job_json_path"], ev["run_id"]),
+                )
+            ImagingRunsQueries.mark_done(
+                con,
+                ev["run_id"],
+                status=status,
+                retcode=int(ev.get("retcode", 1 if status == ImagingRunStatus.FAILED else 0)),
+                finished_at=ev.get("finished_at") or now_iso(),
+                duration_sec=float(ev.get("duration_sec", 0.0)),
+                output_fits=ev.get("output_fits"),
+            )
+            ImagingRunsQueries.set_error_message(
+                con, ev["run_id"], ev.get("error_message"),
+            )
+        elif op == "DISPATCH_TERMINAL":
+            DispatchesQueries.mark_terminal(
+                con, ev["dispatch_id"], state=ev.get("state", DispatchState.DONE),
+            )
+        elif op == "INSERT_DISPATCH":
+            DispatchesQueries.insert(con, **ev["row"])
+        else:
+            log.warning("unknown DB op: %r", op)
+
+
+class sqlite3_close_silently(BaseException):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# GOUS-affinity scheduler with staging gate
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SchedulerState:
+    queue: list[ImagingUnit] = field(default_factory=list)
+    gous_machine: dict[str, str] = field(default_factory=dict)
+    in_flight: dict[tuple[str, str], set[int]] = field(default_factory=dict)
+    gous_staged_on: dict[tuple[str, str], bool] = field(default_factory=dict)
+    # Every (machine, gous) pair the scheduler has ever assigned a unit to.
+    # Used by the cleaner because in_flight entries are deleted once empty.
+    seen_pairs: set[tuple[str, str]] = field(default_factory=set)
+    # Terminal run_ids per (machine, gous), recorded synchronously by the
+    # slot/adoption thread that calls mark_terminal.  The cleaner reads
+    # from this rather than querying SQLite — that avoids a race where
+    # the DB-writer queue hasn't yet committed MARK_DONE when the cleaner
+    # sweeps and would otherwise miss SUCCESS work-dirs.
+    success_run_ids: dict[tuple[str, str], set[int]] = field(default_factory=dict)
+    failed_run_ids: dict[tuple[str, str], set[int]] = field(default_factory=dict)
+    # The dispatch_id whose /raid/d_<id>/... paths the cleaner should
+    # target for each (machine, gous) pair.  Adopted units inherit the
+    # *prior* dispatch_id; new units use the current one.
+    pair_dispatch_id: dict[tuple[str, str], str] = field(default_factory=dict)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def queued_for_gous_on_machine(self, gous: str, machine: str) -> int:
+        with self.lock:
+            return sum(
+                1 for u in self.queue
+                if u.gous_uid == gous
+                and self.gous_machine.get(u.gous_uid) == machine
+            )
+
+    def queued_for_gous_total(self, gous: str) -> int:
+        with self.lock:
+            return sum(1 for u in self.queue if u.gous_uid == gous)
+
+    def pick(self, machine: str, run_id_assigner) -> Optional[ImagingUnit]:
+        """Return a unit for *machine* per the affinity strategy."""
+        with self.lock:
+            # 1. mapped + staged on this machine
+            for i, u in enumerate(self.queue):
+                if (self.gous_machine.get(u.gous_uid) == machine
+                        and self.gous_staged_on.get((machine, u.gous_uid))):
+                    self.queue.pop(i)
+                    return u
+            # 2. mapped to this machine but not yet staged: only if no other
+            #    unit of this GOUS is currently staging on this machine.
+            for i, u in enumerate(self.queue):
+                if (self.gous_machine.get(u.gous_uid) == machine
+                        and not self.in_flight.get((machine, u.gous_uid))):
+                    self.queue.pop(i)
+                    return u
+            # 3. unmapped GOUS — claim
+            for i, u in enumerate(self.queue):
+                if u.gous_uid not in self.gous_machine:
+                    self.gous_machine[u.gous_uid] = machine
+                    self.queue.pop(i)
+                    return u
+            # 4. fallback FIFO — but skip units whose GOUS is currently
+            #    staging-blocked on THIS machine; otherwise we'd pick a
+            #    sibling we already declined in step 2 and just block on
+            #    the staging flock.
+            for i, u in enumerate(self.queue):
+                mapped = self.gous_machine.get(u.gous_uid)
+                if (mapped == machine
+                        and self.in_flight.get((machine, u.gous_uid))
+                        and not self.gous_staged_on.get((machine, u.gous_uid))):
+                    continue
+                self.queue.pop(i)
+                self.gous_machine.setdefault(u.gous_uid, machine)
+                return u
+            return None
+
+    def mark_inflight(
+        self, machine: str, gous: str, run_id: int,
+        *, dispatch_id: Optional[str] = None,
+    ) -> None:
+        """Record an in-flight unit on (machine, gous).
+
+        ``dispatch_id`` records which dispatch's /raid/d_<id>/ tree this
+        pair lives under; the cleaner reads it back so adopted prior-
+        dispatch units get cleaned up against their *original* /raid/
+        layout, not the new dispatch's.
+        """
+        with self.lock:
+            self.in_flight.setdefault((machine, gous), set()).add(run_id)
+            self.seen_pairs.add((machine, gous))
+            if dispatch_id is not None:
+                self.pair_dispatch_id.setdefault((machine, gous), dispatch_id)
+
+    def mark_staged(self, machine: str, gous: str) -> None:
+        with self.lock:
+            self.gous_staged_on[(machine, gous)] = True
+
+    def mark_terminal(
+        self, machine: str, gous: str, run_id: int,
+        *, success: Optional[bool] = None,
+    ) -> bool:
+        """Drop run_id from in-flight; return True if (machine, gous) now empty.
+
+        ``success`` records the run's outcome in-memory so the cleaner
+        can act without a DB round-trip (and without racing the DB
+        writer's queue).  ``None`` is acceptable for callers that don't
+        yet know — adoptions populate this once polling completes.
+        """
+        with self.lock:
+            s = self.in_flight.get((machine, gous))
+            if s and run_id in s:
+                s.discard(run_id)
+            empty = not s
+            if empty and (machine, gous) in self.in_flight:
+                del self.in_flight[(machine, gous)]
+            if success is True:
+                self.success_run_ids.setdefault(
+                    (machine, gous), set()
+                ).add(run_id)
+            elif success is False:
+                self.failed_run_ids.setdefault(
+                    (machine, gous), set()
+                ).add(run_id)
+            return empty
+
+
+# ---------------------------------------------------------------------------
+# SSH helpers
+# ---------------------------------------------------------------------------
+
+def ssh_run(
+    machine: str, remote_cmd: str, *,
+    timeout: int = 30,
+    capture: bool = True,
+) -> subprocess.CompletedProcess:
+    """Run ``ssh <machine> <cmd>``.  Caller composes the remote command.
+
+    The command is base64-encoded and piped through ``bash`` on the
+    remote so the caller can use bash syntax (redirections, ``$!``,
+    ``if/then/fi``) regardless of the remote user's login shell — many
+    of these hosts default to tcsh, which mis-parses ``>file 2>&1`` and
+    history-expands ``!`` even inside single quotes.
+
+    Returns the CompletedProcess; does NOT raise on non-zero exit.
+    """
+    encoded = base64.b64encode(remote_cmd.encode("utf-8")).decode("ascii")
+    wrapped = f"echo {encoded} | base64 -d | bash"
+    cmd = ["ssh", "-o", "BatchMode=yes",
+           "-o", "ConnectTimeout=10",
+           "-o", "StrictHostKeyChecking=accept-new",
+           machine, wrapped]
+    return subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+        text=True, timeout=timeout,
+    )
+
+
+def ssh_pid_alive(
+    machine: str,
+    pid: int,
+    expected_tokens: list[str] | str,
+    timeout: int = 10,
+) -> tuple[Optional[bool], str]:
+    """Check whether *pid* on *machine* is alive AND owned by our worker.
+
+    *expected_tokens* may be a single substring or a list of substrings;
+    every substring must be present in ``/proc/<pid>/cmdline`` for the
+    PID to be considered ours.  This is order-independent, so the
+    launcher's actual flag order doesn't have to match a fixed template.
+
+    NUL separators in cmdline are translated to spaces (``tr '\\0' ' '``)
+    before substring matching.  Without that, distinct argv entries
+    would concatenate and our space-bearing tokens (e.g. ``--run-id 42``)
+    would never match.
+
+    Returns ``(True, cmdline)`` if alive + all tokens present.
+    Returns ``(False, cmdline)`` if dead OR token mismatch (PID reused).
+    Returns ``(None, reason)`` if the check itself failed (network / ssh
+    error) — coordinator must NOT mark FAILED in that case.
+    """
+    if not pid:
+        return False, ""
+    if isinstance(expected_tokens, str):
+        tokens = [expected_tokens]
+    else:
+        tokens = list(expected_tokens)
+    cmd = (
+        f"if [ -e /proc/{int(pid)}/cmdline ]; then "
+        f"  tr '\\0' ' ' </proc/{int(pid)}/cmdline; "
+        f"else "
+        f"  echo __DEAD__; "
+        f"fi"
+    )
+    try:
+        proc = ssh_run(machine, cmd, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return None, f"ssh timeout to {machine}"
+    if proc.returncode != 0:
+        return None, f"ssh rc={proc.returncode}: {(proc.stderr or '')[-200:]}"
+    text = (proc.stdout or "").strip()
+    if text == "__DEAD__":
+        return False, ""
+    if all(tok in text for tok in tokens):
+        return True, text
+    # PID reused for unrelated process
+    return False, text
+
+
+def ssh_preflight_machine(
+    machine: str,
+    m: "MachineCfg",
+    cfg: "MachinesConfig",
+    *,
+    required_gb: float = 0.0,
+    nas_check_path: Optional[str] = None,
+    timeout: int = 30,
+) -> tuple[bool, dict]:
+    """SSH ``machine`` and run ``remote_worker preflight``.
+
+    Returns ``(ok, details)``.  ``details`` is the parsed JSON from the
+    worker, or a synthetic dict on failure (no JSON / non-zero exit /
+    SSH error).
+    """
+    cmd = (
+        f"env PYTHONPATH={shlex.quote(cfg.repo_path)} "
+        f"{shlex.quote(cfg.conda_env)}/bin/python -m {WORKER_MODULE} "
+        f"preflight --raid-dir {shlex.quote(m.raid)} "
+        f"--required-gb {float(required_gb)}"
+    )
+    if nas_check_path:
+        cmd += f" --nas-check-path {shlex.quote(nas_check_path)}"
+    try:
+        proc = ssh_run(machine, cmd, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return False, {"error": f"ssh timeout to {machine}"}
+    if proc.returncode != 0 and not (proc.stdout or "").strip():
+        return False, {
+            "error": f"ssh rc={proc.returncode}: "
+                     f"{(proc.stderr or '')[-300:]}"
+        }
+    text = (proc.stdout or "").strip()
+    try:
+        # Last line is the JSON output.
+        last = text.splitlines()[-1] if text else ""
+        details = json.loads(last)
+    except (ValueError, IndexError):
+        return False, {
+            "error": f"could not parse preflight JSON: "
+                     f"stdout={text[-300:]} stderr={(proc.stderr or '')[-300:]}"
+        }
+    return bool(details.get("ok")), details
+
+
+def ssh_kill_pgid(machine: str, pgid: int, signal_name: str = "TERM",
+                  timeout: int = 10) -> None:
+    """Send SIG to the process group leader at *pgid* on *machine*.  Best-effort."""
+    if not pgid:
+        return
+    try:
+        ssh_run(machine, f"kill -{shlex.quote(signal_name)} -{int(pgid)}",
+                timeout=timeout)
+    except subprocess.SubprocessError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Remote launch via a NAS-resident shell launcher script
+# ---------------------------------------------------------------------------
+
+def write_launcher_script(
+    nas_unit_dir: Path,
+    cfg: MachinesConfig,
+    raid_dir: str,
+    manifest_path: str,
+    run_id: int,
+    dispatch_id: str,
+    transfer_method: str,
+    publish_policy: str,
+    tokens_dir: str,
+    max_concurrent_staging: int,
+    heartbeat_interval: int,
+    cache_root: Optional[str] = None,
+    cache_min_free_gb: Optional[int] = None,
+) -> Path:
+    """Drop a per-unit ``launch.sh`` on NAS that the SSH command runs.
+
+    Putting all argument substitution into a shell script keeps the
+    SSH command line trivial (``ssh host bash <quoted-launcher>``) and
+    eliminates the temptation to interpolate user-controlled paths into
+    the SSH command — which would be a shell-injection liability.
+    """
+    nas_unit_dir.mkdir(parents=True, exist_ok=True)
+    launcher = nas_unit_dir / "launch.sh"
+    launch_log = nas_unit_dir / "launch.log"
+
+    cache_args = ""
+    if cache_root:
+        cache_args += f"--cache-root {shlex.quote(cache_root)} "
+    if cache_min_free_gb is not None:
+        cache_args += f"--cache-min-free-gb {int(cache_min_free_gb)} "
+
+    content = (
+        "#!/bin/bash\n"
+        "set -u\n"
+        "export OMP_NUM_THREADS=1\n"
+        "export OPENBLAS_NUM_THREADS=1\n"
+        "export MKL_NUM_THREADS=1\n"
+        f"export PYTHONPATH={shlex.quote(cfg.repo_path)}\n"
+        "exec setsid "
+        f"{shlex.quote(cfg.conda_env)}/bin/python -m {WORKER_MODULE} "
+        f"--manifest {shlex.quote(manifest_path)} "
+        f"--raid-dir {shlex.quote(raid_dir)} "
+        f"--run-id {int(run_id)} "
+        f"--dispatch-id {shlex.quote(dispatch_id)} "
+        f"--transfer-method {shlex.quote(transfer_method)} "
+        f"--publish-policy {shlex.quote(publish_policy)} "
+        f"--tokens-dir {shlex.quote(tokens_dir)} "
+        f"--max-concurrent-staging {int(max_concurrent_staging)} "
+        f"--heartbeat-interval {int(heartbeat_interval)} "
+        f"{cache_args}"
+        f">{shlex.quote(str(launch_log))} 2>&1 "
+        "</dev/null\n"
+    )
+    launcher.write_text(content)
+    launcher.chmod(0o755)
+    return launcher
+
+
+def launch_detached(
+    machine: str,
+    launcher: Path,
+    nas_unit_dir: Path,
+    timeout: int = 30,
+) -> tuple[bool, str, Optional[int]]:
+    """SSH a machine and start the worker detached via ``nohup``.
+
+    Returns ``(launched_ok, message, worker_pid)``.
+
+    ``worker_pid`` is the worker's PID (best-effort: read from the
+    launcher's ``pidfile`` after SSH returns).  None if the worker did
+    not write its pidfile within the launch window.
+    """
+    nohup_log = nas_unit_dir / "nohup.log"
+    pidfile = nas_unit_dir / "worker.pidfile"
+    # We pipe `bash launcher` through nohup; the worker itself rewrites
+    # state.json with its own pid+pgid as soon as it starts.  We capture
+    # the wrapper's pid into the pidfile but the source of truth for
+    # liveness checks is state.json's worker_pid (the actual python process).
+    remote = (
+        f"nohup bash {shlex.quote(str(launcher))} "
+        f">{shlex.quote(str(nohup_log))} 2>&1 & "
+        f"echo $! > {shlex.quote(str(pidfile))}"
+    )
+    try:
+        proc = ssh_run(machine, remote, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return False, f"ssh timeout to {machine}", None
+    if proc.returncode != 0:
+        return False, f"ssh rc={proc.returncode}: {(proc.stderr or '')[-500:]}", None
+    pid: Optional[int] = None
+    try:
+        if pidfile.exists():
+            pid = int(pidfile.read_text().strip())
+    except (OSError, ValueError):
+        pid = None
+    return True, "launched", pid
+
+
+# ---------------------------------------------------------------------------
+# Polling
+# ---------------------------------------------------------------------------
+
+def poll_state_until_terminal(
+    machine: str,
+    nas_unit_dir: Path,
+    *,
+    g: GlobalCfg,
+    expected_tokens: list[str],
+    on_phase_change=None,
+    on_poll=None,
+) -> dict:
+    """Block until the unit reaches a terminal phase OR is declared dead.
+
+    Returns the final state dict.
+
+    Callbacks:
+    - ``on_phase_change(phase, state)`` fires whenever ``state.json``
+      ``phase`` transitions.
+    - ``on_poll(state)`` fires every successful poll iteration (after
+      ``state.json`` first appears) — used to push throttled HEARTBEAT
+      events to the DB writer so ``imaging_runs.last_heartbeat`` stays
+      fresh in DB even though NAS heartbeat is the real liveness source.
+    """
+    state_path = nas_unit_dir / "state.json"
+    hb_path = nas_unit_dir / "heartbeat"
+
+    last_phase: Optional[str] = None
+    state_appeared = False
+    started = time.monotonic()
+
+    while True:
+        time.sleep(g.poll_interval_sec)
+        # 1. Wait for state.json to appear
+        if not state_appeared:
+            if state_path.exists():
+                state_appeared = True
+            else:
+                if time.monotonic() - started > g.state_appeared_timeout_sec:
+                    # Worker never wrote state — likely crashed at launch
+                    return {
+                        "phase": "failed",
+                        "success": False,
+                        "error_message": (
+                            f"state.json never appeared within "
+                            f"{g.state_appeared_timeout_sec}s"
+                        ),
+                    }
+                continue
+
+        try:
+            state = json.loads(state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            # Mid-write race; retry.
+            continue
+
+        phase = state.get("phase")
+        if phase != last_phase and on_phase_change is not None:
+            try:
+                on_phase_change(phase, state)
+            except Exception:
+                log.exception("on_phase_change callback failed")
+            last_phase = phase
+
+        if on_poll is not None:
+            try:
+                on_poll(state)
+            except Exception:
+                log.exception("on_poll callback failed")
+
+        if phase in ("done", "failed"):
+            return state
+
+        # Liveness check on stale heartbeat
+        try:
+            hb_age = time.time() - hb_path.stat().st_mtime
+        except OSError:
+            hb_age = float("inf")
+
+        if hb_age > g.heartbeat_stale_threshold_sec:
+            pid = state.get("worker_pid")
+            alive, info = ssh_pid_alive(
+                machine, pid, expected_tokens, timeout=10,
+            )
+            if alive is False:
+                return {
+                    **state,
+                    "phase": "failed",
+                    "success": False,
+                    "error_message": (
+                        f"worker dead pid {pid} (cmdline now: {info!r})"
+                    ),
+                }
+            if alive is None:
+                # Unreachable — keep waiting; coordinator will try again
+                log.warning(
+                    "ssh-unreachable while polling run_id=%s on %s: %s",
+                    state.get("run_id"), machine, info,
+                )
+                continue
+            # Alive but heartbeat stale — bound by max_stale_alive
+            if hb_age > g.max_stale_alive_sec:
+                ssh_kill_pgid(machine, state.get("worker_pgid") or 0, "TERM")
+                return {
+                    **state,
+                    "phase": "failed",
+                    "success": False,
+                    "error_message": (
+                        f"worker pid {pid} alive but heartbeat stale "
+                        f"{hb_age:.0f}s > max_stale_alive "
+                        f"{g.max_stale_alive_sec}s — killed"
+                    ),
+                }
+
+
+# ---------------------------------------------------------------------------
+# Manifest construction
+# ---------------------------------------------------------------------------
+
+def serialise_unit(u: ImagingUnit) -> dict:
+    return {
+        "gous_uid": u.gous_uid,
+        "source_name": u.source_name,
+        "line_group": u.line_group,
+        "spw_id": u.spw_id,
+        "params_id": u.params_id,
+        "recovered_params": u.recovered_params,
+        "vis_tm": list(u.vis_tm),
+        "vis_sm": list(u.vis_sm),
+        "sdimage": u.sdimage,
+        "spw_selection": list(u.spw_selection),
+        "field_selection": list(u.field_selection),
+        "datacolumn": u.datacolumn,
+        "mous_uids_tm": list(u.mous_uids_tm),
+        "mous_uids_sm": list(u.mous_uids_sm),
+        "mous_uids_tp": list(u.mous_uids_tp),
+        "tp_freq_min": u.tp_freq_min,
+        "tp_freq_max": u.tp_freq_max,
+        "tp_nchan": u.tp_nchan,
+    }
+
+
+def union_inputs_for_gous(units: list[ImagingUnit]) -> list[dict]:
+    """Compute the union of MS+TP inputs across all units of one GOUS."""
+    ms = set()
+    tp = set()
+    for u in units:
+        for p in u.vis_tm:
+            ms.add(p)
+        for p in u.vis_sm:
+            ms.add(p)
+        if u.sdimage:
+            tp.add(u.sdimage)
+    out = [{"src": p, "bucket": "ms"} for p in sorted(ms)]
+    out += [{"src": p, "bucket": "tp"} for p in sorted(tp)]
+    return out
+
+
+def write_unit_manifest(
+    nas_unit_dir: Path,
+    *,
+    unit: ImagingUnit,
+    expected_inputs: list[dict],
+    publish_dir: Path,
+    nproc: int,
+    casa_path: Optional[str],
+    deconvolver: str,
+    scales: list[int],
+) -> Path:
+    nas_unit_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = nas_unit_dir / "manifest.json"
+    manifest = {
+        "schema_version": 1,
+        "unit": serialise_unit(unit),
+        "expected_inputs": expected_inputs,
+        "publish_dir": str(publish_dir),
+        "nas_unit_dir": str(nas_unit_dir),
+        "nproc": int(nproc),
+        "casa_path": casa_path,
+        "deconvolver": deconvolver,
+        "scales": list(scales),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, default=str))
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation pass
+# ---------------------------------------------------------------------------
+
+def reconcile_prior(
+    db_manager: DatabaseManager,
+    base_dir: Path,
+    g: GlobalCfg,
+    *,
+    abandon: bool = False,
+) -> list[dict]:
+    """Reconcile prior dispatches.  Returns a list of adoptable runs.
+
+    For each non-terminal dispatch in the DB:
+
+    - For each ``state.json`` under that dispatch's NAS dir:
+        - Terminal phase → apply MARK_DONE (idempotent via mark_done UPDATE).
+        - Non-terminal + fresh heartbeat → adopt.
+        - Non-terminal + stale heartbeat + ``ssh kill -0`` says alive
+          (cmdline match) → adopt with warning.
+        - Non-terminal + stale heartbeat + dead → MARK_FAILED.
+        - Non-terminal + stale heartbeat + ssh-unreachable → keep,
+          log warning (coordinator can't safely declare dead).
+    - Additionally iterate DB rows in non-terminal state for which no
+      state file exists → if the launch_log shows failure or the
+      heartbeat is missing entirely → MARK_FAILED.
+
+    ``abandon=True`` skips all adoption and force-FAILs in-flight units
+    of prior dispatches.
+    """
+    dispatch_root = base_dir / "imaging" / "dispatch"
+    adoptable: list[dict] = []
+
+    with db_manager.connect() as con:
+        prior = DispatchesQueries.list_running(con)
+
+    for d in prior:
+        d_id = d["dispatch_id"]
+        d_dir = dispatch_root / d_id
+        units_dir = d_dir / "units"
+
+        # Pass 1: state files
+        seen_run_ids: set[int] = set()
+        if units_dir.exists():
+            for run_subdir in sorted(units_dir.iterdir()):
+                if not run_subdir.is_dir():
+                    continue
+                state_path = run_subdir / "state.json"
+                if not state_path.exists():
+                    continue
+                try:
+                    state = json.loads(state_path.read_text())
+                except (OSError, json.JSONDecodeError):
+                    continue
+                run_id = int(state.get("run_id") or 0)
+                if not run_id:
+                    continue
+                seen_run_ids.add(run_id)
+                _reconcile_state_entry(
+                    db_manager, d_id, run_id, state, run_subdir, g,
+                    adoptable, abandon=abandon,
+                )
+
+        # Pass 2: DB rows for this dispatch with no state file
+        with db_manager.connect() as con:
+            db_rows = ImagingRunsQueries.list_running_for_dispatch(con, d_id)
+        for row in db_rows:
+            if row["id"] in seen_run_ids:
+                continue
+            # No state.json — this row's launch likely failed
+            _mark_failed(
+                db_manager, row["id"],
+                error="no state.json found at reconciliation",
+            )
+
+    # Mark prior dispatches done if they have no surviving non-terminal rows
+    for d in prior:
+        d_id = d["dispatch_id"]
+        with db_manager.connect() as con:
+            still_active = ImagingRunsQueries.list_running_for_dispatch(con, d_id)
+        if not still_active:
+            with db_manager.connect() as con:
+                DispatchesQueries.mark_terminal(
+                    con, d_id, state=DispatchState.ABORTED if abandon else DispatchState.DONE,
+                )
+                con.commit()
+            if abandon:
+                # Best-effort: reap orphaned staging tokens for this
+                # dispatch and ssh-rm /raid/d_<id>/ on every machine in
+                # its machines_json snapshot.  Without this, prior code
+                # required manual rm -rf on each participating host.
+                _cleanup_abandoned_dispatch(
+                    d_id, dispatch_root / d_id,
+                    d.get("machines_json") or "{}",
+                )
+
+    # When abandoning, also try to release a stale dispatcher lock left
+    # by a coordinator that died (e.g. machine reboot).  Safe in normal
+    # dispatch runs too: our own lock points at our live PID with our
+    # own cmdline, which the helper detects and leaves alone.
+    if abandon:
+        _release_stale_dispatcher_lock(
+            dispatch_root / ".dispatcher.lock",
+            expected_tokens=["run_imaging_dispatch"],
+        )
+
+    return adoptable
+
+
+def _reconcile_state_entry(
+    db_manager, dispatch_id, run_id, state, unit_dir,
+    g: GlobalCfg, adoptable, *, abandon: bool,
+) -> None:
+    """Apply one prior unit's state to the DB; possibly mark for adoption."""
+    phase = state.get("phase", "starting")
+    # state.json stores ``socket.gethostname()``, which on some hosts is the
+    # FQDN (e.g. ``host5.example.com``); normalise to the short name keyed
+    # in machines.json so slot accounting and cleanup mappings match.
+    machine = (state.get("machine") or state.get("hostname") or "").split(".", 1)[0]
+    pid = state.get("worker_pid")
+    expected_tokens = [
+        f"--dispatch-id {dispatch_id}",
+        f"--run-id {int(run_id)}",
+    ]
+
+    if phase in ("done", "failed"):
+        _apply_terminal_to_db(db_manager, run_id, state, unit_dir)
+        return
+
+    if abandon:
+        _mark_failed(db_manager, run_id,
+                     error=f"abandoned by --abandon-prior at phase={phase}")
+        return
+
+    # Heartbeat check
+    hb_path = unit_dir / "heartbeat"
+    try:
+        hb_age = time.time() - hb_path.stat().st_mtime
+    except OSError:
+        hb_age = float("inf")
+
+    if hb_age < g.heartbeat_stale_threshold_sec:
+        adoptable.append({
+            "machine": machine, "run_id": run_id,
+            "unit_dir": unit_dir, "state": state,
+            "expected_tokens": expected_tokens,
+            "prior_dispatch_id": dispatch_id,
+        })
+        return
+
+    alive, info = ssh_pid_alive(machine, pid, expected_tokens, timeout=10)
+    if alive is True:
+        log.warning(
+            "adopting run_id=%d on %s: pid alive but heartbeat stale "
+            "%.0fs (cmdline ok)",
+            run_id, machine, hb_age,
+        )
+        adoptable.append({
+            "machine": machine, "run_id": run_id,
+            "unit_dir": unit_dir, "state": state,
+            "expected_tokens": expected_tokens,
+            "prior_dispatch_id": dispatch_id,
+        })
+        return
+    if alive is False:
+        _mark_failed(
+            db_manager, run_id,
+            error=f"abandoned (no heartbeat {hb_age:.0f}s, pid {pid} dead/reused: {info!r})",
+        )
+        return
+    # alive is None — ssh failed; do NOT mark failed
+    log.warning(
+        "ssh-unreachable during reconcile of run_id=%d on %s: %s; "
+        "leaving row active (rerun --reconcile or use --abandon-prior)",
+        run_id, machine, info,
+    )
+
+
+def _apply_terminal_to_db(db_manager, run_id, state, unit_dir) -> None:
+    """Idempotent terminal-state apply for a recovered worker."""
+    success = bool(state.get("success"))
+    status = ImagingRunStatus.SUCCESS if success else ImagingRunStatus.FAILED
+    job_json = None
+    prov = state.get("provenance") or {}
+    if prov.get("job_json"):
+        job_json = prov["job_json"]
+    with db_manager.connect() as con:
+        if state.get("spw_selection") or state.get("field_selection"):
+            ImagingRunsQueries.update_resolved(
+                con, run_id,
+                spw_selection=json.dumps(state.get("spw_selection"))
+                if state.get("spw_selection") else None,
+                field_selection=json.dumps(state.get("field_selection"))
+                if state.get("field_selection") else None,
+            )
+        if job_json:
+            con.execute(
+                "UPDATE imaging_runs SET job_json_path=? WHERE id=?",
+                (job_json, run_id),
+            )
+        ImagingRunsQueries.mark_done(
+            con, run_id, status=status,
+            retcode=0 if success else 1,
+            finished_at=state.get("finished_at") or now_iso(),
+            duration_sec=0.0,
+            output_fits=state.get("output_fits"),
+        )
+        ImagingRunsQueries.set_error_message(
+            con, run_id, state.get("error_message"),
+        )
+        con.commit()
+
+
+def _mark_failed(db_manager, run_id, *, error: str) -> None:
+    with db_manager.connect() as con:
+        ImagingRunsQueries.mark_done(
+            con, run_id,
+            status=ImagingRunStatus.FAILED,
+            retcode=1,
+            finished_at=now_iso(),
+            duration_sec=0.0,
+            output_fits=None,
+        )
+        ImagingRunsQueries.set_error_message(con, run_id, error)
+        con.commit()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup helpers used by both ``reconcile_prior(abandon=True)`` and the
+# running coordinator's TokenReaper.  Kept as module-level functions so
+# the abandon path can invoke them without spawning a thread.
+# ---------------------------------------------------------------------------
+
+# A token whose ``host``/``pid`` files are missing is either fresh
+# (worker mid-write between mkdir and metadata) or a worker that crashed
+# in that window.  Reap only after this grace period so live workers
+# aren't disrupted.
+_TOKEN_MALFORMED_GRACE_SEC = 60.0
+
+
+def _sweep_tokens_once(
+    tokens_dir: Path,
+    expected_tokens: list[str],
+    *,
+    malformed_grace_sec: float = _TOKEN_MALFORMED_GRACE_SEC,
+    ssh_timeout: int = 8,
+) -> int:
+    """Reap stale staging tokens under *tokens_dir*; return count reaped.
+
+    Used by the running coordinator's :class:`TokenReaper` (every
+    ``token_reaper_interval_sec``) and by ``reconcile_prior`` when
+    cleaning up an abandoned dispatch.  ``ssh_pid_alive(..., None)``
+    (ssh-unreachable) is treated as "do nothing" — never reap on an
+    inconclusive check.
+    """
+    import shutil
+    reaped = 0
+    if not Path(tokens_dir).exists():
+        return 0
+    for t in list_held_tokens(tokens_dir):
+        host = t.get("host")
+        pid = t.get("pid")
+        if not host or not pid:
+            try:
+                age = time.time() - Path(t["path"]).stat().st_mtime
+            except OSError:
+                continue
+            if age >= malformed_grace_sec:
+                shutil.rmtree(t["path"], ignore_errors=True)
+                reaped += 1
+                log.info(
+                    "reaped malformed staging token %s "
+                    "(no holder metadata after %.0fs)",
+                    t["slot"], age,
+                )
+            continue
+        alive, _ = ssh_pid_alive(host, pid, expected_tokens, timeout=ssh_timeout)
+        if alive is False:
+            shutil.rmtree(t["path"], ignore_errors=True)
+            reaped += 1
+            log.info(
+                "reaped stale staging token %s (host=%s pid=%s)",
+                t["slot"], host, pid,
+            )
+    return reaped
+
+
+def _release_stale_dispatcher_lock(
+    lock_path: Path,
+    expected_tokens: list[str],
+    *,
+    timeout: int = 8,
+) -> bool:
+    """Unlink the dispatcher lock file iff its recorded holder is dead.
+
+    The lock file format written by :class:`DispatcherLock.acquire` is
+    ``host=<fqdn> pid=<int>``.  We strip the FQDN to a short name and
+    consult ``ssh_pid_alive`` with *expected_tokens* (a substring of our
+    own dispatcher cmdline, e.g. ``run_imaging_dispatch``) to confirm
+    the holder process is dead AND not a PID-reused unrelated process.
+    Returns ``True`` iff we removed the file.
+
+    Conservative on every error path: missing/malformed lock, ssh
+    failure, or live holder all return ``False`` without touching the
+    file.  Safe to call in a live-dispatcher run — we'll find our own
+    PID alive with our own cmdline and leave the lock alone.
+    """
+    try:
+        text = lock_path.read_text().strip()
+    except OSError:
+        return False
+    m = re.search(r"host=(\S+)\s+pid=(\d+)", text)
+    if not m:
+        return False
+    host = m.group(1).split(".", 1)[0]
+    try:
+        pid = int(m.group(2))
+    except (TypeError, ValueError):
+        return False
+    alive, info = ssh_pid_alive(host, pid, expected_tokens, timeout=timeout)
+    if alive is True:
+        return False
+    if alive is None:
+        log.warning(
+            "stale dispatcher lock not released: ssh-unreachable to %s "
+            "(holder %r); leaving %s in place",
+            host, text, lock_path,
+        )
+        return False
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        return False
+    log.info(
+        "released stale dispatcher lock %s (holder %r was dead/reused)",
+        lock_path, text,
+    )
+    return True
+
+
+def _cleanup_abandoned_dispatch(
+    dispatch_id: str,
+    dispatch_dir: Path,
+    machines_json_str: str,
+    *,
+    ssh_timeout: int = 30,
+) -> dict:
+    """Best-effort cleanup of a dispatch we just force-abandoned.
+
+    1. Sweep orphaned staging tokens under
+       ``<dispatch_dir>/staging_tokens/`` using ``_sweep_tokens_once``.
+       The expected token is ``--dispatch-id <id>`` so a PID reused for
+       an unrelated live process is correctly classified as dead.
+    2. ``ssh <m> "rm -rf <raid>/d_<dispatch_id>/"`` on every machine in
+       the ``machines_json`` snapshot stored on the ``dispatches`` row.
+
+    Returns a summary dict.  Errors on any single host are logged and
+    counted but never raised — this runs from ``reconcile_prior`` which
+    must remain best-effort across a partial cluster.
+    """
+    summary = {"tokens_reaped": 0, "machines_swept": [], "machine_failures": {}}
+
+    tokens_dir = dispatch_dir / "staging_tokens"
+    expected = [f"--dispatch-id {dispatch_id}"]
+    try:
+        summary["tokens_reaped"] = _sweep_tokens_once(tokens_dir, expected)
+    except Exception:
+        log.exception(
+            "token sweep failed for abandoned dispatch %s", dispatch_id,
+        )
+
+    try:
+        machines = json.loads(machines_json_str or "{}")
+    except (TypeError, ValueError):
+        log.warning(
+            "could not parse machines_json for dispatch %s", dispatch_id,
+        )
+        machines = {}
+
+    for name, mcfg in machines.items():
+        raid = (mcfg or {}).get("raid")
+        if not raid:
+            continue
+        target = f"{raid}/d_{dispatch_id}"
+        cmd = f"rm -rf -- {shlex.quote(target)}"
+        try:
+            proc = ssh_run(name, cmd, timeout=ssh_timeout)
+        except subprocess.TimeoutExpired:
+            summary["machine_failures"][name] = "ssh timeout"
+            log.warning(
+                "raid sweep timeout on %s for dispatch %s", name, dispatch_id,
+            )
+            continue
+        except Exception as e:
+            summary["machine_failures"][name] = str(e)
+            log.warning(
+                "raid sweep error on %s for dispatch %s: %s",
+                name, dispatch_id, e,
+            )
+            continue
+        if proc.returncode != 0:
+            summary["machine_failures"][name] = (
+                f"rc={proc.returncode}: {(proc.stderr or '')[-120:]}"
+            )
+            log.warning(
+                "raid sweep rc=%d on %s for dispatch %s: %s",
+                proc.returncode, name, dispatch_id,
+                (proc.stderr or "")[-120:],
+            )
+            continue
+        summary["machines_swept"].append(name)
+
+    log.info(
+        "abandoned dispatch %s cleaned: tokens_reaped=%d, swept=%s, failed=%s",
+        dispatch_id, summary["tokens_reaped"],
+        summary["machines_swept"], summary["machine_failures"],
+    )
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Token reaper (background thread)
+# ---------------------------------------------------------------------------
+
+class TokenReaper(threading.Thread):
+    def __init__(self, tokens_dir: Path, g: GlobalCfg, expected_tokens: list[str]):
+        super().__init__(name="token-reaper", daemon=True)
+        self.tokens_dir = Path(tokens_dir)
+        self.g = g
+        self.expected_tokens = list(expected_tokens)
+        self._stop = threading.Event()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    # Kept as a class attribute for backwards-compat with code that may
+    # have referenced ``TokenReaper.MALFORMED_GRACE_SEC``; the actual
+    # sweep delegates to the module-level ``_sweep_tokens_once``.
+    MALFORMED_GRACE_SEC = _TOKEN_MALFORMED_GRACE_SEC
+
+    def run(self) -> None:
+        while not self._stop.wait(self.g.token_reaper_interval_sec):
+            try:
+                self._sweep()
+            except Exception:
+                log.exception("token reaper sweep failed")
+
+    def _sweep(self) -> int:
+        """Thin wrapper around :func:`_sweep_tokens_once` — kept so
+        existing tests that call ``reaper._sweep()`` still work."""
+        return _sweep_tokens_once(
+            self.tokens_dir,
+            self.expected_tokens,
+            malformed_grace_sec=self.MALFORMED_GRACE_SEC,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cleanup thread (coordinator-driven)
+# ---------------------------------------------------------------------------
+
+class GousCleaner(threading.Thread):
+    def __init__(
+        self,
+        scheduler: SchedulerState,
+        cfg: MachinesConfig,
+        dispatch_id: str,
+        g: GlobalCfg,
+    ):
+        super().__init__(name="gous-cleaner", daemon=True)
+        self.scheduler = scheduler
+        self.cfg = cfg
+        self.dispatch_id = dispatch_id
+        self.g = g
+        self._stop = threading.Event()
+        self._cleaned: set[tuple[str, str]] = set()
+        self._lock = threading.Lock()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def run(self) -> None:
+        while not self._stop.wait(self.g.cleanup_interval_sec):
+            try:
+                self._sweep()
+            except Exception:
+                log.exception("GOUS cleaner sweep failed")
+
+    def force_run(self) -> None:
+        try:
+            self._sweep()
+        except Exception:
+            log.exception("GOUS cleaner force_run failed")
+
+    def _sweep(self) -> None:
+        # Iterate seen_pairs (not in_flight) so we still catch GOUSs whose
+        # in_flight entry has been deleted by mark_terminal.
+        with self.scheduler.lock:
+            pairs = list(self.scheduler.seen_pairs)
+        for machine, gous in pairs:
+            with self._lock:
+                if (machine, gous) in self._cleaned:
+                    continue
+            with self.scheduler.lock:
+                in_flight = self.scheduler.in_flight.get((machine, gous), set())
+            if in_flight:
+                continue
+            if self.scheduler.queued_for_gous_total(gous):
+                continue
+            with self._lock:
+                if (machine, gous) in self._cleaned:
+                    continue
+                self._cleaned.add((machine, gous))
+            self._clean_one(machine, gous)
+
+    def _clean_one(self, machine: str, gous: str) -> None:
+        m = self.cfg.machines.get(machine)
+        if m is None:
+            return
+        # Adopted prior-dispatch units live under /raid/d_<prior_id>/...
+        # (not /raid/d_<new_id>/...), so we resolve the dispatch_id per
+        # pair before building the rm path.
+        with self.scheduler.lock:
+            pair_did = self.scheduler.pair_dispatch_id.get(
+                (machine, gous), self.dispatch_id,
+            )
+            ok_run_ids = sorted(self.scheduler.success_run_ids.get(
+                (machine, gous), set(),
+            ))
+        gous_input = f"{m.raid}/d_{pair_did}/input/{gous}"
+        cmds = [f"rm -rf -- {shlex.quote(gous_input)}"]
+        # Also delete work/runs/<id> for SUCCESS units of this (machine,
+        # gous).  We read from the scheduler's in-memory record rather
+        # than the DB so a queued-but-not-yet-committed MARK_DONE event
+        # can't cause us to miss a cleanup.  Failed-unit work dirs are
+        # preserved for forensics; their logs are already on NAS via
+        # remote_worker._copy_provenance_to_nas.
+        if ok_run_ids:
+            for rid in ok_run_ids:
+                rd = f"{m.raid}/d_{pair_did}/work/runs/{int(rid)}"
+                cmds.append(f"rm -rf -- {shlex.quote(rd)}")
+        try:
+            ssh_run(machine, " && ".join(cmds), timeout=60)
+            log.info(
+                "cleaned (dispatch=%s): input/%s + %d success work-dirs on %s",
+                pair_did, gous, len(ok_run_ids), machine,
+            )
+        except subprocess.SubprocessError as exc:
+            log.warning("cleanup ssh failed for %s:%s: %s", machine, gous, exc)
+
+
+# ---------------------------------------------------------------------------
+# Per-machine worker thread
+# ---------------------------------------------------------------------------
+
+class MachineSlot(threading.Thread):
+    def __init__(
+        self,
+        slot_id: str,
+        machine: MachineCfg,
+        ctx: "DispatchContext",
+    ):
+        super().__init__(name=f"slot-{slot_id}", daemon=True)
+        self.slot_id = slot_id
+        self.machine = machine
+        self.ctx = ctx
+        self._stop = threading.Event()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def run(self) -> None:
+        while not self._stop.is_set():
+            unit = self.ctx.scheduler.pick(self.machine.name, self._next_run_id)
+            if unit is None:
+                # Drained — exit slot
+                return
+            try:
+                self._dispatch_one(unit)
+            except Exception:
+                log.exception("slot %s crashed on unit %s/%s/spw%s",
+                              self.slot_id, unit.gous_uid, unit.source_name, unit.spw_id)
+
+    def _next_run_id(self) -> Optional[int]:  # not used by current scheduler
+        return None
+
+    def _dispatch_one(self, unit: ImagingUnit) -> None:
+        c = self.ctx
+        machine = self.machine.name
+
+        # 1. Allocate run_id (insert QUEUED row)
+        from panta_rei.imaging.runner import get_casa_version
+        from panta_rei.imaging.matching import (
+            _compute_tm_freq_range, build_output_path,
+        )
+        recovered = unit.recovered_params or {}
+        tm_freq = _compute_tm_freq_range(
+            recovered.get("start", ""),
+            recovered.get("width", ""),
+            recovered.get("nchan"),
+        )
+        freq_min = tm_freq[0] if tm_freq else (unit.tp_freq_min or 0)
+        freq_max = tm_freq[1] if tm_freq else (unit.tp_freq_max or 0)
+        canonical_fits = build_output_path(
+            c.publish_dir, unit.gous_uid, unit.source_name, freq_min, freq_max,
+        )
+        imagename_stem = str(canonical_fits).replace(".pbcor.fits", "")
+        scales_str = json.dumps(c.scales)
+
+        row_id_holder: dict = {}
+        c.db_writer.q.put({
+            "op": "INSERT_QUEUED",
+            "row": {
+                "params_id": unit.params_id,
+                "gous_uid": unit.gous_uid,
+                "source_name": unit.source_name,
+                "line_group": unit.line_group,
+                "spw_id": unit.spw_id,
+                "vis_tm": json.dumps(unit.vis_tm),
+                "vis_sm": json.dumps(unit.vis_sm),
+                "sdimage": unit.sdimage,
+                "mous_uids_tm": json.dumps(unit.mous_uids_tm),
+                "mous_uids_sm": json.dumps(unit.mous_uids_sm),
+                "mous_uids_tp": json.dumps(unit.mous_uids_tp),
+                "output_dir": str(c.publish_dir),
+                "imagename": imagename_stem,
+                "deconvolver": c.deconvolver,
+                "scales": scales_str,
+                "casa_version": get_casa_version(),
+                "started_at": now_iso(),
+                "status": ImagingRunStatus.QUEUED,
+                "hostname": machine,
+                "method": "tclean_feather",
+                "parallel": 1,
+                "dispatch_id": c.dispatch_id,
+            },
+            "row_id_holder": row_id_holder,
+        })
+        # Wait for the writer to populate the row id.
+        for _ in range(200):
+            if "id" in row_id_holder:
+                break
+            time.sleep(0.05)
+        if "id" not in row_id_holder:
+            log.error("DB writer did not return run_id within 10s; skipping unit")
+            return
+        run_id = int(row_id_holder["id"])
+
+        # 2. Build NAS unit dir + manifest
+        nas_unit_dir = c.dispatch_dir / "units" / str(run_id)
+        nas_unit_dir.mkdir(parents=True, exist_ok=True)
+
+        # Use the GOUS-union of inputs the coordinator pre-computed
+        expected_inputs = c.gous_inputs[unit.gous_uid]
+
+        manifest_path = write_unit_manifest(
+            nas_unit_dir,
+            unit=unit,
+            expected_inputs=expected_inputs,
+            publish_dir=c.publish_dir,
+            nproc=self.machine.nproc,
+            casa_path=c.cfg.casa_path,
+            deconvolver=c.deconvolver,
+            scales=c.scales,
+        )
+
+        # 3. Build per-unit launcher.sh on NAS
+        raid_dir = f"{self.machine.raid}/d_{c.dispatch_id}"
+        # Per-host cross-dispatch staging cache lives next to the
+        # per-dispatch dir, scoped to this host's /raid only.
+        cache_root = (
+            f"{self.machine.raid}/cache"
+            if self.machine.cache_min_free_gb is not None else None
+        )
+        launcher = write_launcher_script(
+            nas_unit_dir, c.cfg,
+            raid_dir=raid_dir,
+            manifest_path=str(manifest_path),
+            run_id=run_id,
+            dispatch_id=c.dispatch_id,
+            transfer_method=c.transfer_method,
+            publish_policy=c.publish_policy,
+            tokens_dir=str(c.tokens_dir),
+            max_concurrent_staging=c.cfg.global_cfg.max_concurrent_staging,
+            heartbeat_interval=c.cfg.global_cfg.heartbeat_interval_sec,
+            cache_root=cache_root,
+            cache_min_free_gb=self.machine.cache_min_free_gb,
+        )
+
+        # 4. Mark in-flight before SSH so the cleaner doesn't fire.
+        # Tag with the *current* dispatch_id so cleanup hits the right
+        # /raid/d_<id>/... tree.
+        c.scheduler.mark_inflight(
+            machine, unit.gous_uid, run_id, dispatch_id=c.dispatch_id,
+        )
+
+        # 5. Launch detached
+        ok, msg, wrapper_pid = launch_detached(
+            machine, launcher, nas_unit_dir,
+            timeout=c.cfg.global_cfg.ssh_timeout_sec,
+        )
+        if not ok:
+            c.db_writer.q.put({
+                "op": "MARK_DONE",
+                "run_id": run_id,
+                "status": ImagingRunStatus.FAILED,
+                "retcode": 255,
+                "finished_at": now_iso(),
+                "duration_sec": 0.0,
+                "error_message": f"ssh launch failed: {msg}",
+            })
+            c.scheduler.mark_terminal(
+                machine, unit.gous_uid, run_id, success=False,
+            )
+            return
+
+        # 6. Poll until terminal
+        t0 = time.monotonic()
+        expected_tokens = [
+            f"--dispatch-id {c.dispatch_id}",
+            f"--run-id {run_id}",
+        ]
+
+        def _on_phase(phase, state):
+            if phase == "running":
+                # Staging finished — let other slots pick this GOUS freely.
+                c.scheduler.mark_staged(machine, unit.gous_uid)
+            # Push MARK_RUNNING the first time we see worker_pid in state
+            if state.get("worker_pid"):
+                c.db_writer.q.put({
+                    "op": "MARK_RUNNING",
+                    "run_id": run_id,
+                    "remote_workdir": raid_dir,
+                    "worker_pid": int(state["worker_pid"]),
+                    "worker_pgid": int(state.get("worker_pgid") or 0),
+                    "hostname": machine,
+                })
+
+        last_db_hb_state = {"t": 0.0}
+        hb_throttle = max(
+            5.0, c.cfg.global_cfg.heartbeat_interval_sec / 2,
+        )
+
+        def _on_poll(state):
+            # Throttled DB heartbeat so imaging_runs.last_heartbeat is
+            # observable from `panta-rei` queries.  NAS heartbeat is the
+            # real liveness source; this is a visibility convenience.
+            now = time.monotonic()
+            if now - last_db_hb_state["t"] < hb_throttle:
+                return
+            last_db_hb_state["t"] = now
+            c.db_writer.q.put({
+                "op": "HEARTBEAT", "run_id": run_id,
+                "ts": now_iso(),
+            })
+
+        final = poll_state_until_terminal(
+            machine, nas_unit_dir, g=c.cfg.global_cfg,
+            expected_tokens=expected_tokens,
+            on_phase_change=_on_phase,
+            on_poll=_on_poll,
+        )
+        elapsed = time.monotonic() - t0
+
+        # 7. Apply terminal state to DB
+        prov = final.get("provenance") or {}
+        c.db_writer.q.put({
+            "op": "MARK_DONE",
+            "run_id": run_id,
+            "status": (ImagingRunStatus.SUCCESS if final.get("success")
+                       else ImagingRunStatus.FAILED),
+            "retcode": 0 if final.get("success") else 1,
+            "finished_at": final.get("finished_at") or now_iso(),
+            "duration_sec": float(elapsed),
+            "output_fits": final.get("output_fits"),
+            "spw_selection": (json.dumps(final["spw_selection"])
+                              if final.get("spw_selection") else None),
+            "field_selection": (json.dumps(final["field_selection"])
+                                if final.get("field_selection") else None),
+            "error_message": final.get("error_message"),
+            "job_json_path": prov.get("job_json"),
+        })
+        empty = c.scheduler.mark_terminal(
+            machine, unit.gous_uid, run_id,
+            success=bool(final.get("success")),
+        )
+        if empty:
+            # Possible cleanup opportunity — let the cleaner sweep
+            log.debug("(machine=%s, gous=%s) drained", machine, unit.gous_uid)
+
+
+# ---------------------------------------------------------------------------
+# Top-level dispatch context + entry point
+# ---------------------------------------------------------------------------
+
+class AdoptionPoller(threading.Thread):
+    """Poll an adopted (already-running) worker until it terminates.
+
+    Adopted workers were launched by a prior dispatch whose coordinator
+    died; their state.json + heartbeat are still being updated on NAS.
+    We resume polling, push the terminal event to the DB writer, and
+    register the unit in the scheduler's seen_pairs/in_flight so the
+    cleaner will sweep its /raid/ leftovers like any normal unit.
+    """
+
+    def __init__(
+        self,
+        adopted: dict,                      # dict from reconcile_prior
+        ctx: "DispatchContext",
+    ):
+        super().__init__(
+            name=f"adopt-{adopted['run_id']}", daemon=True,
+        )
+        self.adopted = adopted
+        self.ctx = ctx
+
+    def run(self) -> None:
+        c = self.ctx
+        run_id = int(self.adopted["run_id"])
+        machine = self.adopted["machine"]
+        unit_dir = Path(self.adopted["unit_dir"])
+        state = self.adopted["state"]
+        gous_uid = state.get("gous_uid") or self._gous_from_db(run_id)
+        prior_did = (
+            self.adopted.get("prior_dispatch_id")
+            or state.get("dispatch_id")
+        )
+        expected_tokens = self.adopted.get("expected_tokens") or [
+            f"--dispatch-id {prior_did or ''}",
+            f"--run-id {run_id}",
+        ]
+
+        # Account adopted unit in the scheduler so the cleaner reaches it.
+        # Tag with the *prior* dispatch_id so cleanup hits the right
+        # /raid/d_<prior_id>/... tree, NOT the new dispatch's.
+        if gous_uid:
+            c.scheduler.mark_inflight(
+                machine, gous_uid, run_id, dispatch_id=prior_did,
+            )
+
+        t0 = time.monotonic()
+        last_db_hb_state = {"t": 0.0}
+        hb_throttle = max(
+            5.0, c.cfg.global_cfg.heartbeat_interval_sec / 2,
+        )
+
+        def _on_poll(state):
+            now = time.monotonic()
+            if now - last_db_hb_state["t"] < hb_throttle:
+                return
+            last_db_hb_state["t"] = now
+            c.db_writer.q.put({
+                "op": "HEARTBEAT", "run_id": run_id,
+                "ts": now_iso(),
+            })
+
+        try:
+            final = poll_state_until_terminal(
+                machine, unit_dir,
+                g=c.cfg.global_cfg,
+                expected_tokens=expected_tokens,
+                on_poll=_on_poll,
+            )
+        except Exception:
+            log.exception("adoption poller crashed for run_id=%d", run_id)
+            return
+        elapsed = time.monotonic() - t0
+
+        prov = final.get("provenance") or {}
+        c.db_writer.q.put({
+            "op": "MARK_DONE",
+            "run_id": run_id,
+            "status": (ImagingRunStatus.SUCCESS if final.get("success")
+                       else ImagingRunStatus.FAILED),
+            "retcode": 0 if final.get("success") else 1,
+            "finished_at": final.get("finished_at") or now_iso(),
+            "duration_sec": float(elapsed),
+            "output_fits": final.get("output_fits"),
+            "spw_selection": (json.dumps(final["spw_selection"])
+                              if final.get("spw_selection") else None),
+            "field_selection": (json.dumps(final["field_selection"])
+                                if final.get("field_selection") else None),
+            "error_message": final.get("error_message"),
+            "job_json_path": prov.get("job_json"),
+        })
+        if gous_uid:
+            c.scheduler.mark_terminal(
+                machine, gous_uid, run_id,
+                success=bool(final.get("success")),
+            )
+
+    def _gous_from_db(self, run_id: int) -> Optional[str]:
+        try:
+            with self.ctx.db_manager.connect() as con:
+                row = ImagingRunsQueries.get_by_id(con, run_id)
+            return row.get("gous_uid") if row else None
+        except Exception:
+            return None
+
+
+@dataclass
+class DispatchContext:
+    cfg: MachinesConfig
+    dispatch_id: str
+    dispatch_dir: Path                    # <base-dir>/imaging/dispatch/<dispatch_id>/
+    publish_dir: Path
+    tokens_dir: Path
+    db_writer: DBWriter
+    db_manager: DatabaseManager
+    scheduler: SchedulerState
+    transfer_method: str
+    publish_policy: str
+    deconvolver: str
+    scales: list[int]
+    gous_inputs: dict[str, list[dict]]
+
+
+_du_cache: dict[str, int] = {}
+
+
+def _du_bytes(path: str) -> int:
+    """Cached ``du -sb`` for *path*.  Returns 0 on error."""
+    if path in _du_cache:
+        return _du_cache[path]
+    try:
+        proc = subprocess.run(
+            ["du", "-sb", path],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, timeout=120,
+        )
+        if proc.returncode == 0 and proc.stdout:
+            n = int(proc.stdout.split()[0])
+        else:
+            n = 0
+    except (subprocess.SubprocessError, ValueError):
+        n = 0
+    _du_cache[path] = n
+    return n
+
+
+def _estimate_max_gous_gb(by_gous: dict[str, list[ImagingUnit]]) -> float:
+    """Return the largest single-GOUS staged-input size in GB."""
+    if not by_gous:
+        return 0.0
+    sizes_gb: list[float] = []
+    for units in by_gous.values():
+        seen: set[str] = set()
+        total = 0
+        for u in units:
+            for p in list(u.vis_tm) + list(u.vis_sm):
+                if p and p not in seen:
+                    seen.add(p)
+                    total += _du_bytes(p)
+            if u.sdimage and u.sdimage not in seen:
+                seen.add(u.sdimage)
+                try:
+                    total += os.path.getsize(u.sdimage)
+                except OSError:
+                    pass
+        sizes_gb.append(total / 1e9)
+    return max(sizes_gb) if sizes_gb else 0.0
+
+
+def _git_meta(repo_path: Path) -> tuple[Optional[str], bool]:
+    try:
+        head = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5,
+        )
+        commit = head.stdout.strip() if head.returncode == 0 else None
+        dirty = subprocess.run(
+            ["git", "-C", str(repo_path), "status", "--porcelain"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5,
+        )
+        is_dirty = bool(dirty.stdout.strip())
+        return commit, is_dirty
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None, False
+
+
+def run_dispatch(
+    *,
+    base_dir: Path,
+    publish_dir: Path,
+    cfg: MachinesConfig,
+    db_manager: DatabaseManager,
+    selection_filters: SelectionFilters,
+    obs_csv: Path,
+    data_dir: Path,
+    transfer_method: str = "tar",
+    publish_policy: str = "fail_if_exists",
+    deconvolver: str = "multiscale",
+    scales: Optional[list[int]] = None,
+    cli_args: str = "",
+    abandon_prior: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Run one full dispatch.  Returns a summary dict."""
+    if scales is None:
+        scales = [0, 5, 10, 15, 20]
+
+    g = cfg.global_cfg
+
+    # 1. Dispatcher lock
+    lock = DispatcherLock(base_dir / "imaging" / "dispatch" / ".dispatcher.lock")
+    lock.acquire()
+    try:
+        # 2. Reconciliation — runs BEFORE selection so terminal results
+        # discovered here are visible to success_exists() and the
+        # active-row filter the selection uses.  Skipped under dry-run
+        # because reconcile_prior() mutates the DB (terminal applies,
+        # mark-failed for orphaned RUNNING rows, etc.); a read-only
+        # dry-run preview must not have side effects.
+        if dry_run:
+            log.info("dry-run: skipping reconciliation (DB-mutating)")
+            adoptable = []
+        else:
+            log.info("reconciling prior dispatches")
+            adoptable = reconcile_prior(
+                db_manager, base_dir, g, abandon=abandon_prior,
+            )
+            if adoptable:
+                log.info(
+                    "adopting %d in-flight unit(s) from prior dispatches",
+                    len(adoptable),
+                )
+
+        # 2b. Selection — uses fresh DB state from reconciliation.
+        log.info("selecting units to dispatch")
+        selection = select_units_to_image(
+            db_manager, obs_csv, data_dir, selection_filters,
+        )
+        log.info(
+            "selection: ready=%d not_ready=%d skipped_done=%d "
+            "skipped_active=%d skipped_filter=%d",
+            len(selection.ready), len(selection.not_ready),
+            selection.skipped_already_done, selection.skipped_active,
+            selection.skipped_filtered_out,
+        )
+
+        if dry_run:
+            return {
+                "dispatch_id": None,
+                "to_run": len(selection.ready),
+                "skipped_already_done": selection.skipped_already_done,
+                "skipped_active": selection.skipped_active,
+                "skipped_filtered_out": selection.skipped_filtered_out,
+                "adopted": len(adoptable or []),
+                "machines": list(cfg.machines.keys()),
+                "dry_run": True,
+            }
+
+        # 3. New dispatch identity + dir
+        dispatch_id = (
+            f"d_{int(time.time())}_{uuid.uuid4().hex[:6]}"
+        )
+        dispatch_dir = base_dir / "imaging" / "dispatch" / dispatch_id
+        dispatch_dir.mkdir(parents=True, exist_ok=True)
+        tokens_dir = dispatch_dir / "staging_tokens"
+        tokens_dir.mkdir(exist_ok=True)
+
+        # 4. Dispatches row
+        commit, is_dirty = _git_meta(Path(cfg.repo_path))
+        with db_manager.connect() as con:
+            DispatchesQueries.insert(
+                con,
+                dispatch_id=dispatch_id,
+                coordinator_host=socket.gethostname(),
+                coordinator_pid=os.getpid(),
+                git_commit=commit,
+                git_dirty=is_dirty,
+                machines_json=json.dumps({
+                    name: {"raid": m.raid, "slots": m.slots, "nproc": m.nproc}
+                    for name, m in cfg.machines.items()
+                }),
+                cli_args=cli_args,
+            )
+            con.commit()
+
+        # 5. Group by GOUS, compute union of inputs
+        ready = selection.ready
+        if not ready and not adoptable:
+            log.info("nothing to dispatch (no ready units, no adoptions)")
+            with db_manager.connect() as con:
+                DispatchesQueries.mark_terminal(con, dispatch_id, DispatchState.DONE)
+                con.commit()
+            return {
+                "dispatch_id": dispatch_id,
+                "to_run": 0,
+                "skipped_already_done": selection.skipped_already_done,
+                "skipped_active": selection.skipped_active,
+                "adopted": 0,
+            }
+
+        by_gous: dict[str, list[ImagingUnit]] = {}
+        for u in ready:
+            by_gous.setdefault(u.gous_uid, []).append(u)
+        gous_inputs = {g_uid: union_inputs_for_gous(us)
+                       for g_uid, us in by_gous.items()}
+
+        # 6. Spawn DB writer + scheduler.  These exist for both adoption
+        # pollers (which have running workers from prior dispatches) AND
+        # new slot threads, so they must come up BEFORE preflight.
+        db_writer = DBWriter(db_manager, dispatch_id)
+        db_writer.start()
+
+        scheduler = SchedulerState(queue=list(ready))
+        ctx = DispatchContext(
+            cfg=cfg, dispatch_id=dispatch_id, dispatch_dir=dispatch_dir,
+            publish_dir=publish_dir, tokens_dir=tokens_dir,
+            db_writer=db_writer, db_manager=db_manager, scheduler=scheduler,
+            transfer_method=transfer_method, publish_policy=publish_policy,
+            deconvolver=deconvolver, scales=scales,
+            gous_inputs=gous_inputs,
+        )
+
+        # 7. Cleaner — runs regardless of preflight outcome since adopted
+        # workers also need their (machine, GOUS) directories cleaned up.
+        cleaner = GousCleaner(scheduler, cfg, dispatch_id, g)
+        cleaner.start()
+
+        # 8. Token reapers — one for the new dispatch, plus one for each
+        # *prior* dispatch we adopted from.  Without the prior reapers,
+        # tokens held by crashed workers in old dispatches stay forever
+        # and adopted live workers may starve waiting for them.
+        reapers: list[TokenReaper] = []
+        new_reaper = TokenReaper(
+            tokens_dir, g,
+            expected_tokens=[f"--dispatch-id {dispatch_id}"],
+        )
+        new_reaper.start()
+        reapers.append(new_reaper)
+
+        prior_dispatch_ids = sorted({
+            a.get("prior_dispatch_id")
+            for a in (adoptable or [])
+            if a.get("prior_dispatch_id")
+        })
+        for prior_did in prior_dispatch_ids:
+            prior_tokens = (
+                base_dir / "imaging" / "dispatch" / prior_did / "staging_tokens"
+            )
+            if not prior_tokens.exists():
+                continue
+            r = TokenReaper(
+                prior_tokens, g,
+                expected_tokens=[f"--dispatch-id {prior_did}"],
+            )
+            r.start()
+            reapers.append(r)
+            log.info("watching prior dispatch staging_tokens: %s", prior_tokens)
+
+        # 9. Adoption pollers — start BEFORE machine preflight so a
+        # totally-unreachable cluster (or simply a different machine set
+        # in the new run) does not block adopted workers from being
+        # finalised in the DB.
+        adopt_per_machine: dict[str, int] = {}
+        adoption_threads: list[AdoptionPoller] = []
+        for a in (adoptable or []):
+            m_name = a["machine"]
+            adopt_per_machine[m_name] = adopt_per_machine.get(m_name, 0) + 1
+            t = AdoptionPoller(a, ctx)
+            t.start()
+            adoption_threads.append(t)
+
+        # 10. Machine preflight — only gates NEW launches.  Adopted units
+        # already running on prior-dispatch /raid/ paths don't care
+        # whether the new machine config preflights cleanly.  We keep
+        # ``cfg.machines`` as the full known set so the cleaner can
+        # reach machines that host adopted-only units; preflight just
+        # produces a separate ``new_launch_machines`` view.
+        new_launch_machines: dict[str, MachineCfg] = {}
+        if ready:
+            max_gous_gb = _estimate_max_gous_gb(by_gous)
+            nas_probe = str(publish_dir.parent if publish_dir.parent.exists()
+                            else publish_dir)
+            for name, m in cfg.machines.items():
+                required_gb = max_gous_gb + 50 + (m.slots * max_gous_gb)
+                ok, details = ssh_preflight_machine(
+                    name, m, cfg,
+                    required_gb=required_gb,
+                    nas_check_path=nas_probe,
+                    timeout=g.ssh_timeout_sec,
+                )
+                if ok:
+                    new_launch_machines[name] = m
+                    log.info("preflight ok: %s (free=%s GB)",
+                             name, details.get("free_gb"))
+                else:
+                    log.warning(
+                        "excluding %s from new launches: %s",
+                        name, details.get("error") or details,
+                    )
+            if not new_launch_machines:
+                log.error(
+                    "no machines passed preflight; "
+                    "skipping new launches but adoptions will still complete"
+                )
+
+        # 11. Slots — only on machines that passed preflight; account for
+        # adopted units already running on each.
+        slots: list[MachineSlot] = []
+        for m in new_launch_machines.values():
+            adopted_n = adopt_per_machine.get(m.name, 0)
+            available = max(0, m.slots - adopted_n)
+            if adopted_n:
+                log.info(
+                    "machine %s: %d adopted unit(s); spawning %d new slot(s)",
+                    m.name, adopted_n, available,
+                )
+            for i in range(available):
+                slot = MachineSlot(f"{m.name}#{i}", m, ctx)
+                slot.start()
+                slots.append(slot)
+
+        # 12. Wait for all slots AND adoption pollers to drain
+        for s in slots:
+            s.join()
+        for t in adoption_threads:
+            t.join()
+
+        # 13. Drain the DB writer queue BEFORE the final cleanup sweep so
+        # MARK_DONE events have committed before the cleaner queries
+        # SUCCESS rows.  q.join() returns when every put() has been
+        # task_done()'d by the writer.
+        db_writer.q.join()
+
+        # 14. Final cleanup sweep (idempotent rm -rf)
+        cleaner.force_run()
+
+        # 15. Stop background threads
+        for r in reapers:
+            r.stop()
+        for r in reapers:
+            r.join(timeout=5)
+        cleaner.stop(); cleaner.join(timeout=5)
+
+        # 16. End-of-run /raid/ sweep — backstop for paths the periodic
+        # cleaner might have missed.  Iterate the union of:
+        #   - new dispatch on each new-launch machine
+        #   - per-pair (machine, dispatch_id) recorded by the scheduler
+        # so adopted prior-dispatch /raid/ trees get cleaned too.
+        sweep_targets: set[tuple[str, str]] = set()
+        for m_name in new_launch_machines:
+            sweep_targets.add((m_name, dispatch_id))
+        with scheduler.lock:
+            for (pair_machine, _gous), pair_did in scheduler.pair_dispatch_id.items():
+                if pair_did:
+                    sweep_targets.add((pair_machine, pair_did))
+        for m_name, did in sorted(sweep_targets):
+            m = cfg.machines.get(m_name)
+            if m is None:
+                continue
+            try:
+                ssh_run(
+                    m_name,
+                    f"rm -rf -- {shlex.quote(f'{m.raid}/d_{did}/input')}",
+                    timeout=30,
+                )
+            except subprocess.SubprocessError as exc:
+                log.warning(
+                    "end-of-run sweep failed on %s/%s: %s",
+                    m_name, did, exc,
+                )
+
+        # 17. Stop DB writer + mark dispatch(es) done.
+        db_writer.stop()
+        db_writer.join(timeout=10)
+        with db_manager.connect() as con:
+            DispatchesQueries.mark_terminal(con, dispatch_id, DispatchState.DONE)
+            # Prior dispatches: mark DONE if they have no surviving
+            # non-terminal rows now that adoptions have completed.
+            for prior_did in prior_dispatch_ids:
+                still_active = ImagingRunsQueries.list_running_for_dispatch(
+                    con, prior_did,
+                )
+                if not still_active:
+                    DispatchesQueries.mark_terminal(
+                        con, prior_did, DispatchState.DONE,
+                    )
+            con.commit()
+
+        return {
+            "dispatch_id": dispatch_id,
+            "to_run": len(ready),
+            "skipped_already_done": selection.skipped_already_done,
+            "skipped_active": selection.skipped_active,
+            "adopted": len(adoption_threads),
+            "machines_used": list(new_launch_machines.keys()),
+        }
+    finally:
+        lock.release()

--- a/panta_rei/imaging/matching.py
+++ b/panta_rei/imaging/matching.py
@@ -462,6 +462,42 @@ def build_tclean_only_output_path(
     return output_dir / subdir / filename
 
 
+# Aux products (QA artefacts produced by tclean) — each is published as
+# FITS alongside the canonical .pbcor pair.  Order is just for stable
+# logging.
+AUX_PRODUCT_KINDS: tuple[str, ...] = ("mask", "residual", "pb")
+
+
+def build_aux_output_path(
+    output_dir: Path,
+    gous_id: str,
+    source_name: str,
+    freq_min_hz: float,
+    freq_max_hz: float,
+    kind: str,
+) -> Path:
+    """Build the output FITS path for a tclean aux product.
+
+    Aux products (mask, residual, pb) come from the tclean step and so
+    inherit the 12m7m naming.  Pattern:
+    ``{output_dir}/group.uid___A001_{gous_id}.lp_nperetto/
+    group.uid___A001_{gous_id}.lp_nperetto.{source}.12m7m.{freq}GHz.cube.{kind}.fits``
+    """
+    if kind not in AUX_PRODUCT_KINDS:
+        raise ValueError(
+            f"unknown aux product kind: {kind!r}; "
+            f"expected one of {AUX_PRODUCT_KINDS}"
+        )
+    sanitized = sanitize_source_name(source_name)
+    freq_range = get_freq_range_string(freq_min_hz, freq_max_hz)
+    subdir = f"group.uid___A001_{gous_id}.lp_nperetto"
+    filename = (
+        f"group.uid___A001_{gous_id}.lp_nperetto."
+        f"{sanitized}.12m7m.{freq_range}GHz.cube.{kind}.fits"
+    )
+    return output_dir / subdir / filename
+
+
 # ---------------------------------------------------------------------------
 # Preflight assembly (advisory mode)
 # ---------------------------------------------------------------------------

--- a/panta_rei/imaging/remote_worker.py
+++ b/panta_rei/imaging/remote_worker.py
@@ -1,0 +1,598 @@
+"""Detached per-unit worker for distributed imaging.
+
+Invoked via SSH by :mod:`panta_rei.imaging.dispatch`.  Each call processes
+exactly one imaging unit on the remote machine, reading its job manifest
+from NAS, staging inputs to the local /raid/, calling
+:func:`panta_rei.imaging.runner.run_tclean_feather_parallel` with
+``work_dir=/raid/...`` and ``publish_dir=<NAS canonical>``, then copying
+provenance back to NAS before exit.
+
+Two ownership rules avoid concurrent writers on shared state:
+
+1. **Heartbeat thread** owns ``<state-dir>/heartbeat`` (an empty file
+   that is touched).  It NEVER writes ``state.json``.
+2. **Main thread** owns ``state.json`` — only writes it on phase
+   transitions.  Atomic via temp + ``os.replace``.
+
+Coordinator polls heartbeat mtime + state.json phase.  PID + PGID are
+recorded once on first state.json write so the coordinator can verify
+liveness via ``ssh kill -0 <pid>`` + ``/proc/<pid>/cmdline`` matching.
+
+Two CLI modes:
+
+- ``--preflight`` : check raid path, free space, conda env, NAS visibility.
+  Returns JSON to stdout, exits.
+- (default run mode) : full lifecycle described above.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import signal
+import socket
+import sys
+import threading
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger("panta_rei.remote_worker")
+
+
+# ---------------------------------------------------------------------------
+# State machine constants
+# ---------------------------------------------------------------------------
+
+class Phase:
+    STARTING = "starting"
+    STAGING = "staging"
+    RUNNING = "running"
+    PUBLISHING = "publishing"
+    DONE = "done"
+    FAILED = "failed"
+
+
+TERMINAL_PHASES = {Phase.DONE, Phase.FAILED}
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat thread
+# ---------------------------------------------------------------------------
+
+class _Heartbeat:
+    """Touches a heartbeat file at fixed intervals.  Owns ONLY that file.
+
+    Started before staging so 10+-minute MS copies don't trigger the
+    coordinator's stale-heartbeat path.
+    """
+
+    def __init__(self, hb_path: Path, interval_sec: float) -> None:
+        self.hb_path = Path(hb_path)
+        self.interval = max(1.0, float(interval_sec))
+        self._stop = threading.Event()
+        self._t: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        self.hb_path.parent.mkdir(parents=True, exist_ok=True)
+        self.hb_path.touch()
+        self._t = threading.Thread(target=self._run, name="hb", daemon=True)
+        self._t.start()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.hb_path.touch()
+            except OSError as exc:
+                log.warning("heartbeat touch failed: %s", exc)
+            self._stop.wait(self.interval)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._t is not None:
+            self._t.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# State.json owner (main thread only)
+# ---------------------------------------------------------------------------
+
+def write_state_atomic(state_path: Path, payload: dict) -> None:
+    """Write state.json via temp + os.replace.  Main thread only."""
+    state_path = Path(state_path)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = state_path.with_suffix(state_path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload, indent=2, default=str))
+    os.replace(str(tmp), str(state_path))
+
+
+def read_state(state_path: Path) -> dict:
+    if not Path(state_path).exists():
+        return {}
+    try:
+        return json.loads(Path(state_path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Preflight mode
+# ---------------------------------------------------------------------------
+
+def preflight(args: argparse.Namespace) -> int:
+    """Validate raid path + free space + NAS visibility + conda env.
+
+    Emits a single line of JSON on stdout, then exits.
+    """
+    raid = Path(args.raid_dir)
+    nas_check = Path(args.nas_check_path) if args.nas_check_path else None
+    required_gb = float(args.required_gb or 0)
+
+    out: dict[str, Any] = {
+        "ok": True,
+        "host": socket.gethostname(),
+        "raid_dir": str(raid),
+    }
+
+    try:
+        raid.mkdir(parents=True, exist_ok=True)
+        # Try a small write
+        probe = raid / f".preflight.{os.getpid()}.tmp"
+        probe.write_text("ok")
+        probe.unlink()
+        out["raid_writable"] = True
+    except OSError as exc:
+        out["ok"] = False
+        out["raid_writable"] = False
+        out["raid_error"] = str(exc)
+
+    try:
+        st = shutil.disk_usage(str(raid))
+        free_gb = st.free / 1e9
+        out["free_gb"] = round(free_gb, 1)
+        if required_gb and free_gb < required_gb:
+            out["ok"] = False
+            out["disk_error"] = (
+                f"required {required_gb:.1f} GB, free {free_gb:.1f} GB"
+            )
+    except OSError as exc:
+        out["ok"] = False
+        out["free_gb"] = None
+        out["disk_error"] = str(exc)
+
+    if nas_check is not None:
+        try:
+            out["nas_visible"] = nas_check.exists()
+            if not out["nas_visible"]:
+                out["ok"] = False
+                out["nas_error"] = f"path not found: {nas_check}"
+        except OSError as exc:
+            out["ok"] = False
+            out["nas_visible"] = False
+            out["nas_error"] = str(exc)
+
+    out["python"] = sys.executable
+    out["pid"] = os.getpid()
+
+    print(json.dumps(out))
+    return 0 if out["ok"] else 1
+
+
+# ---------------------------------------------------------------------------
+# Main run mode
+# ---------------------------------------------------------------------------
+
+def _setup_pgid() -> int:
+    """Detach into a new process group so coordinator can kill -PGID us."""
+    try:
+        os.setsid()
+    except OSError:
+        # Already a session leader — fine.
+        pass
+    try:
+        return os.getpgrp()
+    except OSError:
+        return os.getpid()
+
+
+def _patch_unit_paths(
+    unit_dict: dict, gous_input_dir: Path,
+) -> None:
+    """Rewrite vis_tm/vis_sm/sdimage absolute paths to /raid/ counterparts.
+
+    The dispatcher embeds the original NAS paths in the manifest; the
+    worker stages each input under ``gous_input_dir / <bucket> / <name>``
+    where bucket is "ms" or "tp".  We map basenames back to the staged
+    location.
+    """
+    ms_dir = gous_input_dir / "ms"
+    tp_dir = gous_input_dir / "tp"
+
+    def remap(p: str, bucket_dir: Path) -> str:
+        return str(bucket_dir / Path(p).name)
+
+    unit_dict["vis_tm"] = [remap(p, ms_dir) for p in unit_dict.get("vis_tm", [])]
+    unit_dict["vis_sm"] = [remap(p, ms_dir) for p in unit_dict.get("vis_sm", [])]
+    sdimage = unit_dict.get("sdimage")
+    if sdimage:
+        unit_dict["sdimage"] = remap(sdimage, tp_dir)
+
+
+def _build_imaging_unit(unit_dict: dict):
+    """Reconstruct an ImagingUnit from the manifest dict (with raid paths)."""
+    from panta_rei.imaging.matching import ImagingUnit
+    return ImagingUnit(
+        gous_uid=unit_dict["gous_uid"],
+        source_name=unit_dict["source_name"],
+        line_group=unit_dict.get("line_group"),
+        spw_id=str(unit_dict["spw_id"]),
+        params_id=int(unit_dict["params_id"]),
+        recovered_params=unit_dict.get("recovered_params", {}),
+        vis_tm=list(unit_dict.get("vis_tm", [])),
+        vis_sm=list(unit_dict.get("vis_sm", [])),
+        sdimage=unit_dict.get("sdimage"),
+        spw_selection=list(unit_dict.get("spw_selection", [])),
+        field_selection=list(unit_dict.get("field_selection", [])),
+        datacolumn=unit_dict.get("datacolumn", "corrected"),
+        mous_uids_tm=list(unit_dict.get("mous_uids_tm", [])),
+        mous_uids_sm=list(unit_dict.get("mous_uids_sm", [])),
+        mous_uids_tp=list(unit_dict.get("mous_uids_tp", [])),
+        tp_freq_min=unit_dict.get("tp_freq_min"),
+        tp_freq_max=unit_dict.get("tp_freq_max"),
+        tp_nchan=unit_dict.get("tp_nchan"),
+        ready=True,
+        skip_reason=None,
+    )
+
+
+def _ensure_staged_inputs(
+    gous_input_dir: Path,
+    expected_inputs: list[dict],
+    transfer_method: str,
+    *,
+    cache_root: Optional[Path] = None,
+    cache_min_free_bytes: Optional[int] = None,
+    token_lease: Optional["staging.TokenLease"] = None,
+) -> dict:
+    """Stage all inputs in ``expected_inputs`` (the GOUS union).
+
+    Uses :func:`panta_rei.imaging.staging.stage_one` plus an mkdir-based
+    per-(machine, GOUS) lock so concurrent slot workers cooperate.
+
+    Returns a telemetry dict with per-source counts for state.json::
+
+        {"existing": N, "cache_hit": N, "cache_hit_after_wait": N,
+         "cache_miss": N, "nas_direct": N}
+    """
+    from panta_rei.imaging import staging
+
+    gous_input_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = gous_input_dir / ".staging.manifest"
+    counts = {
+        "existing": 0, "cache_hit": 0, "cache_hit_after_wait": 0,
+        "cache_miss": 0, "nas_direct": 0,
+    }
+
+    with staging.acquire_stage_lock(gous_input_dir, holder_meta={"pid": os.getpid()}):
+        manifest = staging.read_manifest(manifest_path)
+        expected_paths = sorted(set(
+            list(manifest.get("expected", [])) + [e["src"] for e in expected_inputs]
+        ))
+        manifest["expected"] = expected_paths
+        already = set(manifest.get("completed", []))
+
+        for entry in expected_inputs:
+            src = entry["src"]
+            bucket = entry.get("bucket", "ms")
+            if src in already:
+                counts["existing"] += 1
+                continue
+            _staged_path, source = staging.stage_one(
+                src, gous_input_dir,
+                method=transfer_method, bucket=bucket,
+                cache_root=cache_root,
+                cache_min_free_bytes=cache_min_free_bytes,
+                token_lease=token_lease,
+            )
+            counts[source] = counts.get(source, 0) + 1
+            manifest.setdefault("completed", []).append(src)
+            staging.atomic_write_json(manifest_path, manifest)
+
+        manifest["completed_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+        staging.atomic_write_json(manifest_path, manifest)
+    return counts
+
+
+def _copy_provenance_to_nas(
+    work_run_dir: Path,
+    log_path: Path,
+    nas_unit_dir: Path,
+) -> dict:
+    """Copy job.json, result.json, log to NAS.  Return absolute NAS paths."""
+    nas_unit_dir.mkdir(parents=True, exist_ok=True)
+    out: dict[str, Optional[str]] = {
+        "job_json": None, "result_json": None, "log": None,
+    }
+    job_src = work_run_dir / "job.json"
+    if job_src.exists():
+        dst = nas_unit_dir / "job.json"
+        shutil.copy2(str(job_src), str(dst))
+        out["job_json"] = str(dst)
+    result_src = work_run_dir / "result.json"
+    if result_src.exists():
+        dst = nas_unit_dir / "result.json"
+        shutil.copy2(str(result_src), str(dst))
+        out["result_json"] = str(dst)
+    if log_path.exists():
+        dst = nas_unit_dir / "unit.log"
+        shutil.copy2(str(log_path), str(dst))
+        out["log"] = str(dst)
+    return out
+
+
+def run_unit(args: argparse.Namespace) -> int:
+    """Process a single imaging unit end-to-end."""
+    pgid = _setup_pgid()
+
+    manifest_path = Path(args.manifest)
+    raid_dir = Path(args.raid_dir)
+    run_id = int(args.run_id)
+    dispatch_id = args.dispatch_id
+    transfer_method = args.transfer_method or "tar"
+    publish_policy = args.publish_policy or "fail_if_exists"
+    heartbeat_interval = float(args.heartbeat_interval or 30)
+    tokens_dir = Path(args.tokens_dir) if args.tokens_dir else None
+    max_concurrent_staging = int(args.max_concurrent_staging or 4)
+    cache_root = Path(args.cache_root) if args.cache_root else None
+    cache_min_free_bytes = (
+        int(args.cache_min_free_gb) * (1024 ** 3)
+        if args.cache_min_free_gb else None
+    )
+
+    manifest = json.loads(manifest_path.read_text())
+    unit_dict = manifest["unit"]
+    expected_inputs = manifest["expected_inputs"]  # [{"src": "...", "bucket": "ms"}, ...]
+    gous_uid = unit_dict["gous_uid"]
+    publish_dir = Path(manifest["publish_dir"])
+    nas_unit_dir = Path(manifest["nas_unit_dir"])
+    nproc = int(manifest.get("nproc", 4))
+    casa_path = manifest.get("casa_path")
+    deconvolver = manifest.get("deconvolver", "multiscale")
+    scales = manifest.get("scales", [0, 5, 10, 15, 20])
+
+    # Per-unit work dir on /raid/
+    work_dir = raid_dir / "work"
+    gous_input_dir = raid_dir / "input" / gous_uid
+    log_dir = raid_dir / "logs"
+    log_path = log_dir / f"unit_{run_id}.log"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # State + heartbeat live on NAS for coordinator visibility
+    state_path = nas_unit_dir / "state.json"
+    hb_path = nas_unit_dir / "heartbeat"
+
+    # File-log handler in addition to stdout
+    file_h = logging.FileHandler(log_path, mode="a")
+    file_h.setFormatter(logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    ))
+    logging.getLogger().addHandler(file_h)
+    logging.getLogger().setLevel(logging.INFO)
+
+    base_state = {
+        "run_id": run_id,
+        "dispatch_id": dispatch_id,
+        "machine": socket.gethostname(),
+        "hostname": socket.gethostname(),
+        "worker_pid": os.getpid(),
+        "worker_pgid": pgid,
+        "raid_dir": str(raid_dir),
+        "publish_dir": str(publish_dir),
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "phase": Phase.STARTING,
+    }
+    write_state_atomic(state_path, base_state)
+
+    hb = _Heartbeat(hb_path, heartbeat_interval)
+    hb.start()
+
+    # Lazy NAS staging token: acquired ONLY when stage_one needs to
+    # actually read from NAS (cache miss / fallback).  Cache hits skip
+    # the gate entirely.  Released in the outer ``finally``.
+    from panta_rei.imaging import staging as _staging
+    token_lease = _staging.TokenLease(
+        tokens_dir, max_concurrent_staging,
+        holder_id=f"{dispatch_id}/{run_id}",
+    )
+
+    try:
+        # ---------- STAGING ----------
+        base_state["phase"] = Phase.STAGING
+        write_state_atomic(state_path, base_state)
+
+        try:
+            stage_counts = _ensure_staged_inputs(
+                gous_input_dir, expected_inputs, transfer_method,
+                cache_root=cache_root,
+                cache_min_free_bytes=cache_min_free_bytes,
+                token_lease=token_lease,
+            )
+        finally:
+            token_lease.release()
+
+        base_state["staging_stats"] = {**stage_counts, **token_lease.stats}
+        if stage_counts.get("cache_hit", 0) or stage_counts.get("cache_hit_after_wait", 0):
+            log.info(
+                "staging summary: %s, token_acquires=%d, token_wait=%.1fs",
+                stage_counts, token_lease.stats["token_acquires"],
+                token_lease.stats["token_wait_sec"],
+            )
+
+        # ---------- PATCH PATHS + RUN ----------
+        _patch_unit_paths(unit_dict, gous_input_dir)
+        unit = _build_imaging_unit(unit_dict)
+
+        base_state["phase"] = Phase.RUNNING
+        write_state_atomic(state_path, base_state)
+
+        from panta_rei.imaging.runner import run_tclean_feather_parallel
+
+        success, msg, output_fits = run_tclean_feather_parallel(
+            unit=unit,
+            output_dir=publish_dir,
+            row_id=run_id,
+            nproc=nproc,
+            casa_path=casa_path,
+            deconvolver=deconvolver,
+            scales=scales,
+            keep_intermediates=manifest.get("keep_intermediates", False),
+            dry_run=False,
+            work_dir=work_dir,
+            publish_policy=publish_policy,
+            log_path=log_path,
+            extra_env={
+                "OMP_NUM_THREADS": "1",
+                "OPENBLAS_NUM_THREADS": "1",
+                "MKL_NUM_THREADS": "1",
+            },
+        )
+
+        # ---------- PUBLISHING is done inside run_tclean_feather_parallel ----------
+        base_state["phase"] = Phase.PUBLISHING
+        write_state_atomic(state_path, base_state)
+
+        # ---------- COPY PROVENANCE TO NAS ----------
+        provenance = _copy_provenance_to_nas(
+            work_run_dir=work_dir / "runs" / str(run_id),
+            log_path=log_path,
+            nas_unit_dir=nas_unit_dir,
+        )
+
+        # Resolved selections survive on the worker side because
+        # run_trusted_preflight mutates `unit` in-place inside the runner.
+        terminal: dict[str, Any] = {
+            "phase": Phase.DONE if success else Phase.FAILED,
+            "success": bool(success),
+            "message": msg,
+            "output_fits": output_fits,
+            "spw_selection": unit.spw_selection,
+            "field_selection": unit.field_selection,
+            "datacolumn": unit.datacolumn,
+            "provenance": provenance,
+            "finished_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        if not success:
+            terminal["error_message"] = msg
+
+        base_state.update(terminal)
+        write_state_atomic(state_path, base_state)
+        return 0 if success else 1
+
+    except Exception as exc:
+        # Any unexpected failure → mark FAILED + last-resort log
+        log.exception("worker crashed")
+        crash_tail = traceback.format_exc()[-2000:]
+        base_state.update({
+            "phase": Phase.FAILED,
+            "success": False,
+            "error_message": f"worker exception: {exc}: {crash_tail}",
+            "finished_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        })
+        try:
+            write_state_atomic(state_path, base_state)
+        except OSError:
+            pass
+        # Best-effort provenance copy
+        try:
+            _copy_provenance_to_nas(
+                work_run_dir=work_dir / "runs" / str(run_id),
+                log_path=log_path,
+                nas_unit_dir=nas_unit_dir,
+            )
+        except OSError:
+            pass
+        return 2
+
+    finally:
+        try:
+            token_lease.release()
+        except OSError:
+            pass
+        hb.stop()
+
+
+
+
+# ---------------------------------------------------------------------------
+# Argparse
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="panta_rei.imaging.remote_worker",
+        description="Detached worker for distributed tclean+feather imaging.",
+    )
+    sub = ap.add_subparsers(dest="mode")
+
+    # Default (run) mode — flat args, no subcommand keyword required
+    ap.add_argument("--manifest", help="Path to NAS unit manifest JSON")
+    ap.add_argument("--raid-dir", help="Per-dispatch /raid/ work root")
+    ap.add_argument("--run-id", type=int, help="imaging_runs row id")
+    ap.add_argument("--dispatch-id", help="Dispatch identifier")
+    ap.add_argument("--tokens-dir", default=None,
+                    help="NAS staging-token directory (None disables global cap)")
+    ap.add_argument("--max-concurrent-staging", type=int, default=4)
+    ap.add_argument("--cache-root", default=None,
+                    help="Per-host cross-dispatch staging cache root. "
+                         "If unset, the cache is disabled.")
+    ap.add_argument("--cache-min-free-gb", type=int, default=None,
+                    help="Evict cache entries oldest-first to keep at "
+                         "least this many GB free on /raid (default: "
+                         "no eviction).")
+    ap.add_argument("--transfer-method", default="tar", choices=["tar", "rsync", "cp"])
+    ap.add_argument("--publish-policy", default="fail_if_exists",
+                    choices=["fail_if_exists", "overwrite"])
+    ap.add_argument("--heartbeat-interval", type=float, default=30)
+
+    # Preflight subcommand
+    pf = sub.add_parser("preflight", help="Check raid + NAS + free space.")
+    pf.add_argument("--raid-dir", required=True)
+    pf.add_argument("--required-gb", type=float, default=0)
+    pf.add_argument("--nas-check-path", default=None)
+
+    # Convenience: top-level --preflight switch (for callers that prefer flags)
+    ap.add_argument("--preflight", action="store_true",
+                    help="Run in preflight mode (alternative to subcommand).")
+    ap.add_argument("--required-gb", type=float, default=0,
+                    help="(preflight) required free GB on raid.")
+    ap.add_argument("--nas-check-path", default=None,
+                    help="(preflight) NAS path to check for visibility.")
+
+    return ap
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    ap = _build_parser()
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.mode == "preflight" or args.preflight:
+        return preflight(args)
+
+    if not (args.manifest and args.raid_dir and args.run_id and args.dispatch_id):
+        ap.error("--manifest, --raid-dir, --run-id, --dispatch-id are required in run mode")
+
+    return run_unit(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/panta_rei/imaging/runner.py
+++ b/panta_rei/imaging/runner.py
@@ -21,6 +21,7 @@ import logging
 import os
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -856,8 +857,35 @@ def export_to_fits(casa_image: str, output_fits: str) -> None:
     exportfits(imagename=casa_image, fitsimage=output_fits, overwrite=True)
 
 
-def _atomic_publish(src: str, dst: str) -> None:
-    """Copy *src* to *dst* atomically via temp file + ``os.replace``."""
+def _tail_text(path: Path, max_lines: int = 200) -> str:
+    """Return the last *max_lines* lines of *path*, or a short error string."""
+    try:
+        with open(path, "rb") as fp:
+            try:
+                fp.seek(0, os.SEEK_END)
+                size = fp.tell()
+                # Read at most ~64KB from the tail; fine for line counting.
+                read_n = min(size, 64 * 1024)
+                fp.seek(size - read_n, os.SEEK_SET)
+                blob = fp.read(read_n)
+            except OSError:
+                blob = fp.read()
+        text = blob.decode("utf-8", errors="replace")
+        lines = text.splitlines()[-max_lines:]
+        return "\n".join(lines)
+    except OSError as exc:
+        return f"<could not read log {path}: {exc}>"
+
+
+def _publish(src: str, dst: str, *, policy: str = "overwrite") -> None:
+    """Copy *src* to *dst* atomically.
+
+    policy="overwrite": temp + os.replace (current behaviour).
+    policy="fail_if_exists": temp + os.link (atomic claim; raises
+    FileExistsError if dst already exists). Used by the distributed
+    dispatcher so concurrent retries cannot silently overwrite each
+    other's output.
+    """
     dst_path = Path(dst)
     dst_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -869,12 +897,122 @@ def _atomic_publish(src: str, dst: str) -> None:
     os.close(fd)
     try:
         shutil.copy2(src, tmp)
-        os.replace(tmp, dst)
+        if policy == "fail_if_exists":
+            os.link(tmp, str(dst_path))  # atomic; FileExistsError if exists
+            os.unlink(tmp)
+        elif policy == "overwrite":
+            os.replace(tmp, str(dst_path))
+        else:
+            raise ValueError(f"unknown publish policy: {policy!r}")
         log.info("Published: %s", dst_path.name)
     except Exception:
         if os.path.exists(tmp):
-            os.unlink(tmp)
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
         raise
+
+
+def _atomic_publish(src: str, dst: str) -> None:
+    """Backward-compatible alias for ``_publish(..., policy="overwrite")``."""
+    _publish(src, dst, policy="overwrite")
+
+
+def _publish_pair(
+    pairs: list[tuple[str, str]], *, policy: str = "overwrite",
+) -> tuple[bool, str]:
+    """Publish a list of (src, dst) pairs as one logical transaction.
+
+    Each individual publish is atomic via ``_publish``.  If any one
+    fails after others succeeded, the already-published destinations
+    are rolled back so retries see a coherent canonical area.
+
+    Rollback semantics:
+    - ``policy="fail_if_exists"``: a successful publish proves the
+      destination did not previously exist, so rollback simply
+      unlinks the file we created.
+    - ``policy="overwrite"``: the destination may have held a
+      prior canonical FITS that we just replaced.  Before the publish
+      we rename the existing destination aside (``<dst>.bak.<pid>``);
+      on rollback we ``os.replace`` the backup back into place.  On
+      successful commit of the whole pair we unlink the backups.
+
+    Returns ``(ok, message)``.
+    """
+    backups: list[tuple[str, str]] = []          # (canonical, backup)
+    published: list[str] = []                    # canonical paths written
+
+    if policy == "overwrite":
+        # Snapshot pre-existing destinations *before* any publish so a
+        # mid-pair failure can restore the prior canonical state.
+        for _src, dst in pairs:
+            dst_path = Path(dst)
+            if dst_path.exists():
+                bak = (
+                    f"{dst_path}.bak.{os.getpid()}.{int(time.time())}"
+                )
+                try:
+                    os.rename(str(dst_path), bak)
+                    backups.append((str(dst_path), bak))
+                except OSError as exc:
+                    # Couldn't snapshot — undo any backups we did take
+                    # and refuse to continue.
+                    for canonical, b in backups:
+                        try:
+                            os.replace(b, canonical)
+                        except OSError:
+                            log.exception(
+                                "backup restore failed: %s -> %s",
+                                b, canonical,
+                            )
+                    return False, (
+                        f"could not snapshot existing {dst}: {exc}"
+                    )
+
+    for src, dst in pairs:
+        try:
+            _publish(src, dst, policy=policy)
+            published.append(dst)
+        except Exception as exc:
+            # Roll back what we just published.
+            for done_dst in published:
+                try:
+                    os.unlink(done_dst)
+                    log.warning("rolled back publish: %s", done_dst)
+                except OSError:
+                    log.exception(
+                        "rollback failed for %s; manual cleanup may be needed",
+                        done_dst,
+                    )
+            # Restore pre-existing destinations from their backups.
+            for canonical, bak in backups:
+                try:
+                    if Path(bak).exists():
+                        os.replace(bak, canonical)
+                        log.warning(
+                            "restored pre-existing publish target: %s",
+                            canonical,
+                        )
+                except OSError:
+                    log.exception(
+                        "could not restore backup %s -> %s; manual "
+                        "intervention may be needed",
+                        bak, canonical,
+                    )
+            return False, (
+                f"publish failed for {dst} (rolled back "
+                f"{len(published)} new file(s), restored "
+                f"{len(backups)} backup(s)): {exc}"
+            )
+
+    # Whole pair succeeded — drop backups.
+    for _canonical, bak in backups:
+        try:
+            os.unlink(bak)
+        except OSError:
+            log.warning("could not unlink backup: %s", bak)
+    return True, "ok"
 
 
 def run_tclean_feather(
@@ -886,18 +1024,33 @@ def run_tclean_feather(
     parallel: bool = False,
     keep_intermediates: bool = False,
     dry_run: bool = False,
+    *,
+    work_dir: Optional[Path] = None,
+    publish_policy: str = "overwrite",
+    aux_products: tuple[str, ...] = ("mask", "residual", "pb"),
 ) -> tuple[bool, str, Optional[str]]:
     """Execute tclean (12m+7m) followed by feather (with TP).
 
-    All CASA products are written under a per-run work directory
-    ``output_dir/runs/{row_id}/``.  Final FITS are atomically published
-    to canonical output paths on success.
+    Parameters
+    ----------
+    output_dir
+        Publish directory: canonical FITS paths derive from this.
+    work_dir
+        Optional CASA scratch + intermediates directory.  Defaults to
+        ``output_dir`` (existing behaviour).  The distributed dispatcher
+        sets this to a fast local /raid/ path while keeping
+        ``output_dir`` on NAS so canonical FITS publish to NAS.
+    publish_policy
+        ``"overwrite"`` (default, existing behaviour) or
+        ``"fail_if_exists"`` (atomic claim via ``os.link``; the
+        dispatcher uses this to make parallel retries safe).
 
     Returns ``(success, message, canonical_12m7mTP_fits_path)``.
     """
     from panta_rei.imaging.matching import (
         build_output_path,
         build_tclean_only_output_path,
+        build_aux_output_path,
         _compute_tm_freq_range,
     )
 
@@ -928,13 +1081,23 @@ def run_tclean_feather(
     canonical_tclean = build_tclean_only_output_path(
         output_dir, unit.gous_uid, unit.source_name, freq_min, freq_max,
     )
+    canonical_aux: dict[str, str] = {
+        kind: str(build_aux_output_path(
+            output_dir, unit.gous_uid, unit.source_name,
+            freq_min, freq_max, kind,
+        ))
+        for kind in aux_products
+    }
 
     if dry_run:
         log.info("[DRY] Would run tclean+feather → %s", canonical_feathered.name)
         return True, "dry-run", str(canonical_feathered)
 
-    # 4. Set up per-run work directory
-    run_dir = output_dir / "runs" / str(row_id)
+    # 4. Set up per-run work directory.  ``work_dir`` lets the dispatcher
+    #    point CASA scratch at fast local storage (/raid/) while
+    #    publishing canonical FITS to NAS via ``output_dir``.
+    work_root = Path(work_dir) if work_dir is not None else output_dir
+    run_dir = work_root / "runs" / str(row_id)
     run_dir.mkdir(parents=True, exist_ok=True)
 
     # imagename prefix for tclean products (under run_dir).
@@ -976,7 +1139,9 @@ def run_tclean_feather(
         "canonical_paths": {
             "feathered": str(canonical_feathered),
             "tclean_only": str(canonical_tclean),
+            "aux": canonical_aux,
         },
+        "aux_products": list(aux_products),
         "run_dir": str(run_dir),
         "casa_version": get_casa_version(),
     }
@@ -1020,9 +1185,41 @@ def run_tclean_feather(
     local_feathered_fits = str(run_dir / canonical_feathered.name)
     export_to_fits(feathered_image, local_feathered_fits)
 
-    # 12. Atomic publish to canonical paths (only on success)
-    _atomic_publish(local_tclean_fits, str(canonical_tclean))
-    _atomic_publish(local_feathered_fits, str(canonical_feathered))
+    # 11b. Best-effort export of aux QA products (mask/residual/pb) to
+    # FITS.  Each is sourced from <imagename>.<kind> in the run_dir.  A
+    # failure here is logged but does NOT fail the imaging run; the aux
+    # is simply omitted from the publish transaction.
+    aux_local: dict[str, str] = {}
+    for kind in aux_products:
+        casa_image = f"{imagename}.{kind}"
+        if not Path(casa_image).exists():
+            log.warning("aux %s: CASA image not found at %s — skipping",
+                        kind, Path(casa_image).name)
+            continue
+        canonical = canonical_aux.get(kind)
+        if not canonical:
+            continue
+        local_path = str(run_dir / Path(canonical).name)
+        try:
+            export_to_fits(casa_image, local_path)
+            aux_local[kind] = local_path
+        except Exception as exc:
+            log.warning("aux %s export failed: %s", kind, exc)
+
+    # 12. Atomic publish to canonical paths (only on success).  Treat the
+    # tclean + feathered + aux outputs as a single transaction: if any
+    # publish fails after others succeeded, the already-published files
+    # are rolled back so retries see a coherent canonical area.
+    pair: list[tuple[str, str]] = [
+        (local_tclean_fits, str(canonical_tclean)),
+        (local_feathered_fits, str(canonical_feathered)),
+    ]
+    for kind, local_path in aux_local.items():
+        pair.append((local_path, canonical_aux[kind]))
+
+    ok, msg = _publish_pair(pair, policy=publish_policy)
+    if not ok:
+        return False, msg, None
 
     log.info("SUCCESS: %s", canonical_feathered.name)
     return True, "success", str(canonical_feathered)
@@ -1042,12 +1239,40 @@ def run_tclean_feather_parallel(
     scales: Optional[list[int]] = None,
     keep_intermediates: bool = False,
     dry_run: bool = False,
+    *,
+    work_dir: Optional[Path] = None,
+    publish_policy: str = "overwrite",
+    log_path: Optional[Path] = None,
+    extra_env: Optional[dict] = None,
+    aux_products: tuple[str, ...] = ("mask", "residual", "pb"),
 ) -> tuple[bool, str, Optional[str]]:
     """Execute tclean+feather via mpicasa subprocess for MPI parallelism.
 
     The pipeline handles preflight and DB tracking.  The actual CASA
     execution is delegated to a standalone script
     (``panta_rei/casa/tclean_feather.py``) launched via mpicasa.
+
+    Parameters
+    ----------
+    output_dir
+        Publish directory: canonical FITS paths derive from this.
+    work_dir
+        Optional CASA scratch + intermediates directory.  Defaults to
+        ``output_dir`` (existing behaviour).  The distributed dispatcher
+        sets this to a fast local /raid/ path while keeping
+        ``output_dir`` on NAS so canonical FITS publish to NAS.
+    publish_policy
+        ``"overwrite"`` (default, existing behaviour) or
+        ``"fail_if_exists"`` (atomic claim via ``os.link``).
+    log_path
+        Optional path to redirect mpicasa stdout+stderr to.  Defaults to
+        an in-memory capture (current behaviour) which is unsafe for
+        long-running jobs at scale.  Distributed workers set this to a
+        per-unit log file under /raid/ to avoid pipe-deadlock risk.
+    extra_env
+        Optional dict of env vars merged on top of ``os.environ`` for the
+        mpicasa subprocess.  Used to inject thread-pinning knobs
+        (``OMP_NUM_THREADS=1`` etc.) when running 30 concurrent jobs.
 
     Returns ``(success, message, canonical_12m7mTP_fits_path)``.
     """
@@ -1056,6 +1281,7 @@ def run_tclean_feather_parallel(
     from panta_rei.imaging.matching import (
         build_output_path,
         build_tclean_only_output_path,
+        build_aux_output_path,
         _compute_tm_freq_range,
     )
 
@@ -1099,13 +1325,22 @@ def run_tclean_feather_parallel(
     canonical_tclean = build_tclean_only_output_path(
         output_dir, unit.gous_uid, unit.source_name, freq_min, freq_max,
     )
+    canonical_aux: dict[str, str] = {
+        kind: str(build_aux_output_path(
+            output_dir, unit.gous_uid, unit.source_name,
+            freq_min, freq_max, kind,
+        ))
+        for kind in aux_products
+    }
 
     if dry_run:
         log.info("[DRY] Would run parallel tclean+feather → %s", canonical_feathered.name)
         return True, "dry-run", str(canonical_feathered)
 
-    # 4. Per-run work directory
-    run_dir = output_dir / "runs" / str(row_id)
+    # 4. Per-run work directory.  ``work_dir`` lets the dispatcher keep
+    #    CASA scratch on /raid/ while publishing to NAS via output_dir.
+    work_root = Path(work_dir) if work_dir is not None else output_dir
+    run_dir = work_root / "runs" / str(row_id)
     run_dir.mkdir(parents=True, exist_ok=True)
 
     imagename = str(run_dir / canonical_tclean.stem.replace(".pbcor", ""))
@@ -1143,7 +1378,9 @@ def run_tclean_feather_parallel(
         "canonical_paths": {
             "feathered": str(canonical_feathered),
             "tclean_only": str(canonical_tclean),
+            "aux": canonical_aux,
         },
+        "aux_products": list(aux_products),
         "run_dir": str(run_dir),
         "casa_version": "unknown",  # determined inside CASA
     }
@@ -1165,11 +1402,39 @@ def run_tclean_feather_parallel(
     ]
     log.info("Launching: %s", " ".join(cmd))
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Build env with thread-pinning defaults; caller can override via extra_env.
+    merged_env = os.environ.copy()
+    merged_env.setdefault("OMP_NUM_THREADS", "1")
+    merged_env.setdefault("OPENBLAS_NUM_THREADS", "1")
+    merged_env.setdefault("MKL_NUM_THREADS", "1")
+    if extra_env:
+        merged_env.update({k: str(v) for k, v in extra_env.items()})
+
+    # Stream stdout+stderr directly to log_path (no Pipes → no deadlock).
+    # When log_path is unset we keep the legacy in-memory capture for
+    # backward compat but warn — long jobs at scale should pass log_path.
+    if log_path is not None:
+        log_path = Path(log_path)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "ab") as logfp:
+            result = subprocess.run(
+                cmd,
+                stdout=logfp,
+                stderr=subprocess.STDOUT,
+                cwd=str(run_dir),
+                env=merged_env,
+            )
+        tail_str = _tail_text(log_path, max_lines=200)
+    else:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True,
+            cwd=str(run_dir), env=merged_env,
+        )
+        tail_str = (result.stderr or "")[-2000:]
 
     if result.returncode != 0:
-        log.error("mpicasa stderr:\n%s", result.stderr[-2000:] if result.stderr else "")
-        return False, f"mpicasa exited with code {result.returncode}", None
+        log.error("mpicasa output tail:\n%s", tail_str[-2000:])
+        return False, f"mpicasa exited with code {result.returncode}: {tail_str[-500:]}", None
 
     # 9. Parse result JSON
     result_json_path = run_dir / "result.json"
@@ -1181,17 +1446,34 @@ def run_tclean_feather_parallel(
     if not casa_result.get("success"):
         return False, casa_result.get("error_message", "unknown error"), None
 
-    # 10. Atomic publish
+    # 10. Atomic publish — transactional across the (tclean, feathered,
+    # aux...) tuple so a failed unit cannot leave a half-published
+    # canonical area that would poison retries under fail_if_exists.
     local_feathered = casa_result.get("feathered_fits")
     local_tclean = casa_result.get("tclean_fits")
 
-    if local_feathered and Path(local_feathered).exists():
-        _atomic_publish(local_feathered, str(canonical_feathered))
-    else:
+    if not (local_feathered and Path(local_feathered).exists()):
         return False, "Feathered FITS not produced by CASA script", None
 
+    pair = [(local_feathered, str(canonical_feathered))]
     if local_tclean and Path(local_tclean).exists():
-        _atomic_publish(local_tclean, str(canonical_tclean))
+        pair.append((local_tclean, str(canonical_tclean)))
+    # Aux products are best-effort: include only those the CASA script
+    # successfully exported, but include them in the same transaction so
+    # rollback semantics stay coherent.
+    for kind, local_aux in (casa_result.get("aux_fits") or {}).items():
+        if not local_aux or not Path(local_aux).exists():
+            log.warning("aux %s: missing local FITS, skipping publish", kind)
+            continue
+        canonical = canonical_aux.get(kind)
+        if not canonical:
+            log.warning("aux %s: no canonical path resolved, skipping", kind)
+            continue
+        pair.append((local_aux, canonical))
+
+    ok, msg = _publish_pair(pair, policy=publish_policy)
+    if not ok:
+        return False, msg, None
 
     log.info("SUCCESS (parallel): %s", canonical_feathered.name)
     return True, "success", str(canonical_feathered)

--- a/panta_rei/imaging/staging.py
+++ b/panta_rei/imaging/staging.py
@@ -1,0 +1,1130 @@
+"""Distributed-imaging staging primitives.
+
+Pure helpers — no DB, no SSH, no logging side-effects beyond ``log``.
+Used by :mod:`panta_rei.imaging.remote_worker` (workers) and
+:mod:`panta_rei.imaging.dispatch` (coordinator's stale-token reaper).
+
+Key primitives:
+
+- ``stage_one(src, dst_root, *, method, bucket)`` — copy a single MS or TP
+  product from NAS to /raid/ via tar/rsync/cp into a ``.partial`` temp dir,
+  then ``os.rename`` to its final location.  The temp+rename pattern keeps
+  the destination from ever being half-populated.
+- ``acquire_staging_token`` / ``release_staging_token`` — NAS-based
+  global concurrency limit, atomic via ``os.mkdir``.  Detached workers
+  cannot rely on the coordinator to gate them, so we use the filesystem.
+- ``acquire_stage_lock`` / ``release_stage_lock`` — per-(machine, GOUS)
+  staging mutex, also via atomic ``os.mkdir`` rather than NFS flock
+  (which is historically flaky).
+- ``read_manifest`` / ``write_manifest`` — atomic JSON read/write for the
+  ``.staging.manifest`` file that records which inputs of the GOUS union
+  have been staged so far.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import random
+import shutil
+import socket
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers
+# ---------------------------------------------------------------------------
+
+def atomic_write_json(path: Path, payload: dict) -> None:
+    """Write *payload* as JSON to *path* via temp file + ``os.replace``."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}.{random.randint(0, 1<<30)}")
+    tmp.write_text(json.dumps(payload, indent=2, default=str))
+    os.replace(str(tmp), str(path))
+
+
+def read_manifest(path: Path) -> dict:
+    """Return the staging manifest dict, or a fresh skeleton if missing."""
+    if not Path(path).exists():
+        return {"version": 1, "expected": [], "completed": []}
+    return json.loads(Path(path).read_text())
+
+
+# ---------------------------------------------------------------------------
+# Atomic mkdir-based mutex (used for staging lock and tokens)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _MkdirLock:
+    """A simple lock implemented via atomic directory creation.
+
+    NFS guarantees ``mkdir`` atomicity at the server side, which is the
+    primitive we rely on.  If a previous holder crashed, the lock dir
+    persists indefinitely — so on every contended attempt we read the
+    holder's metadata and self-heal: if the holder is on the same host
+    and its PID is dead, we ``rmtree`` and retry.  This bounds recovery
+    to a single host's /proc check (no SSH from the worker).
+
+    For cross-host stale lock recovery (a holder on a different host
+    that died), the coordinator's stale-holder reaper handles it.
+
+    There is a small live-lock race between ``mkdir`` and the
+    ``holder.json`` write: a contender that observes the directory
+    after mkdir but before the metadata is in place would otherwise
+    declare the live lock stale.  We address this by writing
+    ``holder.json`` atomically (temp + rename) and by giving any
+    metadata-missing observation a short grace window before reclaiming.
+    """
+    dir_path: Path
+    holder_meta: dict = field(default_factory=dict)
+    acquired: bool = False
+    # Grace window for a freshly-mkdir'd lock to publish its metadata.
+    missing_metadata_grace_sec: float = 3.0
+
+    def __enter__(self) -> "_MkdirLock":
+        while True:
+            try:
+                self.dir_path.mkdir(parents=True, exist_ok=False)
+                self.acquired = True
+                meta = {
+                    "host": socket.gethostname(),
+                    "pid": os.getpid(),
+                    **self.holder_meta,
+                }
+                # Atomic publish of holder metadata so contenders never
+                # see a half-written file.
+                tmp = self.dir_path / ".holder.json.tmp"
+                tmp.write_text(json.dumps(meta))
+                os.replace(str(tmp), str(self.dir_path / "holder.json"))
+                return self
+            except FileExistsError:
+                if not _holder_alive_locally(
+                    self.dir_path,
+                    missing_metadata_grace_sec=self.missing_metadata_grace_sec,
+                ):
+                    # Stale lock from a crashed holder — recover.
+                    log.warning(
+                        "stale stage lock detected at %s; reclaiming",
+                        self.dir_path,
+                    )
+                    shutil.rmtree(self.dir_path, ignore_errors=True)
+                    continue
+                time.sleep(random.uniform(0.5, 1.5))
+
+    def __exit__(self, *exc_info) -> None:
+        if self.acquired:
+            shutil.rmtree(self.dir_path, ignore_errors=True)
+
+
+def _holder_alive_locally(
+    lock_dir: Path,
+    missing_metadata_grace_sec: float = 3.0,
+) -> bool:
+    """Return True iff the lock's holder is on this host AND alive.
+
+    Cross-host holders are reported as alive (no local check is
+    possible) — the coordinator's reaper handles those.
+
+    Missing ``holder.json`` could mean either (a) a crashed holder
+    that never wrote metadata, or (b) a freshly-mkdir'd lock whose
+    holder is in the brief window between ``mkdir()`` and the
+    holder.json write.  To avoid stealing live locks, we wait up to
+    ``missing_metadata_grace_sec`` for the file to appear before
+    declaring stale.
+
+    Same-host holder: PID-only liveness via ``os.kill(pid, 0)``.  We
+    deliberately do NOT validate the cmdline here because (a) the
+    ``/proc/<pid>/cmdline`` of an unrelated PID-reuse victim is
+    indistinguishable from a legitimate other Python process, and (b)
+    the cross-host coordinator reaper handles cmdline-based PID reuse
+    detection more carefully.
+    """
+    holder_file = Path(lock_dir) / "holder.json"
+    if not holder_file.exists():
+        # Race: holder may be mid-write.  Give it a grace window before
+        # declaring stale.  Polling is short (50ms) to keep contention
+        # latency low on legitimate stale-lock recovery paths.
+        deadline = time.monotonic() + max(0.0, missing_metadata_grace_sec)
+        while time.monotonic() < deadline:
+            time.sleep(0.05)
+            if holder_file.exists():
+                break
+        if not holder_file.exists():
+            return False
+    try:
+        meta = json.loads(holder_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    host = meta.get("host")
+    pid = int(meta.get("pid", 0))
+    if not pid:
+        return False
+    if host and host != socket.gethostname():
+        # Different host — caller must rely on the coordinator reaper.
+        return True
+
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another user — treat as alive.
+        return True
+    except OSError:
+        return True  # ambiguous — assume alive
+
+
+def acquire_stage_lock(gous_dir: Path, holder_meta: dict | None = None) -> _MkdirLock:
+    """Per-(machine, GOUS) mutex via ``mkdir`` on ``<gous_dir>/.stage.lock.d``.
+
+    Callers should use this as a context manager:
+
+    >>> with acquire_stage_lock(gous_dir, {"run_id": 42}):
+    ...     ensure_staged(...)
+    """
+    lock_dir = Path(gous_dir) / ".stage.lock.d"
+    lock_dir.parent.mkdir(parents=True, exist_ok=True)
+    return _MkdirLock(dir_path=lock_dir, holder_meta=holder_meta or {})
+
+
+# ---------------------------------------------------------------------------
+# NAS staging tokens (global concurrency cap)
+# ---------------------------------------------------------------------------
+
+def acquire_staging_token(
+    tokens_root: Path,
+    n_slots: int,
+    *,
+    holder_id: str,
+    poll_sleep: tuple[float, float] = (1.0, 3.0),
+    timeout_sec: Optional[float] = None,
+) -> int:
+    """Acquire one of *n_slots* tokens under *tokens_root*.
+
+    Atomic primitive: ``os.mkdir(tokens_root/<i>)``.  Returns the index
+    of the slot acquired.  On crash, the token directory persists; the
+    coordinator's reaper :func:`reap_stale_tokens` drops it after
+    confirming the holder PID is dead.
+    """
+    tokens_root = Path(tokens_root)
+    tokens_root.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    while True:
+        for i in range(n_slots):
+            slot = tokens_root / str(i)
+            try:
+                slot.mkdir()
+            except FileExistsError:
+                continue
+            try:
+                (slot / "host").write_text(socket.gethostname())
+                (slot / "pid").write_text(str(os.getpid()))
+                (slot / "holder").write_text(holder_id)
+                (slot / "acquired_at").write_text(str(time.time()))
+            except OSError as exc:
+                # Couldn't write metadata — give up the slot
+                shutil.rmtree(slot, ignore_errors=True)
+                raise RuntimeError(f"failed to write token metadata: {exc}")
+            return i
+        if timeout_sec is not None and time.monotonic() - started > timeout_sec:
+            raise TimeoutError(
+                f"could not acquire staging token under {tokens_root} "
+                f"in {timeout_sec}s"
+            )
+        time.sleep(random.uniform(*poll_sleep))
+
+
+def release_staging_token(tokens_root: Path, i: int) -> None:
+    """Release the token at slot *i*.  Idempotent."""
+    shutil.rmtree(Path(tokens_root) / str(i), ignore_errors=True)
+
+
+def list_held_tokens(tokens_root: Path) -> list[dict]:
+    """Return metadata for every held token under *tokens_root*."""
+    tokens_root = Path(tokens_root)
+    if not tokens_root.exists():
+        return []
+    out: list[dict] = []
+    for slot in sorted(tokens_root.iterdir()):
+        if not slot.is_dir():
+            continue
+        try:
+            host = (slot / "host").read_text().strip()
+            pid = int((slot / "pid").read_text().strip())
+            holder = (slot / "holder").read_text().strip() if (slot / "holder").exists() else ""
+            out.append({
+                "slot": slot.name, "path": slot, "host": host, "pid": pid,
+                "holder": holder,
+            })
+        except (OSError, ValueError):
+            # Partially-populated slot — treat as suspect
+            out.append({"slot": slot.name, "path": slot, "host": None, "pid": None,
+                        "holder": ""})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cross-dispatch staging cache
+# ---------------------------------------------------------------------------
+#
+# Layout (per host)::
+#
+#     <machine.raid>/
+#     ├── cache/
+#     │   ├── <basename>.<sha1[:16]>/         ← the cache *entry* dir
+#     │   │   ├── <basename>/                 ← staged MS or TP
+#     │   │   ├── .cache.json                 ← sidecar (commit marker)
+#     │   │   └── .populating/                ← present iff a worker is filling
+#     │   ├── ...
+#     │   └── .gc.lock.d/                     ← GC lock (per-host eviction mutex)
+#     └── d_<dispatch_id>/
+#         └── input/<gous>/ms/<basename>/     ← cp -al hard-links into cache entry
+#
+# Hit semantics: ``stat(src_path)`` on NAS, then sidecar match on
+# ``(mtime_ns, recursive_size_bytes)``.  ``du -sb`` is required because
+# CASA tables are directories — ``stat(dir).st_size`` is not recursive,
+# and the root-dir mtime doesn't always propagate to nested edits.
+#
+# The cache key is ``<basename>.<sha1(src_path)[:16]>`` so that two MSs
+# with identical basenames but different source roots cannot collide.
+#
+# Files inside a cached entry are chmod'd to 0o444 after population so
+# that any unexpected CASA write through a hard-linked inode fails loudly
+# rather than silently corrupting the cache.  Directories stay 0o755 so
+# CASA can still drop lock-files alongside.
+
+_CACHE_KEY_HASH_LEN = 16
+
+
+def _cache_key(src_path: str | Path) -> str:
+    """Stable cache-entry key: ``<basename>.<sha1(src_path)[:16]>``."""
+    p = Path(src_path)
+    digest = hashlib.sha1(str(p.resolve(strict=False)).encode("utf-8")).hexdigest()
+    return f"{p.name}.{digest[:_CACHE_KEY_HASH_LEN]}"
+
+
+_FINGERPRINT_VERSION = 2
+
+
+def _compute_tree_sig(src_path: Path) -> str:
+    """Recursive metadata-only signature of *src_path*.
+
+    Walks the tree (no follow_symlinks), collects every entry, and
+    hashes a sorted record of ``(relpath, kind, size, mtime_ns,
+    ctime_ns, symlink_target)`` per entry.  Catches inner-file
+    rewrites and nested temp+rename patterns that the root mtime +
+    recursive size pair cannot see (proven by
+    ``scripts/test_cache_invalidation.py`` — A/B/C scenarios).
+
+    Cost: one stat per entry, one ``readlink`` per symlink.  Pure
+    metadata; never reads file contents.  For a CASA MS with ~50–200
+    inner files the walk is well under a second.
+
+    For a single-file root (TP FITS), the signature reduces to the
+    file's own ``(size, mtime_ns, ctime_ns)``.
+
+    Symlink-root handling: if *src_path* IS itself a symlink, we
+    resolve it before walking.  Staging dereferences the link
+    (``cp -a``, ``tar -C <parent> <name>/`` and ``rsync -a`` all
+    follow leaf symlinks), so the cached data reflects the target's
+    content.  Fingerprinting the link itself would let the target
+    change underneath us with no fingerprint change.  ``cache_key``
+    hashes the resolved path, so two symlinks at *the same basename*
+    pointing at the same target collide on one cache entry; symlinks
+    with different basenames do not (their cache_key prefix differs)
+    — that's not a correctness issue, just less aggressive dedup.
+    """
+    h = hashlib.sha256()
+    src_path = Path(src_path)
+    if src_path.is_symlink():
+        src_path = src_path.resolve(strict=False)
+
+    if not src_path.is_dir():
+        st = src_path.lstat()
+        rec = (f"|f|{st.st_size}|{st.st_mtime_ns}|"
+               f"{st.st_ctime_ns}|\n")
+        h.update(rec.encode("utf-8"))
+        return h.hexdigest()
+
+    # Directory root — gather every descendant entry, sort, hash.
+    # Skip the root itself: its mtime_ns is already in the v2
+    # fingerprint as a separate field, and including it here would
+    # double-count.
+    entries: list[tuple[str, str]] = []
+    for dirpath, dirnames, filenames in os.walk(
+        src_path, followlinks=False,
+    ):
+        for name in dirnames + filenames:
+            full = os.path.join(dirpath, name)
+            rel = os.path.relpath(full, str(src_path))
+            entries.append((rel, full))
+    entries.sort()
+
+    for rel, full in entries:
+        try:
+            st = os.lstat(full)
+        except OSError:
+            # Entry vanished between os.walk and our lstat — record an
+            # explicit deletion so any concurrent regen still produces
+            # a different signature.
+            h.update(f"{rel}|MISSING\n".encode("utf-8"))
+            continue
+        if os.path.islink(full):
+            try:
+                target = os.readlink(full)
+            except OSError:
+                target = ""
+            kind = "l"
+        elif os.path.isdir(full):
+            target = ""
+            kind = "d"
+        else:
+            target = ""
+            kind = "f"
+        rec = (f"{rel}|{kind}|{st.st_size}|{st.st_mtime_ns}|"
+               f"{st.st_ctime_ns}|{target}\n")
+        h.update(rec.encode("utf-8"))
+    return h.hexdigest()
+
+
+def _compute_fingerprint(src_path: Path) -> dict:
+    """Return ``{'version': 2, 'mtime_ns', 'size_bytes', 'tree_sig'}``.
+
+    - ``mtime_ns`` is the root's ``st_mtime_ns`` (cheap pre-screen).
+    - ``size_bytes`` is recursive ``du -sb`` for directories (used for
+      eviction sizing), or ``stat().st_size`` for files.
+    - ``tree_sig`` is a recursive metadata-only hash that catches the
+      inner-file rewrite + nested temp+rename patterns the v1
+      ``(mtime_ns, size_bytes)`` pair could not detect.
+
+    If *src_path* is itself a symlink, it's resolved first — staging
+    dereferences leaf symlinks (``cp -a``, ``tar -C parent name/``,
+    ``rsync -a`` all follow), so the fingerprint must track the
+    target.  Without this, a swap of the link's target would leave
+    fingerprint unchanged and serve stale cache.
+
+    Raises ``OSError`` if ``du -sb`` fails on a directory — a zero size
+    would silently commit a wrong fingerprint.
+    """
+    src_path = Path(src_path)
+    if src_path.is_symlink():
+        src_path = src_path.resolve(strict=False)
+    st = src_path.stat()
+    if src_path.is_dir():
+        size_bytes = _du_bytes(src_path)
+        if size_bytes <= 0:
+            raise OSError(
+                f"_du_bytes returned {size_bytes} for {src_path} — "
+                f"refusing to commit cache fingerprint with a bad size",
+            )
+    else:
+        size_bytes = int(st.st_size)
+    return {
+        "version": _FINGERPRINT_VERSION,
+        "mtime_ns": int(st.st_mtime_ns),
+        "size_bytes": int(size_bytes),
+        "tree_sig": _compute_tree_sig(src_path),
+    }
+
+
+def _read_sidecar(entry_dir: Path) -> Optional[dict]:
+    side = Path(entry_dir) / ".cache.json"
+    if not side.exists():
+        return None
+    try:
+        return json.loads(side.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_sidecar_atomic(entry_dir: Path, src_path: Path, fingerprint: dict) -> None:
+    """Write ``.cache.json`` LAST (it's the entry's commit marker)."""
+    payload = {
+        "src_path": str(Path(src_path).resolve(strict=False)),
+        "version": int(fingerprint.get("version", _FINGERPRINT_VERSION)),
+        "mtime_ns": int(fingerprint["mtime_ns"]),
+        "size_bytes": int(fingerprint["size_bytes"]),
+        "tree_sig": fingerprint["tree_sig"],
+        "staged_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    atomic_write_json(Path(entry_dir) / ".cache.json", payload)
+
+
+def cache_lookup(
+    cache_root: Path,
+    src_path: str | Path,
+    *,
+    ignore_populating: bool = False,
+) -> Optional[Path]:
+    """Return the staged subdir if the cache has a valid entry.
+
+    Returns ``cache_root/<key>/<basename>`` on hit, ``None`` on miss.
+    A miss covers: missing entry, missing sidecar, mtime mismatch, size
+    mismatch, or (when ``ignore_populating=False``) an entry mid-populate
+    (``.populating`` present).
+
+    ``ignore_populating=True`` is for the *populator* to peek inside its
+    own ``.populating`` lock and discover that a peer's commit landed
+    just before our ``mkdir(.populating)`` won — in which case we should
+    release our lock and return a hit rather than clobbering the entry.
+    External callers never set this.
+    """
+    cache_root = Path(cache_root)
+    src_path = Path(src_path)
+    if not src_path.exists():
+        return None
+    entry_dir = cache_root / _cache_key(src_path)
+    if not entry_dir.is_dir():
+        return None
+    if not ignore_populating and (entry_dir / ".populating").exists():
+        return None
+    side = _read_sidecar(entry_dir)
+    if side is None:
+        return None
+    # v1 sidecars (no version, or version != current) are treated as
+    # stale — the v1 fingerprint (mtime_ns + size_bytes) couldn't
+    # detect inner-file rewrites or nested temp+rename, so we refuse
+    # to trust those entries even if mtime + size happen to match.
+    # See ``_compute_tree_sig`` for the v2 motivation.
+    if int(side.get("version", 1)) != _FINGERPRINT_VERSION:
+        return None
+    if not side.get("tree_sig"):
+        return None
+    try:
+        fp = _compute_fingerprint(src_path)
+    except OSError:
+        return None
+    if (int(side.get("mtime_ns", -1)) != fp["mtime_ns"]
+            or int(side.get("size_bytes", -1)) != fp["size_bytes"]
+            or side.get("tree_sig") != fp["tree_sig"]):
+        return None
+    staged = entry_dir / src_path.name
+    if not staged.exists():
+        return None
+    return staged
+
+
+def _chmod_readonly_files(root: Path) -> None:
+    """Set files under *root* to 0o444 and dirs to 0o755.
+
+    Handles both file and directory roots: TP cubes are single FITS
+    files, MSs are CASA-table directory trees.  Read-only files act as
+    a canary against unexpected CASA writes through the hard-linked
+    inode.  Directories stay writable so CASA can create lock-files
+    inside.
+
+    Raises ``OSError`` on any chmod failure — without read-only files,
+    the canary is gone and an unexpected CASA write through the
+    hard-link would silently corrupt the cache.  Better to refuse to
+    commit the cache entry than ship a writable cache.
+
+    Symlinks are skipped: ``os.chmod`` on a symlink follows the link
+    and would alter the *target* — if a CASA table happens to contain
+    a symlink to outside the entry, we must not modify the target.
+    """
+    root = Path(root)
+    if root.is_file() and not root.is_symlink():
+        os.chmod(root, 0o444)
+        return
+    if root.is_symlink():
+        return
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        os.chmod(dirpath, 0o755)
+        for f in filenames:
+            full = os.path.join(dirpath, f)
+            if os.path.islink(full):
+                # Don't follow link — would chmod the target.
+                continue
+            os.chmod(full, 0o444)
+
+
+def cache_link_into(cache_staged: Path, dst_path: Path) -> None:
+    """Hard-link *cache_staged* into *dst_path*.
+
+    Handles both directory sources (CASA tables) and file sources (TP
+    FITS).  Uses ``cp -al`` (recursive hard-link) for directories;
+    ``ln`` (single hard-link) for files.  Same-filesystem only — the
+    cache lives on the same ``/raid`` as the dispatch input dir, so
+    this is always satisfied.  Eviction-safe: hard-links keep the
+    inode alive even if the cache entry is rmtree'd.
+
+    Atomic: builds the destination as a sibling ``.partial`` then
+    ``os.rename``.  On any failure the partial is removed and the
+    caller can fall back to a NAS read.
+    """
+    cache_staged = Path(cache_staged)
+    dst_path = Path(dst_path)
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    if dst_path.exists():
+        return
+    partial = dst_path.parent / f".{dst_path.name}.partial"
+    if partial.exists():
+        if partial.is_dir():
+            shutil.rmtree(partial)
+        else:
+            partial.unlink()
+    try:
+        if cache_staged.is_dir():
+            # ``cp -al SRC/. PARTIAL/`` — the trailing ``/.`` semantics
+            # copy the *contents* of SRC into PARTIAL, preserving
+            # recursive structure as hard-links.
+            partial.mkdir()
+            _run_check(["cp", "-al", str(cache_staged) + "/.", str(partial)])
+        else:
+            # Single-file hard-link (TP FITS).  ``os.link`` is atomic
+            # and avoids subprocess overhead for the common case.
+            os.link(str(cache_staged), str(partial))
+        os.rename(str(partial), str(dst_path))
+    except Exception:
+        if partial.exists():
+            if partial.is_dir():
+                shutil.rmtree(partial, ignore_errors=True)
+            else:
+                try:
+                    partial.unlink()
+                except OSError:
+                    pass
+        raise
+
+
+@dataclass
+class _PopulateLockHandle:
+    """Handle for a cache populate lock — release via ``__exit__``."""
+    lock_dir: Path
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        shutil.rmtree(self.lock_dir, ignore_errors=True)
+
+
+def acquire_cache_populate(
+    cache_root: Path,
+    src_path: str | Path,
+    *,
+    holder_meta: Optional[dict] = None,
+    timeout_sec: float = 3600.0,
+    poll_sleep: tuple[float, float] = (2.0, 5.0),
+) -> tuple[str, Optional[_PopulateLockHandle]]:
+    """Acquire the populator role for the cache entry of *src_path*.
+
+    Returns one of:
+      ``("populate", handle)`` — caller is the populator.  Use ``handle``
+        as a context manager (it removes the lock dir on exit).
+      ``("hit", None)`` — waited for another worker; cache is now valid.
+
+    Raises ``TimeoutError`` if neither outcome occurs within
+    ``timeout_sec`` (caller should fall back to NAS-direct staging).
+
+    Stale-lock recovery: if the populator's host matches ours and its PID
+    is dead, we ``rmtree`` and retry.  Cross-host stale recovery is left
+    to the coordinator's reaper (same as NAS staging tokens) — workers
+    must NEVER ssh to a peer to check liveness.
+    """
+    cache_root = Path(cache_root)
+    src_path = Path(src_path)
+    entry_dir = cache_root / _cache_key(src_path)
+    populating = entry_dir / ".populating"
+    deadline = time.monotonic() + timeout_sec
+    meta = {"host": socket.gethostname(), "pid": os.getpid(), **(holder_meta or {})}
+    cache_root.mkdir(parents=True, exist_ok=True)
+    gc_lock_path = cache_root / ".gc.lock.d"
+
+    while True:
+        # Check FIRST whether a peer's populate already landed.  Without
+        # this, after A finishes populating and removes .populating, B
+        # (still in the wait loop) will succeed at ``mkdir(.populating)``
+        # and re-stage from NAS even though the cache is now valid.
+        hit = cache_lookup(cache_root, src_path)
+        if hit is not None:
+            return ("hit", None)
+
+        # Publish ``.populating`` *under the GC lock* so concurrent
+        # ``cache_evict_until_free`` cannot rmtree our entry between
+        # our mkdir and our holder.json write — eviction's
+        # candidate-collection sweep and our publish are now mutually
+        # exclusive at the GC mutex.  Populate cost is dominated by the
+        # NAS read which happens AFTER the GC lock is released; the
+        # critical section here is just two filesystem ops.
+        try:
+            with _MkdirLock(
+                dir_path=gc_lock_path,
+                holder_meta={"role": "publish_populate", **(holder_meta or {})},
+            ):
+                try:
+                    populating.mkdir(parents=True, exist_ok=False)
+                except FileExistsError:
+                    publish_outcome = "exists"
+                else:
+                    tmp = populating / ".holder.json.tmp"
+                    tmp.write_text(json.dumps(meta))
+                    os.replace(str(tmp), str(populating / "holder.json"))
+                    publish_outcome = "won"
+        except OSError as exc:
+            # GC lock acquisition itself failed (e.g. cache_root vanished
+            # under us during stale-recovery); retry, but respect the
+            # outer timeout so a persistent filesystem error eventually
+            # surfaces as TimeoutError rather than spinning forever.
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"cache populate wait exceeded {timeout_sec:.0f}s "
+                    f"for {src_path} (last error: {exc})"
+                )
+            time.sleep(random.uniform(0.1, 0.3))
+            continue
+
+        if publish_outcome == "won":
+            # Post-publish recheck (ignoring our OWN .populating).
+            # Closes the race where peer A finishes + removes its
+            # .populating between our top-of-loop ``cache_lookup`` and
+            # our publish.  Without this we'd clobber a fresh valid
+            # entry and re-stage from NAS.
+            hit = cache_lookup(cache_root, src_path, ignore_populating=True)
+            if hit is not None:
+                shutil.rmtree(populating, ignore_errors=True)
+                return ("hit", None)
+            return ("populate", _PopulateLockHandle(populating))
+
+        # ``.populating`` already present — fall through to wait/stale/timeout.
+
+        # Same-host stale recovery (cross-host is the coordinator reaper's job).
+        if not _holder_alive_locally(populating):
+            log.warning("stale cache populate lock at %s; reclaiming", populating)
+            shutil.rmtree(populating, ignore_errors=True)
+            continue
+
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"cache populate wait exceeded {timeout_sec:.0f}s for {src_path}"
+            )
+        time.sleep(random.uniform(*poll_sleep))
+
+
+def _wipe(path: Path) -> None:
+    """Remove a file or directory tree at *path*.  Idempotent."""
+    if not Path(path).exists():
+        return
+    if Path(path).is_dir() and not Path(path).is_symlink():
+        shutil.rmtree(path, ignore_errors=True)
+    else:
+        try:
+            Path(path).unlink()
+        except OSError:
+            pass
+
+
+def _du_free_bytes(root: Path) -> int:
+    """Bytes free under *root*'s filesystem (``shutil.disk_usage``)."""
+    try:
+        return shutil.disk_usage(str(root)).free
+    except OSError:
+        return 0
+
+
+def cache_evict_until_free(
+    cache_root: Path,
+    target_free_bytes: int,
+    *,
+    skip_keys: Optional[set[str]] = None,
+) -> int:
+    """Evict oldest cache entries (by sidecar ``staged_at``) until at
+    least *target_free_bytes* are free on the cache filesystem.
+
+    Returns the number of entries evicted.  Skips entries whose key is
+    in *skip_keys* (the entry currently being populated by the caller),
+    plus any entry with a ``.populating`` lock.
+
+    Concurrency: a per-host GC mutex (mkdir-based) serialises eviction
+    so two workers cannot rmtree the same entry concurrently or race
+    a ``cp -al`` reader.
+    """
+    cache_root = Path(cache_root)
+    if not cache_root.exists():
+        return 0
+    skip_keys = set(skip_keys or ())
+    gc_lock = cache_root / ".gc.lock.d"
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    with _MkdirLock(dir_path=gc_lock, holder_meta={"role": "cache_gc"}):
+        free = _du_free_bytes(cache_root)
+        if free >= target_free_bytes:
+            return 0
+        # Collect candidates: (staged_at, entry_dir, size_bytes)
+        cands = []
+        for entry in cache_root.iterdir():
+            if not entry.is_dir():
+                continue
+            if entry.name in skip_keys:
+                continue
+            if entry.name == ".gc.lock.d":
+                continue
+            if (entry / ".populating").exists():
+                continue
+            side = _read_sidecar(entry)
+            if side is None:
+                # Malformed: evict first to reclaim space
+                cands.append(("", entry, 0))
+                continue
+            cands.append((side.get("staged_at", ""), entry,
+                          int(side.get("size_bytes", 0))))
+        cands.sort(key=lambda t: t[0])  # oldest first; "" sorts before iso dates
+
+        evicted = 0
+        for _, entry_dir, _size in cands:
+            if _du_free_bytes(cache_root) >= target_free_bytes:
+                break
+            # Re-check ``.populating`` immediately before rmtree.  A
+            # populator that raced our candidate-collection above will
+            # have published its lock under our same ``.gc.lock.d``
+            # mutex (see ``acquire_cache_populate``), so by the time
+            # we get here either ``.populating`` was created before
+            # we entered this lock (and we'll see it now) or the
+            # populator is still waiting for us to release.  Either
+            # way the recheck is sufficient to avoid deleting a live
+            # populate in progress.
+            if (entry_dir / ".populating").exists():
+                continue
+            log.info("cache evict: %s (free=%.1fGB target=%.1fGB)",
+                     entry_dir.name,
+                     _du_free_bytes(cache_root) / 1e9,
+                     target_free_bytes / 1e9)
+            shutil.rmtree(entry_dir, ignore_errors=True)
+            evicted += 1
+        return evicted
+
+
+# ---------------------------------------------------------------------------
+# TokenLease — lazy NAS staging token (acquired only when actually reading
+# from NAS, not for cache hits).  Idempotent release.
+# ---------------------------------------------------------------------------
+
+class TokenLease:
+    """Acquire a NAS staging token on first use; release on close.
+
+    The dispatcher used to acquire the token outside ``_ensure_staged_inputs``
+    and hold it across all stages — which serialised even all-cache-hit
+    runs behind the NAS gate.  This class lets ``stage_one`` acquire only
+    when it actually does a NAS read, and reuse the token across multiple
+    misses within a single worker.
+
+    If ``tokens_dir is None`` (no NAS gate configured), all methods are
+    no-ops.
+    """
+
+    def __init__(
+        self,
+        tokens_dir: Optional[Path],
+        n_slots: int,
+        *,
+        holder_id: str,
+    ) -> None:
+        self.tokens_dir = Path(tokens_dir) if tokens_dir else None
+        self.n_slots = int(n_slots)
+        self.holder_id = holder_id
+        self._idx: Optional[int] = None
+        self._wait_total_sec = 0.0
+        self._acquires = 0
+
+    def acquire_if_needed(self) -> None:
+        if self.tokens_dir is None or self._idx is not None:
+            return
+        started = time.monotonic()
+        self._idx = acquire_staging_token(
+            self.tokens_dir, self.n_slots, holder_id=self.holder_id,
+        )
+        waited = time.monotonic() - started
+        self._wait_total_sec += waited
+        self._acquires += 1
+        if waited > 5:
+            log.info(
+                "acquired staging token %d after %.1fs wait (holder=%s)",
+                self._idx, waited, self.holder_id,
+            )
+
+    def release(self) -> None:
+        if self._idx is None or self.tokens_dir is None:
+            return
+        release_staging_token(self.tokens_dir, self._idx)
+        self._idx = None
+
+    def __enter__(self) -> "TokenLease":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.release()
+
+    @property
+    def stats(self) -> dict:
+        return {
+            "token_acquires": self._acquires,
+            "token_wait_sec": round(self._wait_total_sec, 1),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Staging primitives
+# ---------------------------------------------------------------------------
+
+def stage_one(
+    src: str,
+    dst_root: Path,
+    *,
+    method: str = "tar",
+    bucket: str = "ms",
+    validate: bool = True,
+    cache_root: Optional[Path] = None,
+    cache_min_free_bytes: Optional[int] = None,
+    token_lease: Optional["TokenLease"] = None,
+    cache_populate_timeout_sec: float = 3600.0,
+) -> tuple[Path, str]:
+    """Stage a single source path (MS dir or TP FITS) into *dst_root*.
+
+    Layout: ``<dst_root>/<bucket>/<basename(src)>``.
+
+    Returns ``(staged_path, source)`` where ``source`` is one of:
+
+    - ``"existing"``  — destination already present (no work)
+    - ``"cache_hit"`` — hard-linked from cache; no NAS read
+    - ``"cache_hit_after_wait"`` — cache hit after waiting for another
+      worker's populate to complete
+    - ``"cache_miss"`` — populated cache from NAS, then linked into dst
+    - ``"nas_direct"`` — fallback: read from NAS into dst directly
+      (cache disabled, populate timed out, or cache write failed)
+
+    Atomicity: the destination is built in a sibling ``.partial``
+    directory and ``os.rename``'d into place at the end.
+
+    NAS access is gated by *token_lease* (if supplied).  The lease is
+    acquired only on cache miss / NAS-direct paths — cache hits never
+    touch the NAS gate, which is the whole point of the cache.
+
+    Supported ``method`` values: ``"tar"``, ``"rsync"``, ``"cp"``.
+    """
+    src_path = Path(src)
+    if not src_path.exists():
+        raise FileNotFoundError(f"staging source does not exist: {src_path}")
+
+    bucket_dir = Path(dst_root) / bucket
+    bucket_dir.mkdir(parents=True, exist_ok=True)
+    final = bucket_dir / src_path.name
+
+    if final.exists():
+        return final, "existing"
+
+    # ---- 1. Cache hit fast path (no NAS, no token) ----
+    if cache_root is not None:
+        try:
+            hit = cache_lookup(Path(cache_root), src_path)
+        except OSError:
+            hit = None
+        if hit is not None:
+            try:
+                cache_link_into(hit, final)
+                return final, "cache_hit"
+            except Exception as exc:
+                log.warning(
+                    "cache_link_into failed for %s; falling through to populate: %s",
+                    src_path.name, exc,
+                )
+
+    # ---- 2. Try to populate the cache (or wait for another worker) ----
+    if cache_root is not None:
+        try:
+            outcome, lock = acquire_cache_populate(
+                Path(cache_root), src_path,
+                holder_meta={"role": "cache_populate"},
+                timeout_sec=cache_populate_timeout_sec,
+            )
+        except TimeoutError:
+            log.warning(
+                "cache populate timeout for %s; falling back to NAS-direct",
+                src_path.name,
+            )
+            outcome, lock = "fallback", None
+
+        if outcome == "hit":
+            # Populator finished while we waited — link in.
+            hit = cache_lookup(Path(cache_root), src_path)
+            if hit is not None:
+                try:
+                    cache_link_into(hit, final)
+                    return final, "cache_hit_after_wait"
+                except Exception as exc:
+                    log.warning(
+                        "cache_link_into failed after wait for %s: %s — NAS-direct",
+                        src_path.name, exc,
+                    )
+
+        if outcome == "populate":
+            with lock:
+                # NOTE: post-lock recheck (peer's commit landed just
+                # before we won mkdir) is performed inside
+                # ``acquire_cache_populate`` itself — it returns
+                # ("hit", None) instead of ("populate", lock) in that
+                # case, so we only reach here when there is genuinely
+                # no valid entry to reuse.
+                entry_dir = Path(cache_root) / _cache_key(src_path)
+                entry_dir.mkdir(parents=True, exist_ok=True)
+                cache_partial = entry_dir / f".{src_path.name}.partial"
+                cache_final = entry_dir / src_path.name
+                populate_ok = False
+                try:
+                    fp = _compute_fingerprint(src_path)
+                    if cache_min_free_bytes is not None:
+                        cache_evict_until_free(
+                            Path(cache_root),
+                            cache_min_free_bytes + int(fp["size_bytes"]),
+                            skip_keys={_cache_key(src_path)},
+                        )
+                    _wipe(cache_partial)
+                    if cache_final.exists():
+                        # Stale (mtime/size mismatch landed us here) — wipe.
+                        _wipe(cache_final)
+
+                    if token_lease is not None:
+                        token_lease.acquire_if_needed()
+                    _do_nas_read(src_path, cache_partial, method)
+                    os.rename(str(cache_partial), str(cache_final))
+                    # Read-only canary BEFORE sidecar — if chmod fails
+                    # we must not commit (sidecar is the commit marker).
+                    _chmod_readonly_files(cache_final)
+                    # Sidecar LAST — this is the entry's commit marker.
+                    _write_sidecar_atomic(entry_dir, src_path, fp)
+                    populate_ok = True
+                except Exception as exc:
+                    log.warning(
+                        "cache populate failed for %s: %s — NAS-direct",
+                        src_path.name, exc,
+                    )
+                finally:
+                    if not populate_ok:
+                        # Don't leak a (possibly very large) .partial
+                        # under the cache.  cache_final is left alone:
+                        # if it was rename'd before chmod/sidecar
+                        # failed, removing it would also kill any
+                        # peer's hard-linked dispatch dir.  An entry
+                        # without sidecar is treated as a miss anyway.
+                        _wipe(cache_partial)
+
+                if populate_ok:
+                    try:
+                        cache_link_into(cache_final, final)
+                        return final, "cache_miss"
+                    except Exception as exc:
+                        log.warning(
+                            "cache_link_into post-populate failed for %s: %s — NAS-direct",
+                            src_path.name, exc,
+                        )
+
+    # ---- 3. Fallback: NAS-direct stage into dst (no cache involvement) ----
+    if token_lease is not None:
+        token_lease.acquire_if_needed()
+    partial = bucket_dir / f".{src_path.name}.partial"
+    if partial.exists():
+        if partial.is_dir():
+            shutil.rmtree(partial)
+        else:
+            partial.unlink()
+    _do_nas_read(src_path, partial, method)
+    os.rename(str(partial), str(final))
+
+    if validate:
+        try:
+            src_bytes = _du_bytes(src_path)
+            dst_bytes = _du_bytes(final)
+        except Exception:
+            src_bytes = dst_bytes = None
+        if (src_bytes and dst_bytes
+                and abs(src_bytes - dst_bytes) > max(src_bytes * 0.001, 4096)):
+            log.warning(
+                "stage size mismatch for %s: src=%d dst=%d (%.2f%% diff)",
+                src_path.name, src_bytes, dst_bytes,
+                100.0 * abs(src_bytes - dst_bytes) / max(src_bytes, 1),
+            )
+
+    return final, "nas_direct"
+
+
+def _do_nas_read(src_path: Path, partial_dst: Path, method: str) -> None:
+    """Stage *src_path* into *partial_dst* using the requested method."""
+    if src_path.is_file() or method == "cp":
+        if src_path.is_dir():
+            partial_dst.mkdir(parents=True, exist_ok=True)
+            _run_check(["cp", "-a", str(src_path) + "/.", str(partial_dst)])
+        else:
+            partial_dst.parent.mkdir(parents=True, exist_ok=True)
+            _run_check(["cp", "-p", str(src_path), str(partial_dst)])
+    elif method == "tar":
+        partial_dst.mkdir(parents=True, exist_ok=True)
+        cmd = (
+            f"tar -cf - -C {_shquote(str(src_path.parent))} "
+            f"{_shquote(src_path.name)}/ "
+            f"| tar -xf - -C {_shquote(str(partial_dst))} --strip-components=1"
+        )
+        _run_check(cmd, shell=True)
+    elif method == "rsync":
+        partial_dst.mkdir(parents=True, exist_ok=True)
+        _run_check([
+            "rsync", "-a", "--inplace", "--whole-file",
+            str(src_path) + "/", str(partial_dst) + "/",
+        ])
+    else:
+        raise ValueError(f"unknown transfer method: {method!r}")
+
+
+def _du_bytes(path: Path) -> int:
+    """Return ``du -sb <path>`` (recursive total size).  0 on error."""
+    try:
+        proc = subprocess.run(
+            ["du", "-sb", str(path)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, timeout=120,
+        )
+        if proc.returncode != 0:
+            return 0
+        return int(proc.stdout.split()[0])
+    except (subprocess.SubprocessError, ValueError, IndexError):
+        return 0
+
+
+def _run_check(cmd, *, shell: bool = False) -> None:
+    """``subprocess.run`` with check + helpful error tail on failure."""
+    log.debug("stage exec: %s", cmd if shell else " ".join(cmd))
+    proc = subprocess.run(
+        cmd, shell=shell,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, errors="replace",
+    )
+    if proc.returncode != 0:
+        tail = (proc.stdout or "")[-2000:]
+        raise RuntimeError(
+            f"staging command failed (rc={proc.returncode}): {tail}"
+        )
+
+
+def _shquote(s: str) -> str:
+    """Minimal shell quoter for the `tar` pipe path arguments."""
+    import shlex
+    return shlex.quote(s)
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+def cleanup_workdir(path: Path) -> None:
+    """``rm -rf`` *path* if it exists.  Safe on missing dirs."""
+    if Path(path).exists():
+        shutil.rmtree(path, ignore_errors=True)

--- a/panta_rei/imaging/unit_selection.py
+++ b/panta_rei/imaging/unit_selection.py
@@ -1,0 +1,167 @@
+"""Shared selection logic for imaging units.
+
+Both :class:`panta_rei.workflows.imaging.JointImagingStep` and
+the distributed dispatcher pick units to run from the same pool of
+recovered params.  The actual filter / preflight / idempotency logic
+lives here so it cannot drift between the two callers.
+
+The dispatcher additionally needs to exclude units that are *already
+in-flight* under another (non-terminal) dispatch — otherwise a fresh
+run can enqueue a duplicate row for a job an adopted worker is still
+executing.  ``select_units_to_image`` exposes that via
+``exclude_active=True``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from panta_rei.db.connection import DatabaseManager
+from panta_rei.db.models import (
+    DispatchState,
+    ImagingParamsQueries,
+    ImagingRunsQueries,
+)
+from panta_rei.imaging.matching import (
+    ImagingUnit,
+    build_imaging_units_advisory,
+    load_targets_csv,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class SelectionFilters:
+    """Selection-time filters shared by step and dispatcher."""
+
+    match: Optional[str] = None
+    include_sources: Optional[list[str]] = None
+    include_line_groups: Optional[list[str]] = None
+    limit: Optional[int] = None
+    method: str = "tclean_feather"
+    sdgain: Optional[float] = None
+    deconvolver: str = "multiscale"
+    scales: list[int] = None  # type: ignore[assignment]
+    re_run: bool = False
+    exclude_active: bool = False
+
+
+@dataclass
+class SelectionResult:
+    """Outcome of :func:`select_units_to_image`."""
+
+    ready: list[ImagingUnit]
+    not_ready: list[ImagingUnit]
+    skipped_already_done: int
+    skipped_active: int
+    skipped_filtered_out: int
+
+
+def select_units_to_image(
+    db_manager: DatabaseManager,
+    targets_csv: Path,
+    data_dir: Path,
+    filters: SelectionFilters,
+) -> SelectionResult:
+    """Build, filter, and idempotency-check the list of imaging units.
+
+    Steps:
+      1. Load all recovered ``imaging_params`` rows.
+      2. Apply ``--match`` / ``--include-sources`` / ``--include-line-groups``.
+      3. Build :class:`ImagingUnit` records via advisory preflight.
+      4. Drop not-ready units.
+      5. Drop units with a matching prior SUCCESS unless ``re_run``.
+      6. If ``exclude_active``, drop units currently QUEUED/RUNNING under a
+         non-terminal dispatch.
+      7. Honour ``limit``.
+    """
+    if filters.scales is None:
+        filters.scales = [0, 5, 10, 15, 20]
+
+    targets = load_targets_csv(targets_csv)
+
+    with db_manager.connect() as con:
+        all_params = ImagingParamsQueries.get_all_recovered(con)
+
+    if not all_params:
+        return SelectionResult(
+            ready=[], not_ready=[],
+            skipped_already_done=0, skipped_active=0, skipped_filtered_out=0,
+        )
+
+    regex: Optional[re.Pattern] = None
+    if filters.match:
+        try:
+            regex = re.compile(filters.match, re.IGNORECASE)
+        except re.error:
+            regex = None
+
+    filtered = []
+    skipped_filter = 0
+    for row in all_params:
+        src = row["source_name"]
+        gous = row["gous_uid"]
+        lg = row.get("line_group")
+        if filters.include_sources and src not in filters.include_sources:
+            skipped_filter += 1
+            continue
+        if filters.include_line_groups and lg not in filters.include_line_groups:
+            skipped_filter += 1
+            continue
+        if regex and not regex.search(src) and not regex.search(gous):
+            skipped_filter += 1
+            continue
+        filtered.append(row)
+
+    units = build_imaging_units_advisory(filtered, targets, data_dir)
+    ready_units = [u for u in units if u.ready]
+    not_ready = [u for u in units if not u.ready]
+
+    scales_str = json.dumps(filters.scales)
+    to_run: list[ImagingUnit] = []
+    skipped_done = 0
+    skipped_active = 0
+
+    for u in ready_units:
+        with db_manager.connect() as con:
+            if not filters.re_run and ImagingRunsQueries.success_exists(
+                con,
+                u.params_id,
+                method=filters.method,
+                sdgain=filters.sdgain if filters.method == "sdintimaging" else None,
+                deconvolver=filters.deconvolver,
+                scales=scales_str,
+            ):
+                skipped_done += 1
+                continue
+
+            if filters.exclude_active:
+                active = ImagingRunsQueries.list_active_for_params(
+                    con, u.params_id,
+                )
+                non_terminal = [
+                    r for r in active
+                    if r.get("dispatch_state") in (None, DispatchState.RUNNING)
+                ]
+                if non_terminal:
+                    skipped_active += 1
+                    continue
+
+        to_run.append(u)
+
+    if filters.limit is not None:
+        to_run = to_run[: filters.limit]
+
+    return SelectionResult(
+        ready=to_run,
+        not_ready=not_ready,
+        skipped_already_done=skipped_done,
+        skipped_active=skipped_active,
+        skipped_filtered_out=skipped_filter,
+    )

--- a/panta_rei/workflows/calibration.py
+++ b/panta_rei/workflows/calibration.py
@@ -72,6 +72,24 @@ def _extract_xpair(uid: str) -> Optional[str]:
     return m.group(1) if m else None
 
 
+# Depth-bounded glob patterns for ALMA layout.  The standard QA2
+# delivery places ``script/scriptForPI*.py`` at:
+#
+#     <data_dir>/science_goal.uid___*/group.uid___*/member.uid___*/script/*.py
+#
+# Some sites (notably this project) also have a re-extracted copy nested
+# under an extra wrapper dir (e.g. doubled project-name dir from a tar
+# extract).  We try a few wrapper depths but cap at 2 — beyond that
+# we'd be back to ``rglob``-style explosions.  ``Path.glob`` does NOT
+# descend below the literal pattern depth, so this never enters
+# ``calibrated/``, ``pipeline-*``, MS internals, etc.
+_SCRIPT_PATTERNS: tuple[str, ...] = (
+    "science_goal.*/group.*/member.*/script/*.py",
+    "*/science_goal.*/group.*/member.*/script/*.py",
+    "*/*/science_goal.*/group.*/member.*/script/*.py",
+)
+
+
 def discover_scriptforpi(
     base_dir: Path,
 ) -> Iterator[Tuple[str, Path, Path, Dict[str, Optional[str]]]]:
@@ -81,24 +99,47 @@ def discover_scriptforpi(
       1. From script filename (member/MOUS UID).
       2. Last UID in the directory path.
       3. ``canonical_uid(str(mous_dir))``.
+
+    Bounded-glob search (no ``rglob``): on large projects rglob hangs
+    indefinitely walking through ``pipeline-*/html/...`` weblog MS
+    subtrees.  Patterns above match only the legitimate ALMA layout.
+
+    Dedup: if the same UID appears at multiple depths (e.g. a project
+    with both ``base/science_goal/...`` and
+    ``base/<wrapper>/science_goal/...`` containing the same MOUS), the
+    shallowest match wins and a warning is emitted.  Without UID-based
+    dedup we'd silently process the same MOUS twice.
     """
-    for script_path in base_dir.rglob("script/*.py"):
-        if not _SCRIPT_NAME_RE.search(script_path.name):
-            continue
-        mous_dir = script_path.parent.parent
+    seen_uids: set[str] = set()
+    for pat in _SCRIPT_PATTERNS:
+        for script_path in sorted(base_dir.glob(pat)):
+            if not script_path.is_file():
+                continue
+            if not _SCRIPT_NAME_RE.search(script_path.name):
+                continue
+            mous_dir = script_path.parent.parent  # lexical, not resolved
 
-        uid = (
-            canonical_uid(script_path.name)
-            or _last_uid_in(str(mous_dir))
-            or canonical_uid(str(mous_dir))
-        )
+            uid = (
+                canonical_uid(script_path.name)
+                or _last_uid_in(str(mous_dir))
+                or canonical_uid(str(mous_dir))
+            )
 
-        if not uid:
-            log.debug("Skipping script with no parseable UID: %s", script_path)
-            continue
+            if not uid:
+                log.debug("Skipping script with no parseable UID: %s", script_path)
+                continue
 
-        hierarchy = parse_hierarchy_from_path(mous_dir)
-        yield (uid.lower(), script_path.resolve(), mous_dir.resolve(), hierarchy)
+            uid_lower = uid.lower()
+            if uid_lower in seen_uids:
+                log.warning(
+                    "Duplicate MOUS %s discovered at %s; using shallower copy",
+                    uid_lower, script_path,
+                )
+                continue
+            seen_uids.add(uid_lower)
+
+            hierarchy = parse_hierarchy_from_path(mous_dir)
+            yield (uid_lower, script_path.resolve(), mous_dir.resolve(), hierarchy)
 
 
 # ---------------------------------------------------------------------------

--- a/panta_rei/workflows/imaging.py
+++ b/panta_rei/workflows/imaging.py
@@ -368,54 +368,38 @@ class JointImagingStep(Step):
                 errors=[str(csv_path)],
             )
 
-        targets = load_targets_csv(csv_path)
-
-        # Load all recovered params from DB
-        with ctx.db_manager.connect() as con:
-            all_params = ImagingParamsQueries.get_all_recovered(con)
-
-        if not all_params:
-            return StepResult(
-                success=True,
-                summary="No recovered params to process",
-                items_processed=0,
-            )
-
-        # Apply filters
-        regex: Optional[re.Pattern] = None
-        if opts.match:
-            try:
-                regex = re.compile(opts.match, re.IGNORECASE)
-            except re.error:
-                regex = None
-
-        filtered = []
-        for row in all_params:
-            src = row["source_name"]
-            gous = row["gous_uid"]
-            lg = row.get("line_group")
-            if opts.include_sources and src not in opts.include_sources:
-                continue
-            if opts.include_line_groups and lg not in opts.include_line_groups:
-                continue
-            if regex and not regex.search(src) and not regex.search(gous):
-                continue
-            filtered.append(row)
-
-        if not filtered:
-            return StepResult(
-                success=True,
-                summary="No params match filters",
-                items_processed=0,
-            )
-
-        # Build imaging units with advisory preflight
-        units = build_imaging_units_advisory(
-            filtered, targets, ctx.data_dir
+        # Single source of truth: select_units_to_image() handles
+        # filter, advisory preflight, and idempotency the same way as
+        # the distributed dispatcher.  exclude_active=False here keeps
+        # the legacy single-host serial path untouched (the dispatcher
+        # is the only caller that needs to gate on in-flight rows).
+        #
+        # ``--step preflight`` deliberately reports the full ready/not-
+        # ready picture independent of prior successful runs, matching
+        # the legacy behaviour.  Bypass success_exists() + limit by
+        # forcing re_run=True and limit=None just for that mode.
+        from panta_rei.imaging.unit_selection import (
+            SelectionFilters,
+            select_units_to_image,
         )
-
-        ready_units = [u for u in units if u.ready]
-        not_ready = [u for u in units if not u.ready]
+        is_preflight = (opts.step == "preflight")
+        filters = SelectionFilters(
+            match=opts.match,
+            include_sources=opts.include_sources,
+            include_line_groups=opts.include_line_groups,
+            limit=None if is_preflight else opts.limit,
+            method=opts.method,
+            sdgain=opts.sdgain,
+            deconvolver=opts.deconvolver,
+            scales=list(opts.scales),
+            re_run=True if is_preflight else opts.re_run,
+            exclude_active=False,
+        )
+        selection = select_units_to_image(
+            ctx.db_manager, csv_path, ctx.data_dir, filters,
+        )
+        ready_units = selection.ready
+        not_ready = selection.not_ready
 
         for u in not_ready:
             log.info(
@@ -424,16 +408,24 @@ class JointImagingStep(Step):
             )
 
         log.info(
-            "Preflight: %d ready, %d not ready out of %d",
-            len(ready_units), len(not_ready), len(units),
+            "Selection: %d ready, %d not ready, %d already done, "
+            "%d filtered out",
+            len(ready_units), len(not_ready),
+            selection.skipped_already_done,
+            selection.skipped_filtered_out,
         )
 
         # If preflight-only mode, stop here
         if opts.step == "preflight":
+            total_units = (len(ready_units) + len(not_ready)
+                           + selection.skipped_already_done)
             return StepResult(
                 success=True,
-                summary=f"Preflight: {len(ready_units)} ready, {len(not_ready)} not ready",
-                items_processed=len(units),
+                summary=(
+                    f"Preflight: {len(ready_units)} ready, "
+                    f"{len(not_ready)} not ready"
+                ),
+                items_processed=total_units,
                 items_skipped=len(not_ready),
             )
 
@@ -468,36 +460,19 @@ class JointImagingStep(Step):
                     )
             # parallel mode: skip check — tclean runs via mpicasa subprocess
 
-        # Idempotence: filter out already-successful runs
+        # Selection has already applied success_exists() and limit;
+        # the result is the units to actually run.
         scales_str = json.dumps(opts.scales)
-        to_run: list[ImagingUnit] = []
-        for u in ready_units:
-            if not opts.re_run:
-                with ctx.db_manager.connect() as con:
-                    if ImagingRunsQueries.success_exists(
-                        con,
-                        u.params_id,
-                        method=opts.method,
-                        sdgain=opts.sdgain if opts.method == "sdintimaging" else None,
-                        deconvolver=opts.deconvolver,
-                        scales=scales_str,
-                    ):
-                        log.info(
-                            "Skipping %s/%s/spw%s (already successful with %s)",
-                            u.gous_uid, u.source_name, u.spw_id, opts.method,
-                        )
-                        continue
-            to_run.append(u)
-
-        if opts.limit:
-            to_run = to_run[: opts.limit]
+        to_run = ready_units
 
         if not to_run:
             return StepResult(
                 success=True,
                 summary="All ready units already have successful runs",
                 items_processed=0,
-                items_skipped=len(ready_units),
+                items_skipped=(
+                    len(not_ready) + selection.skipped_already_done
+                ),
             )
 
         # Execute imaging for each ready unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ panta-rei-calibrate = "panta_rei.cli.run_calibration:main"
 panta-rei-reset = "panta_rei.cli.reset_mous:main"
 panta-rei-migrate-db = "panta_rei.cli.migrate_db:main"
 panta-rei-imaging = "panta_rei.cli.run_imaging:main"
+panta-rei-imaging-dispatch = "panta_rei.cli.run_imaging_dispatch:main"
 panta-rei-contsub = "panta_rei.cli.run_contsub:main"
 
 [tool.setuptools.packages.find]

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -62,6 +62,65 @@ class TestDiscoverScriptForPI:
         assert "uid___a001_x3833_x64bc" in uids
         assert "uid___a001_x3833_x64bd" in uids
 
+    def test_doubled_layout_dedups_by_uid(self, tmp_path, caplog):
+        """Regression: when the same MOUS UID appears under both
+        ``<base>/science_goal/...`` AND ``<base>/<wrapper>/science_goal/...``
+        (real layout artifact from doubled tar-extracts), discover must
+        yield the MOUS only ONCE, preferring the shallower copy, and
+        emit a duplicate warning."""
+        # Shallow copy
+        shallow_member = (tmp_path / "science_goal.uid___A001_X3833_X64b8"
+                          / "group.uid___A001_X3833_X64b9"
+                          / "member.uid___A001_X3833_X64bc"
+                          / "script")
+        shallow_member.mkdir(parents=True)
+        (shallow_member / "scriptForPI.py").write_text("# shallow\n")
+        # Deep copy of the SAME UID under a wrapper dir
+        deep_member = (tmp_path / "extra_wrapper"
+                       / "science_goal.uid___A001_X3833_X64b8"
+                       / "group.uid___A001_X3833_X64b9"
+                       / "member.uid___A001_X3833_X64bc"
+                       / "script")
+        deep_member.mkdir(parents=True)
+        (deep_member / "scriptForPI.py").write_text("# deep\n")
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            found = list(discover_scriptforpi(tmp_path))
+
+        # Only one yielded entry
+        assert len(found) == 1
+        # Shallow copy wins
+        _uid, script_path, _mous_dir, _hier = found[0]
+        assert "extra_wrapper" not in str(script_path)
+        # Warning emitted
+        assert any("Duplicate MOUS" in r.message for r in caplog.records)
+
+    def test_disjoint_doubled_layout_yields_both(self, tmp_path):
+        """Counterpart: when the doubled layer has DIFFERENT MOUSs
+        (the actual production case), all of them are discovered."""
+        # Shallow MOUS A
+        sa = (tmp_path / "science_goal.uid___A001_X3833_X64b8"
+              / "group.uid___A001_X3833_X64b9"
+              / "member.uid___A001_X3833_X64bc"
+              / "script")
+        sa.mkdir(parents=True)
+        (sa / "scriptForPI.py").write_text("# A\n")
+        # Deep MOUS B (different UID under wrapper)
+        sb = (tmp_path / "extra_wrapper"
+              / "science_goal.uid___A001_X3833_X65aa"
+              / "group.uid___A001_X3833_X65ab"
+              / "member.uid___A001_X3833_X65ac"
+              / "script")
+        sb.mkdir(parents=True)
+        (sb / "scriptForPI.py").write_text("# B\n")
+
+        found = list(discover_scriptforpi(tmp_path))
+        uids = {uid for uid, *_ in found}
+        assert "uid___a001_x3833_x64bc" in uids
+        assert "uid___a001_x3833_x65ac" in uids
+        assert len(found) == 2
+
     def test_script_path_is_under_script_dir(self, alma_tree):
         """Each discovered script lives in a member/script/ directory."""
         for _uid, script_path, _mous_dir, _hier in discover_scriptforpi(alma_tree):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,20 @@ class TestPipelineConfig:
         assert config.state_db_path == tmp_path / "2025.1.00383.L" / "alma_retrieval_state.sqlite3"
         assert config.targets_csv_path == tmp_path / "2025.1.00383.L" / "targets_by_array.csv"
 
+    def test_doubled_panta_rei_base_raises(self, tmp_path):
+        """Regression: passing project_dir as panta_rei_base must fail loudly.
+
+        Without this guard, ``data_dir = base / project / project`` silently
+        becomes a third nesting level when ``base`` already ends in
+        ``project_code``.  See the "two data layers" incident
+        (2026-05-01).
+        """
+        from panta_rei.core.errors import ConfigError
+        bad = tmp_path / "2025.1.00383.L"
+        bad.mkdir()
+        with pytest.raises(ConfigError, match="already ends in the project_code"):
+            PipelineConfig(panta_rei_base=bad)
+
     def test_cron_log_dir_default(self, tmp_path):
         config = PipelineConfig(panta_rei_base=tmp_path)
         assert config.cron_log_dir == tmp_path / "cron_logs"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -52,7 +52,7 @@ class TestSchemaCreation:
 
     def test_all_migrations_recorded(self, con):
         count = con.execute("SELECT COUNT(*) FROM schema_version").fetchone()[0]
-        assert count == 13
+        assert count == 15
 
     def test_obs_has_all_columns(self, con):
         cols = {row[1] for row in con.execute("PRAGMA table_info(obs)")}

--- a/tests/test_db_bootstrap.py
+++ b/tests/test_db_bootstrap.py
@@ -69,7 +69,7 @@ ALL_INDEXES = {
 }
 
 
-ALL_VERSIONS = set(range(1, 14))  # migrations 1-13
+ALL_VERSIONS = set(range(1, 16))  # migrations 1-15
 
 
 def assert_full_schema(con: sqlite3.Connection) -> None:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,1255 @@
+"""Tests for panta_rei.imaging.dispatch.
+
+Focuses on the correctness-critical parts that don't need real SSH:
+
+- machines.json load + validate
+- DispatcherLock (flock blocks second holder)
+- DBWriter event application via in-memory DB
+- SchedulerState GOUS-affinity + staging gate
+- Manifest construction (serialise_unit + union_inputs_for_gous)
+- Reconciliation outcomes (terminal apply, adoption, dead-pid mark FAILED,
+  ssh-unreachable does NOT mark FAILED)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from panta_rei.db.connection import DatabaseManager
+from panta_rei.db.models import (
+    DispatchesQueries,
+    DispatchState,
+    ImagingRunsQueries,
+    ImagingRunStatus,
+)
+from panta_rei.imaging import dispatch as D
+from panta_rei.imaging.matching import ImagingUnit
+
+
+# ---------------------------------------------------------------------------
+# load_machines_config
+# ---------------------------------------------------------------------------
+
+def _write_machines_json(tmp_path, machines=None, **kw):
+    payload = {
+        "conda_env": "/opt/conda",
+        "repo_path": "/repo",
+        "global": {"max_concurrent_staging": 3},
+        "machines": machines or {
+            "alpha": {"raid": "/raid/alpha", "slots": 1, "nproc": 4},
+            "beta":  {"raid": "/raid/beta",  "slots": 2, "nproc": 4},
+        },
+    }
+    payload.update(kw)
+    p = tmp_path / "machines.json"
+    p.write_text(json.dumps(payload))
+    return p
+
+
+def test_load_machines_config_happy(tmp_path):
+    p = _write_machines_json(tmp_path)
+    cfg = D.load_machines_config(p)
+    assert cfg.conda_env == "/opt/conda"
+    assert cfg.global_cfg.max_concurrent_staging == 3
+    assert set(cfg.machines.keys()) == {"alpha", "beta"}
+    assert cfg.machines["beta"].slots == 2
+
+
+def test_load_machines_config_missing_required(tmp_path):
+    p = tmp_path / "m.json"
+    p.write_text(json.dumps({"conda_env": "/x"}))
+    with pytest.raises(ValueError):
+        D.load_machines_config(p)
+
+
+def test_load_machines_config_machine_without_raid(tmp_path):
+    p = _write_machines_json(tmp_path, machines={"x": {"slots": 1}})
+    with pytest.raises(ValueError):
+        D.load_machines_config(p)
+
+
+# ---------------------------------------------------------------------------
+# DispatcherLock
+# ---------------------------------------------------------------------------
+
+def test_dispatcher_lock_blocks_second(tmp_path):
+    lock_path = tmp_path / "lock"
+    a = D.DispatcherLock(lock_path)
+    a.acquire()
+    try:
+        b = D.DispatcherLock(lock_path)
+        with pytest.raises(RuntimeError):
+            b.acquire()
+    finally:
+        a.release()
+    # After release, a fresh acquire works
+    c = D.DispatcherLock(lock_path)
+    c.acquire()
+    c.release()
+
+
+# ---------------------------------------------------------------------------
+# DBWriter
+# ---------------------------------------------------------------------------
+
+def _make_unit(gous="X", source="S", spw="23", params_id=1) -> ImagingUnit:
+    return ImagingUnit(
+        gous_uid=gous, source_name=source, line_group="LG",
+        spw_id=spw, params_id=params_id, ready=True,
+    )
+
+
+def test_db_writer_handles_lifecycle(tmp_path):
+    db = DatabaseManager(tmp_path / "x.db")
+    dispatch_id = "d_test_0001"
+    # Pre-insert a dispatches row so MARK_RUNNING etc. has FK-like context.
+    with db.connect() as con:
+        DispatchesQueries.insert(
+            con, dispatch_id=dispatch_id,
+            coordinator_host="local", coordinator_pid=os.getpid(),
+            machines_json="{}", cli_args="",
+        )
+        con.commit()
+
+    writer = D.DBWriter(db, dispatch_id)
+    writer.start()
+    try:
+        # INSERT_QUEUED
+        holder: dict = {}
+        writer.q.put({
+            "op": "INSERT_QUEUED",
+            "row": {
+                "params_id": 7, "gous_uid": "G", "source_name": "S",
+                "line_group": "LG", "spw_id": "23",
+                "started_at": "2026-01-01T00:00:00",
+                "status": ImagingRunStatus.QUEUED,
+            },
+            "row_id_holder": holder,
+        })
+        # Wait
+        for _ in range(50):
+            if "id" in holder:
+                break
+            time.sleep(0.02)
+        assert "id" in holder
+        run_id = holder["id"]
+
+        writer.q.put({
+            "op": "MARK_RUNNING",
+            "run_id": run_id, "remote_workdir": "/raid/test",
+            "worker_pid": 1234, "worker_pgid": 1234,
+            "hostname": "alpha",
+        })
+        writer.q.put({
+            "op": "HEARTBEAT", "run_id": run_id,
+            "ts": "2026-01-01T00:00:30",
+        })
+        writer.q.put({
+            "op": "MARK_DONE",
+            "run_id": run_id,
+            "status": ImagingRunStatus.SUCCESS,
+            "retcode": 0,
+            "duration_sec": 12.5,
+            "finished_at": "2026-01-01T00:01:00",
+            "output_fits": "/nas/out.fits",
+            "spw_selection": json.dumps(["23"]),
+            "field_selection": json.dumps(["S"]),
+            "job_json_path": "/nas/jobs/x.json",
+        })
+    finally:
+        writer.stop()
+        writer.join(timeout=5)
+
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, run_id)
+    assert row["status"] == ImagingRunStatus.SUCCESS
+    assert row["worker_pid"] == 1234
+    assert row["last_heartbeat"] == "2026-01-01T00:00:30"
+    assert row["output_fits"] == "/nas/out.fits"
+    assert row["job_json_path"] == "/nas/jobs/x.json"
+    assert row["dispatch_id"] == dispatch_id
+    assert row["hostname"] == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# SchedulerState
+# ---------------------------------------------------------------------------
+
+def test_scheduler_first_pick_claims_unmapped_gous():
+    s = D.SchedulerState(queue=[
+        _make_unit("G1", "S1"),
+        _make_unit("G2", "S2"),
+    ])
+    u = s.pick("alpha", run_id_assigner=lambda: 0)
+    assert u is not None
+    assert s.gous_machine[u.gous_uid] == "alpha"
+
+
+def test_scheduler_prefers_mapped_and_staged_for_machine():
+    g = "G42"
+    s = D.SchedulerState(queue=[
+        _make_unit(g, "S1"),
+        _make_unit(g, "S2"),
+        _make_unit(g, "S3"),
+    ])
+    s.gous_machine[g] = "alpha"
+    s.gous_staged_on[("alpha", g)] = True
+    picks = []
+    for _ in range(3):
+        picks.append(s.pick("alpha", run_id_assigner=lambda: 0))
+    assert all(u.gous_uid == g for u in picks)
+    assert s.queue == []
+
+
+def test_scheduler_staging_gate_holds_back_second_unit():
+    """A fresh GOUS only releases more units once it transitions to staged."""
+    g = "G42"
+    s = D.SchedulerState(queue=[
+        _make_unit(g, "S1"),
+        _make_unit(g, "S2"),
+    ])
+    # Unit 1 picked: claims GOUS for alpha
+    u1 = s.pick("alpha", run_id_assigner=lambda: 0)
+    assert u1 is not None
+    s.mark_inflight("alpha", g, run_id=1)
+    # Unit 2 should NOT come back yet (in-flight on alpha, not staged yet)
+    u2 = s.pick("alpha", run_id_assigner=lambda: 0)
+    assert u2 is None
+    # Once staging completes, unit 2 picks freely
+    s.mark_staged("alpha", g)
+    u2 = s.pick("alpha", run_id_assigner=lambda: 0)
+    assert u2 is not None and u2.source_name == "S2"
+
+
+def test_scheduler_fallback_fifo_when_only_other_machine_units():
+    """Idle machine drains queue from another machine's GOUS as fallback."""
+    g = "G42"
+    s = D.SchedulerState(queue=[_make_unit(g, "S1")])
+    s.gous_machine[g] = "alpha"  # claimed by alpha
+    # Beta tries to pick: nothing mapped to beta, no unmapped GOUSs left.
+    # Falls through to FIFO, takes the unit anyway (cross-machine restage).
+    u = s.pick("beta", run_id_assigner=lambda: 0)
+    assert u is not None
+
+
+def test_scheduler_mark_terminal_returns_empty():
+    g = "G"
+    s = D.SchedulerState(queue=[])
+    s.mark_inflight("alpha", g, run_id=1)
+    s.mark_inflight("alpha", g, run_id=2)
+    assert s.mark_terminal("alpha", g, 1) is False
+    assert s.mark_terminal("alpha", g, 2) is True
+
+
+def test_scheduler_seen_pairs_survive_terminal():
+    """seen_pairs records every (machine, gous) the scheduler has touched
+    so the cleaner can find drained GOUSs after their in_flight entry
+    has been deleted by mark_terminal."""
+    g = "G"
+    s = D.SchedulerState(queue=[])
+    s.mark_inflight("alpha", g, run_id=1)
+    assert ("alpha", g) in s.seen_pairs
+    s.mark_terminal("alpha", g, 1)
+    # in_flight may be empty/deleted, but seen_pairs still has the pair
+    assert ("alpha", g) in s.seen_pairs
+
+
+def test_gous_cleaner_uses_scheduler_success_ids_no_db_race(tmp_path, monkeypatch):
+    """The cleaner must read SUCCESS run_ids from the scheduler, not from
+    the DB.  Pre-fix, a queued-but-not-committed MARK_DONE caused the
+    cleaner to miss work-dir cleanups."""
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={"alpha": D.MachineCfg("alpha", "/raid/a", slots=1, nproc=1)},
+    )
+    s = D.SchedulerState(queue=[])
+    s.seen_pairs.add(("alpha", "G"))
+    s.success_run_ids[("alpha", "G")] = {7, 8}  # in-memory record
+    cleaner = D.GousCleaner(s, cfg, "d_x", D.GlobalCfg())
+
+    seen_cmds: list[str] = []
+
+    def fake_ssh(machine, cmd, timeout=30, capture=True):
+        seen_cmds.append(cmd)
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(D, "ssh_run", fake_ssh)
+    cleaner.force_run()
+    assert len(seen_cmds) == 1
+    cmd = seen_cmds[0]
+    # Must include both SUCCESS work-dir deletions AND the inputs delete.
+    assert "input/G" in cmd
+    assert "work/runs/7" in cmd
+    assert "work/runs/8" in cmd
+
+
+def test_scheduler_mark_terminal_records_success_or_failure():
+    g = "G"
+    s = D.SchedulerState(queue=[])
+    s.mark_inflight("alpha", g, run_id=11)
+    s.mark_inflight("alpha", g, run_id=12)
+    s.mark_terminal("alpha", g, 11, success=True)
+    s.mark_terminal("alpha", g, 12, success=False)
+    assert s.success_run_ids[("alpha", g)] == {11}
+    assert s.failed_run_ids[("alpha", g)] == {12}
+
+
+def test_scheduler_records_pair_dispatch_id():
+    """The cleaner needs to know which dispatch's /raid/ tree each
+    (machine, gous) pair lives under.  Adoption of prior-dispatch
+    units must record the *prior* dispatch_id."""
+    s = D.SchedulerState(queue=[])
+    s.mark_inflight("alpha", "G_NEW", run_id=1, dispatch_id="d_new")
+    s.mark_inflight("alpha", "G_OLD", run_id=2, dispatch_id="d_old")
+    assert s.pair_dispatch_id[("alpha", "G_NEW")] == "d_new"
+    assert s.pair_dispatch_id[("alpha", "G_OLD")] == "d_old"
+
+
+def test_token_reaper_reclaims_malformed_token_after_grace(tmp_path, monkeypatch):
+    """A token dir without holder metadata older than the grace window
+    must be reclaimed; a fresh malformed dir must not be."""
+    tokens_dir = tmp_path / "staging_tokens"
+    tokens_dir.mkdir()
+    # Fresh malformed slot 0 (no holder metadata, mtime is "now")
+    (tokens_dir / "0").mkdir()
+    # Old malformed slot 1 (no holder metadata, mtime is in the past)
+    old_slot = tokens_dir / "1"
+    old_slot.mkdir()
+    old_mtime = time.time() - 600  # 10 minutes ago
+    os.utime(old_slot, (old_mtime, old_mtime))
+
+    reaper = D.TokenReaper(
+        tokens_dir, D.GlobalCfg(),
+        expected_tokens=["--dispatch-id d_x"],
+    )
+    reaper.MALFORMED_GRACE_SEC = 60.0
+
+    # ssh_pid_alive should not be called for malformed dirs.
+    monkeypatch.setattr(D, "ssh_pid_alive",
+                        lambda *a, **kw: (None, "should not call"))
+
+    reaper._sweep()
+    # Slot 0 (fresh) survives; slot 1 (old) reclaimed
+    assert (tokens_dir / "0").exists()
+    assert not (tokens_dir / "1").exists()
+
+
+def test_poll_state_until_terminal_invokes_on_poll(tmp_path):
+    """Each poll iteration must fire on_poll(state) so callers can push
+    throttled HEARTBEAT events to the DB writer."""
+    nas_unit = tmp_path / "u"
+    nas_unit.mkdir()
+    state_path = nas_unit / "state.json"
+    state_path.write_text(json.dumps({
+        "run_id": 1, "phase": "running", "machine": "alpha",
+    }))
+    (nas_unit / "heartbeat").touch()
+
+    polls: list[dict] = []
+    g = D.GlobalCfg(
+        poll_interval_sec=0.05, state_appeared_timeout_sec=2,
+        heartbeat_stale_threshold_sec=300,
+    )
+    # Flip to terminal after a few polls so the test exits.
+    import threading as _th
+    def _flip():
+        state_path.write_text(json.dumps({
+            "run_id": 1, "phase": "done", "success": True,
+            "finished_at": "2026-01-01T00:00:00",
+        }))
+    _th.Timer(0.2, _flip).start()
+
+    def _on_poll(s):
+        polls.append(dict(s))
+
+    final = D.poll_state_until_terminal(
+        "alpha", nas_unit, g=g,
+        expected_tokens=["--run-id 1"],
+        on_poll=_on_poll,
+    )
+    assert final.get("success") is True
+    assert len(polls) >= 1
+    # Every entry in `polls` must be a state dict snapshot (has phase).
+    assert all("phase" in p for p in polls)
+
+
+def test_dry_run_does_not_mutate_db_via_reconcile(tmp_path):
+    """--dry-run must skip reconciliation so prior dispatch state is
+    not mutated by a read-only preview."""
+    db = DatabaseManager(tmp_path / "x.db")
+    # Seed a prior RUNNING dispatch with one stale RUNNING row that, in a
+    # non-dry-run, would be marked FAILED by reconciliation (no state
+    # file, no heartbeat).
+    _seed_dispatch(db, dispatch_id="d_old")
+    rid = _seed_run(db, dispatch_id="d_old")
+
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={"alpha": D.MachineCfg("alpha", "/raid/a", slots=1, nproc=1)},
+    )
+    obs_csv = tmp_path / "targets.csv"
+    obs_csv.write_text("source_name,array,sb_name,sgous_id,gous_id,mous_ids,Line group\n")
+    summary = D.run_dispatch(
+        base_dir=tmp_path,
+        publish_dir=tmp_path / "out",
+        cfg=cfg,
+        db_manager=db,
+        selection_filters=D.SelectionFilters(scales=[0, 5, 10, 15, 20]),
+        obs_csv=obs_csv,
+        data_dir=tmp_path,
+        dry_run=True,
+    )
+    assert summary["dry_run"] is True
+    # The prior RUNNING row must still be RUNNING.  In a non-dry-run we
+    # would have marked it FAILED.
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.RUNNING
+    assert (row.get("error_message") or "") == ""
+
+
+def test_gous_cleaner_uses_prior_dispatch_id_for_adopted(tmp_path, monkeypatch):
+    """An adopted (machine, gous) pair must be cleaned under
+    /raid/d_<prior_id>/..., NOT under the new dispatch's directory."""
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={"alpha": D.MachineCfg("alpha", "/raid/a", slots=1, nproc=1)},
+    )
+    s = D.SchedulerState(queue=[])
+    s.seen_pairs.add(("alpha", "G_OLD"))
+    s.pair_dispatch_id[("alpha", "G_OLD")] = "d_OLD_42"
+    s.success_run_ids[("alpha", "G_OLD")] = {7}
+    cleaner = D.GousCleaner(s, cfg, "d_NEW_99", D.GlobalCfg())
+
+    seen_cmds: list[str] = []
+
+    def fake_ssh(machine, cmd, timeout=30, capture=True):
+        seen_cmds.append(cmd)
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(D, "ssh_run", fake_ssh)
+    cleaner.force_run()
+    assert len(seen_cmds) == 1
+    cmd = seen_cmds[0]
+    # Must reference the PRIOR dispatch ID, not the new one.
+    assert "d_OLD_42" in cmd
+    assert "d_NEW_99" not in cmd
+    assert "input/G_OLD" in cmd
+    assert "work/runs/7" in cmd
+
+
+def test_gous_cleaner_iterates_seen_pairs(tmp_path, monkeypatch):
+    """Once a GOUS drains, the cleaner sees it via seen_pairs and SSHes
+    a cleanup."""
+    db = DatabaseManager(":memory:")
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={"alpha": D.MachineCfg("alpha", "/raid/a", slots=1, nproc=1)},
+    )
+    s = D.SchedulerState(queue=[])
+    s.seen_pairs.add(("alpha", "G42"))
+    # in_flight is empty (drained); no queued units of G42
+    cleaner = D.GousCleaner(s, cfg, "d_test", D.GlobalCfg())
+    calls: list[str] = []
+
+    def fake_ssh(machine, cmd, timeout=30, capture=True):
+        calls.append((machine, cmd))
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(D, "ssh_run", fake_ssh)
+    cleaner.force_run()
+    assert len(calls) == 1
+    machine, cmd = calls[0]
+    assert machine == "alpha"
+    assert "rm -rf" in cmd
+    assert "input/G42" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Manifest construction
+# ---------------------------------------------------------------------------
+
+def test_serialise_unit_round_trip():
+    u = ImagingUnit(
+        gous_uid="G", source_name="S", line_group="LG", spw_id="23",
+        params_id=7, vis_tm=["/nas/a.ms"], vis_sm=["/nas/b.ms"],
+        sdimage="/nas/tp.fits", spw_selection=["23"], field_selection=["S"],
+        datacolumn="data", mous_uids_tm=["X"], mous_uids_sm=["Y"],
+        mous_uids_tp=["Z"], ready=True,
+    )
+    d = D.serialise_unit(u)
+    assert d["vis_tm"] == ["/nas/a.ms"]
+    assert d["sdimage"] == "/nas/tp.fits"
+    assert d["spw_selection"] == ["23"]
+
+
+def test_union_inputs_for_gous_dedups():
+    u1 = ImagingUnit(
+        gous_uid="G", source_name="A", line_group=None, spw_id="23", params_id=1,
+        vis_tm=["/nas/x.ms"], vis_sm=["/nas/y.ms"],
+        sdimage="/nas/tp_A.fits", ready=True,
+    )
+    u2 = ImagingUnit(
+        gous_uid="G", source_name="B", line_group=None, spw_id="25", params_id=2,
+        vis_tm=["/nas/x.ms"], vis_sm=["/nas/y.ms"],   # same MSs
+        sdimage="/nas/tp_B.fits", ready=True,         # different TP
+    )
+    out = D.union_inputs_for_gous([u1, u2])
+    srcs = sorted(e["src"] for e in out)
+    assert srcs == sorted([
+        "/nas/x.ms", "/nas/y.ms",
+        "/nas/tp_A.fits", "/nas/tp_B.fits",
+    ])
+    bucket_for = {e["src"]: e["bucket"] for e in out}
+    assert bucket_for["/nas/x.ms"] == "ms"
+    assert bucket_for["/nas/tp_A.fits"] == "tp"
+
+
+def test_write_unit_manifest_round_trip(tmp_path):
+    u = ImagingUnit(
+        gous_uid="G", source_name="S", line_group=None,
+        spw_id="23", params_id=1,
+        vis_tm=["/nas/a.ms"], ready=True,
+    )
+    nas_unit_dir = tmp_path / "u1"
+    p = D.write_unit_manifest(
+        nas_unit_dir, unit=u,
+        expected_inputs=[{"src": "/nas/a.ms", "bucket": "ms"}],
+        publish_dir=tmp_path / "out",
+        nproc=4, casa_path=None,
+        deconvolver="multiscale", scales=[0, 5, 10],
+    )
+    payload = json.loads(p.read_text())
+    assert payload["unit"]["gous_uid"] == "G"
+    assert payload["expected_inputs"][0]["src"] == "/nas/a.ms"
+    assert payload["publish_dir"] == str(tmp_path / "out")
+    assert payload["nproc"] == 4
+
+
+# ---------------------------------------------------------------------------
+# write_launcher_script — exact shape, shlex-quoted
+# ---------------------------------------------------------------------------
+
+def test_write_launcher_script_quotes_paths(tmp_path):
+    cfg = D.MachinesConfig(
+        conda_env="/opt with space/conda",
+        repo_path="/r p/panta-rei",
+        casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={},
+    )
+    nas = tmp_path / "u1"
+    p = D.write_launcher_script(
+        nas, cfg,
+        raid_dir="/raid/d/foo bar",
+        manifest_path="/nas/m.json",
+        run_id=42, dispatch_id="d_x",
+        transfer_method="tar", publish_policy="fail_if_exists",
+        tokens_dir="/nas/tokens",
+        max_concurrent_staging=3,
+        heartbeat_interval=30,
+    )
+    text = p.read_text()
+    # Spaces are quoted; injected back-tick can't escape
+    assert "/opt with space/conda" not in text or "'/opt with space/conda'" in text
+    assert "panta_rei.imaging.remote_worker" in text
+    assert "--run-id 42" in text
+    assert "--dispatch-id d_x" in text
+    assert os.access(p, os.X_OK)
+    # Cache args ABSENT when not requested
+    assert "--cache-root" not in text
+    assert "--cache-min-free-gb" not in text
+
+
+def test_write_launcher_script_includes_cache_args(tmp_path):
+    cfg = D.MachinesConfig(
+        conda_env="/opt/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(), machines={},
+    )
+    p = D.write_launcher_script(
+        tmp_path / "u", cfg,
+        raid_dir="/raid/d", manifest_path="/nas/m.json",
+        run_id=1, dispatch_id="d",
+        transfer_method="tar", publish_policy="fail_if_exists",
+        tokens_dir="/t", max_concurrent_staging=2,
+        heartbeat_interval=30,
+        cache_root="/raid/cache",
+        cache_min_free_gb=512,
+    )
+    text = p.read_text()
+    assert "--cache-root /raid/cache" in text
+    assert "--cache-min-free-gb 512" in text
+
+
+def test_machines_config_cache_min_free_gb_default_and_override(tmp_path):
+    """Default cache_min_free_gb is 1024; per-host override is honored;
+    null disables cache."""
+    payload = {
+        "conda_env": "/c",
+        "repo_path": "/r",
+        "global": {"max_concurrent_staging": 2},
+        "machines": {
+            "default": {"raid": "/raid/d", "slots": 1, "nproc": 4},
+            "tight":   {"raid": "/raid/t", "slots": 1, "nproc": 4,
+                        "cache_min_free_gb": 256},
+            "off":     {"raid": "/raid/o", "slots": 1, "nproc": 4,
+                        "cache_min_free_gb": None},
+        },
+    }
+    p = tmp_path / "machines.json"
+    p.write_text(json.dumps(payload))
+    cfg = D.load_machines_config(p)
+    assert cfg.machines["default"].cache_min_free_gb == 1024
+    assert cfg.machines["tight"].cache_min_free_gb == 256
+    assert cfg.machines["off"].cache_min_free_gb is None
+
+
+# ---------------------------------------------------------------------------
+# ssh_pid_alive — distinguishes dead / alive / unreachable
+# ---------------------------------------------------------------------------
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_pid_alive_dead_returns_false(ssh_run):
+    ssh_run.return_value = mock.Mock(returncode=0, stdout="__DEAD__", stderr="")
+    alive, info = D.ssh_pid_alive("alpha", 12345, ["expected"])
+    assert alive is False
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_pid_alive_pid_reused_returns_false(ssh_run):
+    ssh_run.return_value = mock.Mock(
+        returncode=0,
+        stdout="/usr/bin/somethingelse",   # cmdline doesn't match
+        stderr="",
+    )
+    alive, info = D.ssh_pid_alive("alpha", 12345, ["expected-marker"])
+    assert alive is False
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_pid_alive_match_returns_true_unordered(ssh_run):
+    """Tokens may appear in any order in the cmdline."""
+    # Note: launcher emits --run-id BEFORE --dispatch-id; check that order.
+    ssh_run.return_value = mock.Mock(
+        returncode=0,
+        stdout=("python -m panta_rei.imaging.remote_worker "
+                "--manifest /n/m.json --raid-dir /raid "
+                "--run-id 42 --dispatch-id d_x ..."),
+        stderr="",
+    )
+    alive, info = D.ssh_pid_alive(
+        "alpha", 12345,
+        ["--dispatch-id d_x", "--run-id 42"],
+    )
+    assert alive is True
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_pid_alive_partial_match_returns_false(ssh_run):
+    """All tokens must be present; single match isn't enough."""
+    ssh_run.return_value = mock.Mock(
+        returncode=0,
+        stdout=("python -m panta_rei.imaging.remote_worker "
+                "--run-id 42 --dispatch-id d_other"),
+        stderr="",
+    )
+    alive, info = D.ssh_pid_alive(
+        "alpha", 12345,
+        ["--dispatch-id d_x", "--run-id 42"],
+    )
+    assert alive is False
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_pid_alive_unreachable_returns_none(ssh_run):
+    ssh_run.return_value = mock.Mock(returncode=255, stdout="", stderr="conn refused")
+    alive, info = D.ssh_pid_alive("alpha", 12345, ["expected"])
+    assert alive is None
+    assert "rc=" in info or "ssh" in info.lower()
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_preflight_parses_ok_json(ssh_run):
+    ssh_run.return_value = mock.Mock(
+        returncode=0,
+        stdout=('{"ok": true, "free_gb": 800, "raid_writable": true, '
+                '"nas_visible": true}'),
+        stderr="",
+    )
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={},
+    )
+    m = D.MachineCfg("alpha", "/raid/a", slots=1, nproc=4)
+    ok, details = D.ssh_preflight_machine(
+        "alpha", m, cfg,
+        required_gb=10, nas_check_path="/nas/marker",
+    )
+    assert ok is True
+    assert details["free_gb"] == 800
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_preflight_failure_returns_false(ssh_run):
+    ssh_run.return_value = mock.Mock(
+        returncode=1,
+        stdout='{"ok": false, "raid_error": "permission denied"}',
+        stderr="",
+    )
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={},
+    )
+    m = D.MachineCfg("alpha", "/raid/a", slots=1, nproc=4)
+    ok, details = D.ssh_preflight_machine("alpha", m, cfg)
+    assert ok is False
+    assert "permission denied" in str(details)
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_preflight_unparseable_returns_error(ssh_run):
+    ssh_run.return_value = mock.Mock(
+        returncode=0, stdout="not json", stderr="",
+    )
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={},
+    )
+    m = D.MachineCfg("alpha", "/raid/a", slots=1, nproc=4)
+    ok, details = D.ssh_preflight_machine("alpha", m, cfg)
+    assert ok is False
+    assert "could not parse" in str(details)
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_run")
+def test_ssh_pid_alive_uses_tr_with_space_replacement(ssh_run):
+    """The remote command must translate NUL→space, not delete NUL."""
+    ssh_run.return_value = mock.Mock(returncode=0, stdout="__DEAD__", stderr="")
+    D.ssh_pid_alive("alpha", 99, ["x"])
+    # Inspect the remote command passed to ssh_run
+    call_args = ssh_run.call_args
+    remote_cmd = call_args[0][1] if len(call_args[0]) > 1 else call_args.kwargs["remote_cmd"]
+    assert "tr '\\0' ' '" in remote_cmd
+    assert "tr -d '\\0'" not in remote_cmd
+
+
+def test_ssh_run_wraps_remote_command_in_bash(monkeypatch):
+    """Login shell on the cluster is tcsh; the remote command must be
+    forced through bash so redirections and ``!`` work."""
+    captured = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(D.subprocess, "run", fake_run)
+    D.ssh_run("alpha", "echo hi >log 2>&1")
+    argv = captured["argv"]
+    assert argv[0] == "ssh"
+    assert argv[-2] == "alpha"
+    wrapped = argv[-1]
+    # Outer command is shell-agnostic: echo <b64> | base64 -d | bash
+    assert wrapped.startswith("echo ")
+    assert "| base64 -d | bash" in wrapped
+    # Forbidden-in-tcsh tokens must NOT appear in the outer wrapper
+    assert ">log 2>&1" not in wrapped
+    assert "$!" not in wrapped
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation
+# ---------------------------------------------------------------------------
+
+def _seed_dispatch(db, dispatch_id="d_old"):
+    with db.connect() as con:
+        DispatchesQueries.insert(
+            con, dispatch_id=dispatch_id,
+            coordinator_host="h", coordinator_pid=42,
+            machines_json="{}", cli_args="",
+        )
+        con.commit()
+
+
+def _seed_run(db, dispatch_id="d_old", status=ImagingRunStatus.RUNNING):
+    with db.connect() as con:
+        rid = ImagingRunsQueries.insert_row(
+            con,
+            params_id=1, gous_uid="G", source_name="S",
+            line_group="LG", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=status,
+            dispatch_id=dispatch_id,
+        )
+        con.commit()
+    return rid
+
+
+def _state_dir(base_dir, dispatch_id, run_id):
+    d = base_dir / "imaging" / "dispatch" / dispatch_id / "units" / str(run_id)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def test_reconcile_terminal_state_applied(tmp_path):
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db)
+    rid = _seed_run(db)
+    sd = _state_dir(tmp_path, "d_old", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "done", "success": True,
+        "output_fits": "/nas/out.fits",
+        "finished_at": "2026-01-01T00:05:00",
+    }))
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=300)
+    D.reconcile_prior(db, tmp_path, g)
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.SUCCESS
+    assert row["output_fits"] == "/nas/out.fits"
+
+
+def test_reconcile_fresh_heartbeat_adopts(tmp_path):
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db)
+    rid = _seed_run(db)
+    sd = _state_dir(tmp_path, "d_old", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "running", "machine": "alpha",
+        "worker_pid": 99,
+    }))
+    (sd / "heartbeat").touch()
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=300)
+    adoptable = D.reconcile_prior(db, tmp_path, g)
+    assert any(a["run_id"] == rid for a in adoptable)
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    # Still RUNNING (adoption preserves state)
+    assert row["status"] == ImagingRunStatus.RUNNING
+
+
+def test_reconcile_normalises_fqdn_to_short_name(tmp_path):
+    """state.json stores ``socket.gethostname()`` (FQDN on these hosts);
+    adoptable[*]['machine'] must be the short name so it matches the
+    keys in machines.json — otherwise slot accounting and cleanup
+    mappings silently miss the adopted unit."""
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db)
+    rid = _seed_run(db)
+    sd = _state_dir(tmp_path, "d_old", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "running",
+        "machine": "host0.example.com",
+        "hostname": "host0.example.com",
+        "worker_pid": 99,
+    }))
+    (sd / "heartbeat").touch()
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=300)
+    adoptable = D.reconcile_prior(db, tmp_path, g)
+    assert len(adoptable) == 1
+    assert adoptable[0]["machine"] == "host0"
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_pid_alive",
+            return_value=(False, ""))
+def test_reconcile_stale_heartbeat_dead_pid_marks_failed(_ssh, tmp_path):
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db)
+    rid = _seed_run(db)
+    sd = _state_dir(tmp_path, "d_old", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "running", "machine": "alpha",
+        "worker_pid": 99,
+    }))
+    # No heartbeat file => infinite age → stale
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=10)
+    D.reconcile_prior(db, tmp_path, g)
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.FAILED
+    assert "abandoned" in (row["error_message"] or "")
+
+
+@mock.patch("panta_rei.imaging.dispatch.ssh_pid_alive",
+            return_value=(None, "ssh refused"))
+def test_reconcile_ssh_unreachable_does_not_mark_failed(_ssh, tmp_path):
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db)
+    rid = _seed_run(db)
+    sd = _state_dir(tmp_path, "d_old", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "running", "machine": "alpha",
+        "worker_pid": 99,
+    }))
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=10)
+    D.reconcile_prior(db, tmp_path, g)
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    # Still RUNNING — coordinator must not declare dead.
+    assert row["status"] == ImagingRunStatus.RUNNING
+
+
+def test_reconcile_abandon_prior_force_fails(tmp_path):
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db)
+    rid = _seed_run(db)
+    sd = _state_dir(tmp_path, "d_old", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "running", "machine": "alpha",
+        "worker_pid": 99,
+    }))
+    (sd / "heartbeat").touch()
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=300)
+    D.reconcile_prior(db, tmp_path, g, abandon=True)
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.FAILED
+
+
+def test_adoption_poller_applies_terminal_to_db(tmp_path, monkeypatch):
+    """An AdoptionPoller resumes polling an existing unit's state.json
+    and pushes its terminal result to the DB writer."""
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db, dispatch_id="d_old")
+    rid = _seed_run(db, dispatch_id="d_old")
+
+    sd = _state_dir(tmp_path, "d_old", rid)
+    state_file = sd / "state.json"
+    state_file.write_text(json.dumps({
+        "run_id": rid, "phase": "running",
+        "machine": "alpha", "worker_pid": 99,
+        "dispatch_id": "d_old", "gous_uid": "G",
+    }))
+    (sd / "heartbeat").touch()
+
+    # Worker "finishes" between polls — flip the file to terminal SUCCESS.
+    def _flip_to_done(*_a, **_kw):
+        state_file.write_text(json.dumps({
+            "run_id": rid, "phase": "done", "success": True,
+            "output_fits": "/nas/out.fits",
+            "finished_at": "2026-01-01T00:00:00",
+            "spw_selection": ["23"], "field_selection": ["S"],
+            "gous_uid": "G",
+        }))
+        (sd / "heartbeat").touch()
+
+    # First poll triggers the flip
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (True, "ok"))
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(
+            poll_interval_sec=0.1, state_appeared_timeout_sec=2,
+            heartbeat_stale_threshold_sec=300,
+        ),
+        machines={"alpha": D.MachineCfg("alpha", "/raid/a", slots=2, nproc=4)},
+    )
+    writer = D.DBWriter(db, "d_new")
+    writer.start()
+    _seed_dispatch(db, dispatch_id="d_new")
+    scheduler = D.SchedulerState(queue=[])
+    ctx = D.DispatchContext(
+        cfg=cfg, dispatch_id="d_new", dispatch_dir=tmp_path / "imaging" / "dispatch" / "d_new",
+        publish_dir=tmp_path / "out", tokens_dir=tmp_path / "tokens",
+        db_writer=writer, db_manager=db, scheduler=scheduler,
+        transfer_method="tar", publish_policy="fail_if_exists",
+        deconvolver="multiscale", scales=[0, 5, 10, 15, 20],
+        gous_inputs={},
+    )
+
+    # Schedule the flip so it happens AFTER the poller has picked up the file
+    import threading as _th
+    timer = _th.Timer(0.2, _flip_to_done)
+    timer.start()
+
+    poller = D.AdoptionPoller(
+        adopted={
+            "machine": "alpha", "run_id": rid,
+            "unit_dir": sd,
+            "state": {"dispatch_id": "d_old", "gous_uid": "G"},
+            "expected_tokens": ["--dispatch-id d_old", f"--run-id {rid}"],
+        },
+        ctx=ctx,
+    )
+    poller.start()
+    poller.join(timeout=5)
+    timer.cancel()
+    writer.stop(); writer.join(timeout=5)
+
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.SUCCESS
+    assert row["output_fits"] == "/nas/out.fits"
+    # Scheduler should have seen the (machine, gous) pair so the cleaner
+    # picks it up at end-of-run.
+    assert ("alpha", "G") in scheduler.seen_pairs
+
+
+def test_reconcile_db_row_without_state_file_marked_failed(tmp_path):
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db)
+    rid = _seed_run(db)
+    g = D.GlobalCfg()
+    # No state.json or unit dir at all
+    D.reconcile_prior(db, tmp_path, g)
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.FAILED
+    assert "no state.json" in (row["error_message"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Abandoned-dispatch cleanup helpers
+# ---------------------------------------------------------------------------
+
+def _write_lock(path: Path, host: str = "host_a.example.com", pid: int = 9999):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"host={host} pid={pid}\n")
+
+
+def test_release_stale_lock_removes_when_holder_dead(tmp_path, monkeypatch):
+    lock = tmp_path / ".dispatcher.lock"
+    _write_lock(lock)
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (False, ""))
+    released = D._release_stale_dispatcher_lock(lock, ["run_imaging_dispatch"])
+    assert released is True
+    assert not lock.exists()
+
+
+def test_release_stale_lock_preserved_when_holder_alive(tmp_path, monkeypatch):
+    lock = tmp_path / ".dispatcher.lock"
+    _write_lock(lock)
+    monkeypatch.setattr(
+        D, "ssh_pid_alive",
+        lambda *a, **kw: (True, "python -m panta_rei.cli.run_imaging_dispatch"),
+    )
+    released = D._release_stale_dispatcher_lock(lock, ["run_imaging_dispatch"])
+    assert released is False
+    assert lock.exists()
+
+
+def test_release_stale_lock_preserved_when_ssh_unreachable(tmp_path, monkeypatch):
+    lock = tmp_path / ".dispatcher.lock"
+    _write_lock(lock)
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (None, "ssh timeout"))
+    released = D._release_stale_dispatcher_lock(lock, ["run_imaging_dispatch"])
+    assert released is False
+    assert lock.exists()
+
+
+def test_release_stale_lock_strips_fqdn_to_short(tmp_path, monkeypatch):
+    lock = tmp_path / ".dispatcher.lock"
+    _write_lock(lock, host="host_a.example.com", pid=42)
+    seen_hosts: list[str] = []
+
+    def _fake(host, pid, tokens, timeout=8):
+        seen_hosts.append(host)
+        return (False, "")
+
+    monkeypatch.setattr(D, "ssh_pid_alive", _fake)
+    D._release_stale_dispatcher_lock(lock, ["run_imaging_dispatch"])
+    assert seen_hosts == ["host_a"]
+
+
+def test_release_stale_lock_missing_or_malformed_returns_false(tmp_path):
+    # Missing file
+    assert D._release_stale_dispatcher_lock(
+        tmp_path / "nope", ["run_imaging_dispatch"],
+    ) is False
+    # Malformed contents
+    bad = tmp_path / ".dispatcher.lock"
+    bad.write_text("garbage\n")
+    assert D._release_stale_dispatcher_lock(
+        bad, ["run_imaging_dispatch"],
+    ) is False
+    assert bad.exists()  # malformed → leave alone
+
+
+def _make_token(tokens_dir: Path, slot: str, host: str, pid: int):
+    d = tokens_dir / slot
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "host").write_text(host)
+    (d / "pid").write_text(str(pid))
+    (d / "holder").write_text(f"d_x/{slot}")
+    (d / "acquired_at").write_text("2026-04-30T14:43:00")
+    return d
+
+
+def test_sweep_tokens_once_reaps_dead_holders(tmp_path, monkeypatch):
+    tokens = tmp_path / "staging_tokens"
+    _make_token(tokens, "0", "host_b", 100)
+    _make_token(tokens, "1", "host_c", 200)
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (False, ""))
+    reaped = D._sweep_tokens_once(tokens, ["--dispatch-id d_x"])
+    assert reaped == 2
+    assert not (tokens / "0").exists()
+    assert not (tokens / "1").exists()
+
+
+def test_sweep_tokens_once_keeps_live_holders(tmp_path, monkeypatch):
+    tokens = tmp_path / "staging_tokens"
+    _make_token(tokens, "0", "host_b", 100)
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (True, "ok"))
+    reaped = D._sweep_tokens_once(tokens, ["--dispatch-id d_x"])
+    assert reaped == 0
+    assert (tokens / "0").exists()
+
+
+def test_sweep_tokens_once_missing_dir_returns_zero(tmp_path):
+    assert D._sweep_tokens_once(tmp_path / "no_such", []) == 0
+
+
+def test_cleanup_abandoned_dispatch_sshs_each_machine(tmp_path, monkeypatch):
+    """For each machine in machines_json, ssh `rm -rf <raid>/d_<id>/`."""
+    d_id = "d_xyz"
+    d_dir = tmp_path / "imaging" / "dispatch" / d_id
+    (d_dir / "staging_tokens").mkdir(parents=True)
+    machines_json = json.dumps({
+        "host_a": {"raid": "/raid/scratch/userA", "slots": 1, "nproc": 4},
+        "host_d":  {"raid": "/raid/data/userB",        "slots": 1, "nproc": 4},
+    })
+
+    calls: list[tuple[str, str]] = []
+
+    class _OK:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_ssh_run(machine, cmd, *, timeout=30, capture=True):
+        calls.append((machine, cmd))
+        return _OK()
+
+    monkeypatch.setattr(D, "ssh_run", _fake_ssh_run)
+    summary = D._cleanup_abandoned_dispatch(d_id, d_dir, machines_json)
+
+    assert sorted(c[0] for c in calls) == ["host_a", "host_d"]
+    host_a_cmd = next(c[1] for c in calls if c[0] == "host_a")
+    host_d_cmd = next(c[1] for c in calls if c[0] == "host_d")
+    assert "/raid/scratch/userA/d_d_xyz" in host_a_cmd
+    assert "/raid/data/userB/d_d_xyz" in host_d_cmd
+    assert host_a_cmd.startswith("rm -rf -- ")
+    assert sorted(summary["machines_swept"]) == ["host_a", "host_d"]
+    assert summary["machine_failures"] == {}
+
+
+def test_cleanup_abandoned_dispatch_ssh_failure_recorded_not_raised(
+    tmp_path, monkeypatch,
+):
+    d_id = "d_xyz"
+    d_dir = tmp_path / "imaging" / "dispatch" / d_id
+    d_dir.mkdir(parents=True)
+    machines_json = json.dumps({
+        "host_a": {"raid": "/raid/scratch/userA", "slots": 1, "nproc": 4},
+        "deadhost": {"raid": "/raid/x", "slots": 1, "nproc": 4},
+    })
+
+    class _OK:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake(machine, cmd, *, timeout=30, capture=True):
+        if machine == "deadhost":
+            import subprocess as _sp
+            raise _sp.TimeoutExpired(cmd=["ssh"], timeout=timeout)
+        return _OK()
+
+    monkeypatch.setattr(D, "ssh_run", _fake)
+    summary = D._cleanup_abandoned_dispatch(d_id, d_dir, machines_json)
+    assert summary["machines_swept"] == ["host_a"]
+    assert "deadhost" in summary["machine_failures"]
+
+
+def test_reconcile_abandon_prior_invokes_cleanup(tmp_path, monkeypatch):
+    """When reconcile_prior abandons a dispatch, it must call the
+    cleanup helper *and* try to release the dispatcher lock."""
+    db = DatabaseManager(tmp_path / "x.db")
+    machines_json = json.dumps({
+        "alpha": {"raid": "/raid/alpha", "slots": 1, "nproc": 4},
+    })
+    with db.connect() as con:
+        DispatchesQueries.insert(
+            con, dispatch_id="d_abandon",
+            coordinator_host="h", coordinator_pid=42,
+            machines_json=machines_json, cli_args="",
+        )
+        con.commit()
+    rid = _seed_run(db, dispatch_id="d_abandon")
+    sd = _state_dir(tmp_path, "d_abandon", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "staging", "machine": "alpha", "worker_pid": 99,
+    }))
+    (sd / "heartbeat").touch()
+
+    # Stale dispatcher lock pointing at a "dead" PID.
+    lock = tmp_path / "imaging" / "dispatch" / ".dispatcher.lock"
+    _write_lock(lock, host="oldhost", pid=12345)
+
+    cleanup_calls: list[str] = []
+    lock_release_calls: list[Path] = []
+
+    def _fake_cleanup(d_id, d_dir, mj, **kw):
+        cleanup_calls.append(d_id)
+        return {"tokens_reaped": 0, "machines_swept": [], "machine_failures": {}}
+
+    def _fake_release(p, *, expected_tokens, **kw):
+        lock_release_calls.append(p)
+        return True
+
+    monkeypatch.setattr(D, "_cleanup_abandoned_dispatch", _fake_cleanup)
+    monkeypatch.setattr(D, "_release_stale_dispatcher_lock", _fake_release)
+
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=300)
+    D.reconcile_prior(db, tmp_path, g, abandon=True)
+
+    assert cleanup_calls == ["d_abandon"]
+    assert len(lock_release_calls) == 1
+    assert lock_release_calls[0].name == ".dispatcher.lock"
+
+
+def test_reconcile_without_abandon_does_not_invoke_cleanup(tmp_path, monkeypatch):
+    """Plain --reconcile-only (no --abandon-prior) must NOT touch the
+    lock or run the per-host raid sweep, even for prior dispatches it
+    happens to mark DONE."""
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db, dispatch_id="d_done")
+    rid = _seed_run(db, dispatch_id="d_done")
+    sd = _state_dir(tmp_path, "d_done", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "done", "success": True,
+        "output_fits": "/nas/out.fits",
+    }))
+
+    cleanup_calls: list[str] = []
+    lock_release_calls: list[Path] = []
+
+    monkeypatch.setattr(
+        D, "_cleanup_abandoned_dispatch",
+        lambda *a, **kw: cleanup_calls.append(a[0]) or {},
+    )
+    def _fake_release_noabandon(p, *, expected_tokens, **kw):
+        lock_release_calls.append(p)
+        return True
+
+    monkeypatch.setattr(
+        D, "_release_stale_dispatcher_lock", _fake_release_noabandon,
+    )
+
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=300)
+    D.reconcile_prior(db, tmp_path, g, abandon=False)
+
+    assert cleanup_calls == []
+    assert lock_release_calls == []

--- a/tests/test_imaging_workflow.py
+++ b/tests/test_imaging_workflow.py
@@ -239,6 +239,60 @@ class TestJointImagingStep:
         reason = step.should_skip(imaging_ctx)
         assert reason is not None
 
+    def test_preflight_reports_units_independent_of_prior_success(
+        self, imaging_ctx, imaging_tree,
+    ):
+        """``--step preflight`` should report all matching ready/not-ready
+        units regardless of whether they have a successful run already.
+        Pre-fix, the shared selection helper applied success_exists()
+        and would shrink the preflight count."""
+        from panta_rei.db.models import (
+            ImagingParamsQueries, ImagingParamsStatus,
+            ImagingRunsQueries, ImagingRunStatus,
+        )
+        # Recover params first (gives us at least one params row).
+        recover_opts = ImagingOptions(
+            weblog_dir=imaging_tree["weblog_dir"],
+            obs_csv=imaging_tree["csv_path"],
+            step="recover",
+        )
+        RecoverParamsStep(recover_opts).run(imaging_ctx)
+
+        # Run preflight once to get the baseline counts.
+        baseline = JointImagingStep(ImagingOptions(
+            obs_csv=imaging_tree["csv_path"], step="preflight",
+        )).run(imaging_ctx)
+        assert baseline.success
+        baseline_processed = baseline.items_processed
+
+        # Inject a SUCCESS imaging_runs row for one of the params.
+        with imaging_ctx.db_manager.connect() as con:
+            params_rows = ImagingParamsQueries.get_all_recovered(con)
+            assert params_rows, "fixture should have produced recovered params"
+            pid = params_rows[0]["id"]
+            ImagingRunsQueries.insert_row(
+                con,
+                params_id=pid,
+                gous_uid=params_rows[0]["gous_uid"],
+                source_name=params_rows[0]["source_name"],
+                line_group=params_rows[0].get("line_group"),
+                spw_id=params_rows[0]["spw_id"],
+                started_at="2026-01-01T00:00:00",
+                status=ImagingRunStatus.SUCCESS,
+                method="tclean_feather",
+                deconvolver="multiscale",
+                scales="[0, 5, 10, 15, 20]",
+            )
+            con.commit()
+
+        # Re-run preflight; the count must be unchanged because preflight
+        # ignores prior successes.
+        after = JointImagingStep(ImagingOptions(
+            obs_csv=imaging_tree["csv_path"], step="preflight",
+        )).run(imaging_ctx)
+        assert after.success
+        assert after.items_processed == baseline_processed
+
 
 # ---------------------------------------------------------------------------
 # run_imaging orchestration

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -179,6 +179,50 @@ class TestBuildOutputPath:
         assert "group.uid___A001_X3833_X64b9.lp_nperetto" in str(p.parent)
 
 
+class TestBuildAuxOutputPath:
+    """Aux QA products inherit the 12m7m naming (they come from tclean,
+    not from feather), so their canonical paths sit alongside the
+    .pbcor.fits pair in the same group subdir."""
+
+    def test_each_kind(self):
+        from panta_rei.imaging.matching import build_aux_output_path
+        for kind in ("mask", "residual", "pb"):
+            p = build_aux_output_path(
+                Path("/out"),
+                "X3833_X64b9",
+                "AG231.7986-1.9684",
+                86e9, 87e9, kind,
+            )
+            assert p.name == (
+                "group.uid___A001_X3833_X64b9.lp_nperetto."
+                f"AG231.7986m1.9684.12m7m.86.0-87.0GHz.cube.{kind}.fits"
+            )
+            assert "group.uid___A001_X3833_X64b9.lp_nperetto" in str(p.parent)
+
+    def test_unknown_kind_rejected(self):
+        from panta_rei.imaging.matching import build_aux_output_path
+        with pytest.raises(ValueError, match="unknown aux product kind"):
+            build_aux_output_path(
+                Path("/out"), "X3833_X64b9", "AG231.7986-1.9684",
+                86e9, 87e9, "psf",
+            )
+
+    def test_lives_in_same_group_subdir_as_pbcor(self):
+        from panta_rei.imaging.matching import (
+            build_aux_output_path, build_tclean_only_output_path,
+        )
+        kw = dict(
+            output_dir=Path("/out"),
+            gous_id="X3833_X64b9",
+            source_name="AG231.7986-1.9684",
+            freq_min_hz=86e9,
+            freq_max_hz=87e9,
+        )
+        pbcor = build_tclean_only_output_path(**kw)
+        residual = build_aux_output_path(kind="residual", **kw)
+        assert residual.parent == pbcor.parent
+
+
 # ---------------------------------------------------------------------------
 # TP validation (requires astropy)
 # ---------------------------------------------------------------------------

--- a/tests/test_remote_worker.py
+++ b/tests/test_remote_worker.py
@@ -1,0 +1,104 @@
+"""Tests for panta_rei.imaging.remote_worker — non-CASA logic only."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from panta_rei.imaging import remote_worker as W
+
+
+def test_write_state_atomic_replaces_existing(tmp_path):
+    p = tmp_path / "state.json"
+    W.write_state_atomic(p, {"phase": "starting"})
+    W.write_state_atomic(p, {"phase": "running", "pid": 1234})
+    state = W.read_state(p)
+    assert state == {"phase": "running", "pid": 1234}
+    leftover = list(tmp_path.glob("state.json.tmp*"))
+    assert leftover == []
+
+
+def test_read_state_missing_returns_empty(tmp_path):
+    assert W.read_state(tmp_path / "nope.json") == {}
+
+
+def test_patch_unit_paths_remaps_to_raid(tmp_path):
+    gous_input = tmp_path / "gous"
+    (gous_input / "ms").mkdir(parents=True)
+    (gous_input / "tp").mkdir(parents=True)
+    unit = {
+        "vis_tm": ["/nas/a.ms", "/nas/b.ms"],
+        "vis_sm": ["/nas/c.ms"],
+        "sdimage": "/nas/tp_X.fits",
+    }
+    W._patch_unit_paths(unit, gous_input)
+    assert unit["vis_tm"] == [
+        str(gous_input / "ms" / "a.ms"),
+        str(gous_input / "ms" / "b.ms"),
+    ]
+    assert unit["vis_sm"] == [str(gous_input / "ms" / "c.ms")]
+    assert unit["sdimage"] == str(gous_input / "tp" / "tp_X.fits")
+
+
+def test_heartbeat_thread_touches_file(tmp_path):
+    hb_path = tmp_path / "hb"
+    hb = W._Heartbeat(hb_path, interval_sec=0.1)
+    hb.start()
+    try:
+        deadline = time.time() + 1.0
+        while time.time() < deadline:
+            if hb_path.exists() and time.time() - hb_path.stat().st_mtime < 0.5:
+                break
+            time.sleep(0.05)
+    finally:
+        hb.stop()
+    assert hb_path.exists()
+
+
+def test_copy_provenance_copies_present_files(tmp_path):
+    work_run = tmp_path / "work" / "runs" / "1"
+    work_run.mkdir(parents=True)
+    (work_run / "job.json").write_text(json.dumps({"k": "v"}))
+    (work_run / "result.json").write_text(json.dumps({"success": True}))
+    log_path = tmp_path / "logs" / "unit_1.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("hello")
+    nas_unit = tmp_path / "nas" / "u1"
+    out = W._copy_provenance_to_nas(work_run, log_path, nas_unit)
+    assert (nas_unit / "job.json").exists()
+    assert (nas_unit / "result.json").exists()
+    assert (nas_unit / "unit.log").exists()
+    assert out["job_json"] == str(nas_unit / "job.json")
+    assert out["log"] == str(nas_unit / "unit.log")
+
+
+def test_copy_provenance_handles_missing_optional(tmp_path):
+    work_run = tmp_path / "work" / "runs" / "2"
+    work_run.mkdir(parents=True)
+    # Only job.json present
+    (work_run / "job.json").write_text("{}")
+    log_path = tmp_path / "missing.log"
+    nas_unit = tmp_path / "nas" / "u2"
+    out = W._copy_provenance_to_nas(work_run, log_path, nas_unit)
+    assert out["job_json"] is not None
+    assert out["result_json"] is None
+    assert out["log"] is None
+
+
+def test_preflight_emits_json(tmp_path, capsys, monkeypatch):
+    raid = tmp_path / "raid"
+    nas = tmp_path / "nas-marker"
+    nas.write_text("ok")
+    rc = W.main([
+        "preflight", "--raid-dir", str(raid),
+        "--required-gb", "0",
+        "--nas-check-path", str(nas),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    parsed = json.loads(out.splitlines()[-1])
+    assert parsed["ok"] is True
+    assert parsed["raid_writable"] is True
+    assert parsed["nas_visible"] is True

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,6 +13,8 @@ from panta_rei.imaging.matching import ImagingUnit
 from panta_rei.imaging.runner import (
     FIXED_PARAMS,
     FIXED_TCLEAN_PARAMS,
+    _publish,
+    _publish_pair,
     build_sdintimaging_params,
     build_tclean_params,
     cleanup_intermediates,
@@ -663,3 +665,234 @@ class TestRunTcleanFeatherParallel:
         # Verify canonical FITS were published
         assert Path(output).exists()
         assert "fake feathered" in Path(output).read_text()
+
+    def test_subprocess_success_publishes_aux_products(self, basic_unit, tmp_path):
+        """When the CASA script reports aux_fits, the runner publishes
+        each alongside the canonical pair using the canonical aux paths
+        passed in the job spec."""
+        casa_path = tmp_path / "casa"
+        (casa_path / "bin").mkdir(parents=True)
+        (casa_path / "bin" / "mpicasa").touch()
+        (casa_path / "bin" / "casa").touch()
+
+        output_dir = tmp_path / "output"
+        observed_spec = {}
+
+        def fake_subprocess_run(cmd, **kwargs):
+            job_json = Path(cmd[-1])
+            spec = json.loads(job_json.read_text())
+            observed_spec.update(spec)
+            run_dir = Path(spec["run_dir"])
+
+            feathered_name = Path(spec["canonical_paths"]["feathered"]).name
+            tclean_name = Path(spec["canonical_paths"]["tclean_only"]).name
+            aux_paths = spec["canonical_paths"]["aux"]
+            (run_dir / feathered_name).write_text("F")
+            (run_dir / tclean_name).write_text("T")
+
+            aux_fits: dict[str, str] = {}
+            # Simulate CASA exporting all 3 aux products successfully
+            for kind, canonical in aux_paths.items():
+                local = run_dir / Path(canonical).name
+                local.write_text(f"AUX-{kind}")
+                aux_fits[kind] = str(local)
+
+            (run_dir / "result.json").write_text(json.dumps({
+                "success": True,
+                "feathered_fits": str(run_dir / feathered_name),
+                "tclean_fits": str(run_dir / tclean_name),
+                "aux_fits": aux_fits,
+                "error_message": None,
+            }))
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            return mock_result
+
+        with patch("panta_rei.imaging.runner.run_trusted_preflight", return_value=(True, "OK")), \
+             patch("panta_rei.imaging.runner.get_casa_version", return_value="6.6.6"), \
+             patch("subprocess.run", side_effect=fake_subprocess_run):
+            success, msg, output = run_tclean_feather_parallel(
+                unit=basic_unit,
+                output_dir=output_dir,
+                row_id=77,
+                nproc=4,
+                casa_path=str(casa_path),
+            )
+
+        assert success, msg
+        # job spec should advertise the 3 default aux products + canonical
+        # paths for each
+        assert observed_spec["aux_products"] == ["mask", "residual", "pb"]
+        for kind in ("mask", "residual", "pb"):
+            canonical = Path(observed_spec["canonical_paths"]["aux"][kind])
+            # Lives in same group subdir as the .pbcor.fits, named .cube.<kind>.fits
+            assert canonical.parent == Path(output).parent
+            assert canonical.name.endswith(f".cube.{kind}.fits")
+            assert "12m7m." in canonical.name and "12m7mTP" not in canonical.name
+            assert canonical.exists()
+            assert canonical.read_text() == f"AUX-{kind}"
+
+    def test_subprocess_success_aux_missing_does_not_fail(self, basic_unit, tmp_path):
+        """If the CASA script reports no aux_fits, the unit still
+        succeeds — aux is best-effort."""
+        casa_path = tmp_path / "casa"
+        (casa_path / "bin").mkdir(parents=True)
+        (casa_path / "bin" / "mpicasa").touch()
+        (casa_path / "bin" / "casa").touch()
+        output_dir = tmp_path / "output"
+
+        def fake_subprocess_run(cmd, **kwargs):
+            spec = json.loads(Path(cmd[-1]).read_text())
+            run_dir = Path(spec["run_dir"])
+            feathered_name = Path(spec["canonical_paths"]["feathered"]).name
+            tclean_name = Path(spec["canonical_paths"]["tclean_only"]).name
+            (run_dir / feathered_name).write_text("F")
+            (run_dir / tclean_name).write_text("T")
+            (run_dir / "result.json").write_text(json.dumps({
+                "success": True,
+                "feathered_fits": str(run_dir / feathered_name),
+                "tclean_fits": str(run_dir / tclean_name),
+                # No aux_fits key at all — older CASA scripts won't have it
+                "error_message": None,
+            }))
+            mr = MagicMock(); mr.returncode = 0
+            return mr
+
+        with patch("panta_rei.imaging.runner.run_trusted_preflight", return_value=(True, "OK")), \
+             patch("panta_rei.imaging.runner.get_casa_version", return_value="6.6.6"), \
+             patch("subprocess.run", side_effect=fake_subprocess_run):
+            success, msg, output = run_tclean_feather_parallel(
+                unit=basic_unit,
+                output_dir=output_dir,
+                row_id=78,
+                nproc=4,
+                casa_path=str(casa_path),
+            )
+        assert success, msg
+        assert Path(output).exists()
+        # No aux files published
+        for kind in ("mask", "residual", "pb"):
+            assert not list(Path(output).parent.glob(f"*.cube.{kind}.fits"))
+
+
+# ---------------------------------------------------------------------------
+# _publish + _publish_pair
+# ---------------------------------------------------------------------------
+
+class TestPublish:
+    def test_publish_overwrite_replaces_existing(self, tmp_path):
+        src = tmp_path / "src.fits"
+        src.write_text("new")
+        dst = tmp_path / "dst.fits"
+        dst.write_text("old")
+        _publish(str(src), str(dst), policy="overwrite")
+        assert dst.read_text() == "new"
+
+    def test_publish_fail_if_exists_raises(self, tmp_path):
+        src = tmp_path / "src.fits"
+        src.write_text("new")
+        dst = tmp_path / "dst.fits"
+        dst.write_text("old")
+        with pytest.raises(FileExistsError):
+            _publish(str(src), str(dst), policy="fail_if_exists")
+        # Pre-existing dst is untouched
+        assert dst.read_text() == "old"
+
+    def test_publish_fail_if_exists_succeeds_when_missing(self, tmp_path):
+        src = tmp_path / "src.fits"
+        src.write_text("new")
+        dst = tmp_path / "out" / "dst.fits"
+        _publish(str(src), str(dst), policy="fail_if_exists")
+        assert dst.read_text() == "new"
+
+
+class TestPublishPair:
+    def test_pair_both_succeed(self, tmp_path):
+        a_src = tmp_path / "a.fits"; a_src.write_text("A")
+        b_src = tmp_path / "b.fits"; b_src.write_text("B")
+        a_dst = tmp_path / "out" / "A.fits"
+        b_dst = tmp_path / "out" / "B.fits"
+        ok, msg = _publish_pair(
+            [(str(a_src), str(a_dst)), (str(b_src), str(b_dst))],
+            policy="fail_if_exists",
+        )
+        assert ok
+        assert a_dst.read_text() == "A"
+        assert b_dst.read_text() == "B"
+
+    def test_pair_second_fails_rolls_back_first(self, tmp_path):
+        """If the second publish fails, the first must be unlinked
+        so retries see a clean canonical area."""
+        a_src = tmp_path / "a.fits"; a_src.write_text("A")
+        b_src = tmp_path / "b.fits"; b_src.write_text("B")
+        a_dst = tmp_path / "out" / "A.fits"
+        b_dst = tmp_path / "out" / "B.fits"
+        b_dst.parent.mkdir(parents=True, exist_ok=True)
+        b_dst.write_text("preexisting")  # forces fail_if_exists to error
+
+        ok, msg = _publish_pair(
+            [(str(a_src), str(a_dst)), (str(b_src), str(b_dst))],
+            policy="fail_if_exists",
+        )
+        assert not ok
+        assert "rolled back 1" in msg
+        # First publish was rolled back
+        assert not a_dst.exists()
+        # Pre-existing second target is untouched
+        assert b_dst.read_text() == "preexisting"
+
+    def test_pair_first_fails_no_publishes(self, tmp_path):
+        a_src = tmp_path / "a.fits"; a_src.write_text("A")
+        b_src = tmp_path / "b.fits"; b_src.write_text("B")
+        a_dst = tmp_path / "out" / "A.fits"
+        b_dst = tmp_path / "out" / "B.fits"
+        a_dst.parent.mkdir(parents=True, exist_ok=True)
+        a_dst.write_text("preexisting")  # forces failure on first
+        ok, msg = _publish_pair(
+            [(str(a_src), str(a_dst)), (str(b_src), str(b_dst))],
+            policy="fail_if_exists",
+        )
+        assert not ok
+        assert not b_dst.exists()
+        assert a_dst.read_text() == "preexisting"
+
+    def test_pair_overwrite_rollback_restores_prior_canonical(self, tmp_path):
+        """Under policy=overwrite, a failed second publish must restore
+        the prior canonical FITS that the first publish replaced —
+        otherwise --re-run can permanently destroy existing data."""
+        a_src = tmp_path / "a.fits"; a_src.write_text("A_NEW")
+        a_dst = tmp_path / "out" / "A.fits"
+        a_dst.parent.mkdir(parents=True, exist_ok=True)
+        a_dst.write_text("A_PRIOR_CANONICAL")
+        # b_src does not exist, so the second _publish raises on copy
+        b_src = tmp_path / "ghost_b.fits"
+        b_dst = tmp_path / "out" / "B.fits"
+        b_dst.write_text("B_PRIOR_CANONICAL")
+
+        ok, msg = _publish_pair(
+            [(str(a_src), str(a_dst)), (str(b_src), str(b_dst))],
+            policy="overwrite",
+        )
+        assert not ok, msg
+        # Both prior canonicals must be intact
+        assert a_dst.read_text() == "A_PRIOR_CANONICAL"
+        assert b_dst.read_text() == "B_PRIOR_CANONICAL"
+        # No leftover backup files
+        assert not list(a_dst.parent.glob("*.bak.*"))
+
+    def test_pair_overwrite_success_drops_backups(self, tmp_path):
+        a_src = tmp_path / "a.fits"; a_src.write_text("A_NEW")
+        b_src = tmp_path / "b.fits"; b_src.write_text("B_NEW")
+        a_dst = tmp_path / "out" / "A.fits"
+        b_dst = tmp_path / "out" / "B.fits"
+        a_dst.parent.mkdir(parents=True, exist_ok=True)
+        a_dst.write_text("A_PRIOR")
+        b_dst.write_text("B_PRIOR")
+        ok, msg = _publish_pair(
+            [(str(a_src), str(a_dst)), (str(b_src), str(b_dst))],
+            policy="overwrite",
+        )
+        assert ok
+        assert a_dst.read_text() == "A_NEW"
+        assert b_dst.read_text() == "B_NEW"
+        assert not list(a_dst.parent.glob("*.bak.*"))

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,0 +1,1105 @@
+"""Tests for panta_rei.imaging.staging.
+
+Covers the correctness-critical paths:
+- stage_one() atomic temp+rename for tar / cp / rsync
+- read_manifest / atomic_write_json
+- mkdir-based stage lock (mutex blocks concurrent staging)
+- token acquire / release / list / contention
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from panta_rei.imaging import staging
+
+
+# ---------------------------------------------------------------------------
+# stage_one
+# ---------------------------------------------------------------------------
+
+def _fake_ms(parent: Path, name: str = "fake.ms", n_files: int = 5) -> Path:
+    """Create a CASA-MS-like directory: a dir of small files."""
+    ms = parent / name
+    ms.mkdir(parents=True)
+    for i in range(n_files):
+        (ms / f"table.dat.{i}").write_bytes(os.urandom(256))
+    (ms / "table.f0_TSM0").write_bytes(os.urandom(1024))
+    return ms
+
+
+@pytest.mark.parametrize("method", ["tar", "rsync", "cp"])
+def test_stage_one_atomic_temp_then_rename(tmp_path, method):
+    src = _fake_ms(tmp_path / "src")
+    dst_root = tmp_path / "dst"
+    final, source = staging.stage_one(str(src), dst_root, method=method, bucket="ms")
+    assert final == dst_root / "ms" / src.name
+    assert final.is_dir()
+    assert source == "nas_direct"
+    # All source files arrived
+    src_files = sorted(p.name for p in src.iterdir())
+    dst_files = sorted(p.name for p in final.iterdir())
+    assert src_files == dst_files
+    # No leftover .partial
+    assert not list((dst_root / "ms").glob(".*.partial"))
+
+
+def test_stage_one_idempotent(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    dst_root = tmp_path / "dst"
+    a, sa = staging.stage_one(str(src), dst_root, method="cp", bucket="ms")
+    mtime = a.stat().st_mtime
+    assert sa == "nas_direct"
+    # Second call returns the same path without re-copying
+    time.sleep(0.05)
+    b, sb = staging.stage_one(str(src), dst_root, method="cp", bucket="ms")
+    assert b == a
+    assert sb == "existing"
+    assert b.stat().st_mtime == mtime
+
+
+def test_stage_one_unknown_method(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    with pytest.raises(ValueError):
+        staging.stage_one(str(src), tmp_path / "dst", method="bogus")
+
+
+def test_stage_one_missing_source(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        staging.stage_one(str(tmp_path / "nope"), tmp_path / "dst", method="cp")
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers
+# ---------------------------------------------------------------------------
+
+def test_read_manifest_skeleton_when_missing(tmp_path):
+    m = staging.read_manifest(tmp_path / "nope.json")
+    assert m == {"version": 1, "expected": [], "completed": []}
+
+
+def test_atomic_write_json_replaces_existing(tmp_path):
+    p = tmp_path / "m.json"
+    staging.atomic_write_json(p, {"a": 1})
+    staging.atomic_write_json(p, {"a": 2, "b": 3})
+    m = staging.read_manifest(p)
+    assert m == {"a": 2, "b": 3}
+
+
+def test_atomic_write_json_no_orphan_temp(tmp_path):
+    p = tmp_path / "m.json"
+    staging.atomic_write_json(p, {"x": 1})
+    leftover = list(tmp_path.glob("m.json.tmp*"))
+    assert leftover == []
+
+
+# ---------------------------------------------------------------------------
+# Stage lock (mkdir mutex)
+# ---------------------------------------------------------------------------
+
+def test_stage_lock_recovers_from_dead_pid(tmp_path):
+    """A stale lock from a crashed holder is reclaimed instead of
+    spinning forever."""
+    gous_dir = tmp_path / "gous"
+    gous_dir.mkdir()
+    # Simulate a crashed holder: lock dir + holder.json with a PID that
+    # certainly does not exist (signal 0 raises ProcessLookupError).
+    lock_dir = gous_dir / ".stage.lock.d"
+    lock_dir.mkdir()
+    import json as _json
+    import socket as _sock
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(),
+        "pid": 2 ** 22,   # almost certainly unused
+    }))
+    # Sanity: it really is gone
+    import os
+    try:
+        os.kill(2 ** 22, 0)
+    except ProcessLookupError:
+        pass
+    else:
+        pytest.skip("PID 2^22 unexpectedly exists on this host")
+
+    # Acquire should NOT spin forever — it should detect dead holder + recover.
+    acquired = threading.Event()
+
+    def worker():
+        with staging.acquire_stage_lock(gous_dir, {"id": "new"}):
+            acquired.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    assert acquired.wait(timeout=5), "acquire never succeeded — likely deadlock"
+    t.join()
+
+
+def test_stage_lock_grace_does_not_steal_freshly_mkdird_lock(tmp_path):
+    """Window between mkdir and holder.json write must not be racy.
+
+    Simulates: lock dir exists with no holder.json, but a holder
+    publishes metadata within the grace window.  The contender must
+    NOT reclaim it.
+    """
+    gous_dir = tmp_path / "gous"
+    gous_dir.mkdir()
+    lock_dir = gous_dir / ".stage.lock.d"
+    lock_dir.mkdir()
+    # No holder.json yet — but a "writer" thread will publish one shortly.
+    import json as _json
+    import socket as _sock
+    publish_at = threading.Event()
+    finish = threading.Event()
+
+    def writer():
+        publish_at.wait(timeout=2)
+        # Write holder.json with this process's PID (alive).
+        meta = {"host": _sock.gethostname(), "pid": os.getpid()}
+        (lock_dir / "holder.json").write_text(_json.dumps(meta))
+        finish.set()
+
+    wt = threading.Thread(target=writer)
+    wt.start()
+    # Give the contender up to 2.5s grace; release the writer at 0.5s.
+    timer = threading.Timer(0.5, publish_at.set)
+    timer.start()
+
+    # Contender attempts to acquire — its grace period (default 3s)
+    # should observe the holder.json that arrives at t=0.5s.
+    second_acquired = threading.Event()
+
+    def contender():
+        try:
+            with staging.acquire_stage_lock(gous_dir, {"id": "c"}):
+                second_acquired.set()
+        finally:
+            pass
+
+    ct = threading.Thread(target=contender)
+    ct.start()
+
+    # The writer's holder.json is published; its PID is alive (us).  The
+    # contender should NOT acquire while we hold metadata "live".
+    finish.wait(timeout=2)
+    # Give a bit more time then verify: contender did NOT acquire.
+    assert not second_acquired.wait(timeout=1.0), (
+        "contender stole a lock whose holder.json arrived within grace"
+    )
+    # Now remove the holder.json so the contender can finally claim it.
+    (lock_dir / "holder.json").unlink()
+    # Eventually the contender's grace expires and it reclaims.
+    assert second_acquired.wait(timeout=10)
+    timer.cancel()
+    wt.join(); ct.join()
+
+
+def test_stage_lock_recovers_from_missing_holder_metadata(tmp_path):
+    """Lock dir without holder.json is treated as stale."""
+    gous_dir = tmp_path / "gous"
+    gous_dir.mkdir()
+    (gous_dir / ".stage.lock.d").mkdir()  # no holder.json
+    acquired = threading.Event()
+
+    def worker():
+        with staging.acquire_stage_lock(gous_dir, {"id": "new"}):
+            acquired.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    assert acquired.wait(timeout=5)
+    t.join()
+
+
+def test_stage_lock_blocks_concurrent_holder(tmp_path):
+    gous_dir = tmp_path / "gous"
+    gous_dir.mkdir()
+    held = threading.Event()
+    release = threading.Event()
+    second_acquired = threading.Event()
+
+    def worker_a():
+        with staging.acquire_stage_lock(gous_dir, {"id": "a"}):
+            held.set()
+            release.wait(timeout=5)
+
+    def worker_b():
+        held.wait(timeout=5)
+        with staging.acquire_stage_lock(gous_dir, {"id": "b"}):
+            second_acquired.set()
+
+    ta = threading.Thread(target=worker_a)
+    tb = threading.Thread(target=worker_b)
+    ta.start()
+    tb.start()
+    held.wait(timeout=5)
+    # B should be blocked because A holds the lock
+    assert not second_acquired.wait(timeout=0.5)
+    # Release A; B should then acquire.
+    release.set()
+    assert second_acquired.wait(timeout=5)
+    ta.join(); tb.join()
+
+
+# ---------------------------------------------------------------------------
+# Staging tokens
+# ---------------------------------------------------------------------------
+
+def test_token_acquire_release_atomic(tmp_path):
+    tok = tmp_path / "tokens"
+    i = staging.acquire_staging_token(tok, n_slots=2, holder_id="x")
+    assert i in (0, 1)
+    held = staging.list_held_tokens(tok)
+    assert len(held) == 1
+    assert held[0]["pid"] == os.getpid()
+    staging.release_staging_token(tok, i)
+    assert staging.list_held_tokens(tok) == []
+
+
+def test_token_pool_full_blocks(tmp_path):
+    tok = tmp_path / "tokens"
+    i0 = staging.acquire_staging_token(tok, n_slots=1, holder_id="a")
+    with pytest.raises(TimeoutError):
+        staging.acquire_staging_token(
+            tok, n_slots=1, holder_id="b",
+            poll_sleep=(0.05, 0.1), timeout_sec=0.5,
+        )
+    staging.release_staging_token(tok, i0)
+    # Now it should succeed
+    i1 = staging.acquire_staging_token(
+        tok, n_slots=1, holder_id="b",
+        poll_sleep=(0.05, 0.1), timeout_sec=2,
+    )
+    assert i1 == 0
+    staging.release_staging_token(tok, i1)
+
+
+def test_release_idempotent(tmp_path):
+    tok = tmp_path / "tokens"
+    i = staging.acquire_staging_token(tok, n_slots=2, holder_id="x")
+    staging.release_staging_token(tok, i)
+    # Second release is a no-op (no exception)
+    staging.release_staging_token(tok, i)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_workdir
+# ---------------------------------------------------------------------------
+
+def test_cleanup_workdir_recursive(tmp_path):
+    work = tmp_path / "work"
+    (work / "a" / "b").mkdir(parents=True)
+    (work / "a" / "b" / "c.bin").write_bytes(b"x")
+    staging.cleanup_workdir(work)
+    assert not work.exists()
+
+
+def test_cleanup_workdir_missing_ok(tmp_path):
+    staging.cleanup_workdir(tmp_path / "ghost")  # no exception
+
+
+# ---------------------------------------------------------------------------
+# Cross-dispatch staging cache
+# ---------------------------------------------------------------------------
+
+def test_cache_key_stable_and_includes_basename(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    k1 = staging._cache_key(src)
+    k2 = staging._cache_key(src)
+    assert k1 == k2
+    assert k1.startswith(src.name + ".")
+    # Two MSs with same basename but different paths produce distinct keys
+    src2 = _fake_ms(tmp_path / "other")
+    assert staging._cache_key(src2) != k1
+
+
+def test_compute_fingerprint_uses_recursive_size(tmp_path):
+    src = _fake_ms(tmp_path / "src", n_files=5)
+    fp = staging._compute_fingerprint(src)
+    assert fp["size_bytes"] > 1024  # 5 × 256 + 1024 at minimum
+    assert isinstance(fp["mtime_ns"], int)
+    # st_size of the directory (not recursive) is far smaller
+    import os as _os
+    assert fp["size_bytes"] != _os.stat(src).st_size
+
+
+def test_compute_fingerprint_v2_includes_tree_sig(tmp_path):
+    """Regression: v2 fingerprint MUST carry version + tree_sig.
+    Without these, v1 sidecars from before the fix would be trusted."""
+    src = _fake_ms(tmp_path / "src")
+    fp = staging._compute_fingerprint(src)
+    assert fp["version"] == staging._FINGERPRINT_VERSION == 2
+    assert isinstance(fp["tree_sig"], str)
+    assert len(fp["tree_sig"]) == 64  # sha256 hex
+
+
+def _fake_ms_with_subtables(parent, name="fake.ms"):
+    """Realistic CASA-table-shaped fake — root files + subtables."""
+    import os as _os
+    ms = parent / name
+    ms.mkdir(parents=True)
+    (ms / "table.dat").write_bytes(b"R" * 1024)
+    (ms / "table.f0_TSM0").write_bytes(b"r" * 4096)
+    for sub in ("FIELD", "SPECTRAL_WINDOW", "DATA_DESCRIPTION"):
+        (ms / sub).mkdir()
+        (ms / sub / "table.dat").write_bytes(bytes([0x55]) * 512)
+    return ms
+
+
+def _restore_root_mtime_ns(path, ns):
+    import os as _os
+    _os.utime(path, ns=(ns, ns))
+
+
+def test_tree_sig_stable_for_same_tree(tmp_path):
+    src = _fake_ms_with_subtables(tmp_path / "src")
+    a = staging._compute_tree_sig(src)
+    b = staging._compute_tree_sig(src)
+    assert a == b
+
+
+def test_tree_sig_detects_root_file_in_place_rewrite(tmp_path):
+    """Scenario A: rewrite ``table.dat`` content same-size, restore root
+    mtime. Under v1 fingerprint this was a stale-hit; tree_sig must
+    distinguish."""
+    src = _fake_ms_with_subtables(tmp_path / "src")
+    sig_before = staging._compute_tree_sig(src)
+    saved = src.stat().st_mtime_ns
+    target = src / "table.dat"
+    new = bytes([(b + 17) & 0xFF for b in target.read_bytes()])
+    target.write_bytes(new)
+    _restore_root_mtime_ns(src, saved)
+    sig_after = staging._compute_tree_sig(src)
+    assert sig_before != sig_after
+
+
+def test_tree_sig_detects_nested_in_place_rewrite(tmp_path):
+    """Scenario B: rewrite a subtable file same-size, restore root mtime."""
+    src = _fake_ms_with_subtables(tmp_path / "src")
+    sig_before = staging._compute_tree_sig(src)
+    saved = src.stat().st_mtime_ns
+    target = src / "SPECTRAL_WINDOW" / "table.dat"
+    new = bytes([(b + 7) & 0xFF for b in target.read_bytes()])
+    target.write_bytes(new)
+    _restore_root_mtime_ns(src, saved)
+    sig_after = staging._compute_tree_sig(src)
+    assert sig_before != sig_after
+
+
+def test_tree_sig_detects_nested_temp_rename(tmp_path):
+    """Scenario C: temp+rename a subtable file same-size."""
+    src = _fake_ms_with_subtables(tmp_path / "src")
+    sig_before = staging._compute_tree_sig(src)
+    saved = src.stat().st_mtime_ns
+    target = src / "SPECTRAL_WINDOW" / "table.dat"
+    sz = target.stat().st_size
+    tmp = target.parent / ".table.dat.tmp"
+    tmp.write_bytes(b"X" * sz)
+    import os as _os
+    _os.replace(str(tmp), str(target))
+    _restore_root_mtime_ns(src, saved)
+    sig_after = staging._compute_tree_sig(src)
+    assert sig_before != sig_after
+
+
+def test_tree_sig_detects_symlink_retarget(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    target_a = tmp_path / "a.txt"
+    target_a.write_bytes(b"a")
+    target_b = tmp_path / "b.txt"
+    target_b.write_bytes(b"b")
+    (src / "link").symlink_to(target_a)
+    sig_a = staging._compute_tree_sig(src)
+    (src / "link").unlink()
+    (src / "link").symlink_to(target_b)
+    sig_b = staging._compute_tree_sig(src)
+    assert sig_a != sig_b
+
+
+def test_tree_sig_resolves_symlink_root(tmp_path):
+    """Regression: if *src_path* is a symlink to a real MS dir, the
+    fingerprint must follow the link and reflect the TARGET's contents.
+    Otherwise tar/cp/rsync (which dereference leaf symlinks) would
+    stage fresh data while the fingerprint stayed pinned to the link
+    itself — perfect stale-cache vector."""
+    real = _fake_ms_with_subtables(tmp_path / "real")
+    link = tmp_path / "link.ms"
+    link.symlink_to(real)
+    sig_via_link = staging._compute_tree_sig(link)
+    sig_direct = staging._compute_tree_sig(real)
+    assert sig_via_link == sig_direct
+    # Mutate the target through the real path; sig via link must change.
+    saved = real.stat().st_mtime_ns
+    target = real / "SPECTRAL_WINDOW" / "table.dat"
+    target.write_bytes(b"Y" * target.stat().st_size)
+    _restore_root_mtime_ns(real, saved)
+    sig_after = staging._compute_tree_sig(link)
+    assert sig_via_link != sig_after
+
+
+def test_compute_fingerprint_resolves_symlink_root(tmp_path):
+    """Same pattern, end-to-end through ``_compute_fingerprint``."""
+    real = _fake_ms_with_subtables(tmp_path / "real")
+    link = tmp_path / "link.ms"
+    link.symlink_to(real)
+    fp_via_link = staging._compute_fingerprint(link)
+    fp_direct = staging._compute_fingerprint(real)
+    assert fp_via_link == fp_direct
+    assert fp_via_link["size_bytes"] > 1024  # not the symlink's tiny size
+
+
+def test_stage_one_symlink_root_hit_then_mutate_misses(tmp_path):
+    """Belt-and-braces end-to-end: ``stage_one(link) → cache_miss``,
+    ``stage_one(link)`` again → ``cache_hit``, mutate the real target's
+    inner file, ``stage_one(link)`` → ``cache_miss`` (NOT stale)."""
+    real = _fake_ms_with_subtables(tmp_path / "real")
+    link = tmp_path / "link.ms"
+    link.symlink_to(real)
+    cache = tmp_path / "cache"
+
+    # First stage via link → populate
+    _, source = staging.stage_one(
+        str(link), tmp_path / "dst1", method="cp", bucket="ms",
+        cache_root=cache,
+    )
+    assert source == "cache_miss"
+
+    # Second stage via link → hit
+    _, source2 = staging.stage_one(
+        str(link), tmp_path / "dst2", method="cp", bucket="ms",
+        cache_root=cache,
+    )
+    assert source2 == "cache_hit"
+
+    # Mutate the REAL target's inner file in place; restore root mtime.
+    saved = real.stat().st_mtime_ns
+    target = real / "SPECTRAL_WINDOW" / "table.dat"
+    target.write_bytes(b"M" * target.stat().st_size)
+    _restore_root_mtime_ns(real, saved)
+
+    # Stage via link again — must NOT trust the cache.
+    _, source3 = staging.stage_one(
+        str(link), tmp_path / "dst3", method="cp", bucket="ms",
+        cache_root=cache,
+    )
+    assert source3 == "cache_miss"
+
+
+def test_tree_sig_for_file_root(tmp_path):
+    """TP FITS file: tree_sig is the file's own (size, mtime_ns, ctime_ns)."""
+    f = tmp_path / "tp.fits"
+    f.write_bytes(b"X" * 1024)
+    s1 = staging._compute_tree_sig(f)
+    # Sleep to guarantee a different ns timestamp on the rewrite —
+    # without this the two writes can land in the same nanosecond on
+    # fast filesystems and the test becomes flaky under load.
+    time.sleep(0.005)
+    f.write_bytes(b"Y" * 1024)  # same size, different content
+    s2 = staging._compute_tree_sig(f)
+    assert s1 != s2
+
+
+def test_cache_lookup_rejects_v1_sidecar(tmp_path):
+    """Regression: a sidecar without ``version=2`` and ``tree_sig`` must
+    be treated as a miss.  This prevents v1 cache entries (from before
+    this commit) from being trusted."""
+    src = _fake_ms_with_subtables(tmp_path / "src")
+    cache = tmp_path / "cache"
+    # Simulate a v1 sidecar manually
+    entry = cache / staging._cache_key(src)
+    entry.mkdir(parents=True)
+    import shutil as _sh
+    _sh.copytree(src, entry / src.name)
+    fp_v1 = {"mtime_ns": src.stat().st_mtime_ns,
+             "size_bytes": staging._du_bytes(src)}
+    import json as _json
+    (entry / ".cache.json").write_text(_json.dumps({
+        "src_path": str(src.resolve()),
+        "mtime_ns": fp_v1["mtime_ns"],
+        "size_bytes": fp_v1["size_bytes"],
+        "staged_at": "2026-01-01T00:00:00",
+        # NOTE: no version, no tree_sig — this is a v1 sidecar
+    }))
+    # cache_lookup must treat this as a miss
+    assert staging.cache_lookup(cache, src) is None
+
+
+def test_cache_lookup_v2_sidecar_with_tree_sig_hits(tmp_path):
+    src = _fake_ms_with_subtables(tmp_path / "src")
+    cache = tmp_path / "cache"
+    final, source = staging.stage_one(
+        str(src), tmp_path / "dst1", method="cp", bucket="ms",
+        cache_root=cache,
+    )
+    assert source == "cache_miss"
+    # Sidecar must be v2 with tree_sig
+    import json as _json
+    side = _json.loads(
+        (cache / staging._cache_key(src) / ".cache.json").read_text()
+    )
+    assert side["version"] == 2
+    assert "tree_sig" in side and len(side["tree_sig"]) == 64
+    # Second stage_one hits
+    _, source2 = staging.stage_one(
+        str(src), tmp_path / "dst2", method="cp", bucket="ms",
+        cache_root=cache,
+    )
+    assert source2 == "cache_hit"
+
+
+def test_cache_miss_on_inner_file_rewrite(tmp_path):
+    """End-to-end: in-place rewrite of an inner file (with root mtime
+    restored) must produce a cache miss after the fix.  This is the
+    bug scenario from `scripts/test_cache_invalidation.py` that the
+    v1 fingerprint silently served."""
+    src = _fake_ms_with_subtables(tmp_path / "src")
+    cache = tmp_path / "cache"
+    # Populate
+    staging.stage_one(str(src), tmp_path / "dst1", method="cp",
+                      bucket="ms", cache_root=cache)
+    # Mutate an inner file in place; restore root mtime
+    saved = src.stat().st_mtime_ns
+    target = src / "SPECTRAL_WINDOW" / "table.dat"
+    new = bytes([(b + 7) & 0xFF for b in target.read_bytes()])
+    target.write_bytes(new)
+    _restore_root_mtime_ns(src, saved)
+    # Lookup — must NOT trust the cache
+    assert staging.cache_lookup(cache, src) is None
+    # Restage triggers repopulate, sidecar updates with new tree_sig
+    _, source = staging.stage_one(
+        str(src), tmp_path / "dst2", method="cp", bucket="ms",
+        cache_root=cache,
+    )
+    assert source == "cache_miss"
+
+
+def test_cache_lookup_miss_when_no_entry(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    assert staging.cache_lookup(cache, src) is None
+
+
+def test_cache_populate_then_hit(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    dst1 = tmp_path / "dst1"
+    dst2 = tmp_path / "dst2"
+
+    final, source = staging.stage_one(
+        str(src), dst1, method="cp", bucket="ms", cache_root=cache,
+    )
+    assert source == "cache_miss"
+    assert final.is_dir()
+    # Sidecar and entry exist
+    entry = cache / staging._cache_key(src)
+    assert (entry / ".cache.json").exists()
+    assert (entry / src.name).is_dir()
+    # Files inside the cache entry are 0o444 (canary against unexpected writes)
+    sample_file = next((entry / src.name).iterdir())
+    assert sample_file.stat().st_mode & 0o777 == 0o444
+
+    # Second stage to a different dst hits the cache
+    final2, source2 = staging.stage_one(
+        str(src), dst2, method="cp", bucket="ms", cache_root=cache,
+    )
+    assert source2 == "cache_hit"
+    # Hard-linked: same inode as the cache entry
+    cached_file = next((entry / src.name).iterdir())
+    dst_file = dst2 / "ms" / src.name / cached_file.name
+    assert dst_file.stat().st_ino == cached_file.stat().st_ino
+
+
+def test_cache_miss_on_mtime_change(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    dst1 = tmp_path / "dst1"
+    dst2 = tmp_path / "dst2"
+
+    staging.stage_one(str(src), dst1, method="cp", bucket="ms", cache_root=cache)
+
+    # Bump src mtime by touching an inner file (recursive du size unchanged but
+    # mtime fingerprint should detect the regen).  Use a force-different mtime.
+    import os as _os
+    new_t = _os.stat(src).st_mtime + 60
+    _os.utime(src, (new_t, new_t))
+
+    _, source = staging.stage_one(
+        str(src), dst2, method="cp", bucket="ms", cache_root=cache,
+    )
+    # mtime mismatch → cache miss → repopulate
+    assert source == "cache_miss"
+
+
+def test_cache_miss_on_size_change(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    dst1 = tmp_path / "dst1"
+    dst2 = tmp_path / "dst2"
+
+    staging.stage_one(str(src), dst1, method="cp", bucket="ms", cache_root=cache)
+
+    # Tamper with the sidecar's size_bytes to simulate a stale fingerprint.
+    import json as _json
+    side_path = cache / staging._cache_key(src) / ".cache.json"
+    side = _json.loads(side_path.read_text())
+    side["size_bytes"] = side["size_bytes"] - 1
+    side_path.write_text(_json.dumps(side))
+
+    _, source = staging.stage_one(
+        str(src), dst2, method="cp", bucket="ms", cache_root=cache,
+    )
+    assert source == "cache_miss"
+
+
+def test_cache_populating_marker_treated_as_miss(tmp_path):
+    """A cache entry mid-populate (``.populating`` present) must be a miss."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    dst = tmp_path / "dst"
+    staging.stage_one(str(src), dst, method="cp", bucket="ms", cache_root=cache)
+
+    # Manually drop a .populating dir back in
+    entry = cache / staging._cache_key(src)
+    (entry / ".populating").mkdir()
+    assert staging.cache_lookup(cache, src) is None
+    # Cleanup so other tests aren't affected
+    (entry / ".populating").rmdir()
+
+
+def test_cache_evict_until_free(tmp_path, monkeypatch):
+    src1 = _fake_ms(tmp_path / "src1", name="ms1.ms")
+    src2 = _fake_ms(tmp_path / "src2", name="ms2.ms")
+    cache = tmp_path / "cache"
+
+    # Populate two entries with different staged_at timestamps
+    staging.stage_one(str(src1), tmp_path / "dst1", method="cp",
+                      bucket="ms", cache_root=cache)
+    # Force the first entry to look "older" by rewriting its sidecar
+    import json as _json
+    e1 = cache / staging._cache_key(src1)
+    s1 = _json.loads((e1 / ".cache.json").read_text())
+    s1["staged_at"] = "2020-01-01T00:00:00"
+    (e1 / ".cache.json").write_text(_json.dumps(s1))
+
+    staging.stage_one(str(src2), tmp_path / "dst2", method="cp",
+                      bucket="ms", cache_root=cache)
+
+    # Pretend free space is below target so eviction kicks in.
+    # First call: pretend zero free → must evict at least one.
+    calls = {"n": 0}
+    real_free = staging._du_free_bytes
+    def _fake_free(_root):
+        calls["n"] += 1
+        # First two calls report tight; later calls report plenty.
+        if calls["n"] <= 2:
+            return 0
+        return real_free(_root)
+    monkeypatch.setattr(staging, "_du_free_bytes", _fake_free)
+    n = staging.cache_evict_until_free(cache, target_free_bytes=1)
+
+    assert n >= 1
+    assert not e1.exists()  # oldest evicted first
+
+
+def test_cache_evict_skips_populating(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    staging.stage_one(str(src), tmp_path / "dst", method="cp",
+                      bucket="ms", cache_root=cache)
+
+    entry = cache / staging._cache_key(src)
+    (entry / ".populating").mkdir()
+    try:
+        # Even with eviction pressure, an entry mid-populate is preserved
+        n = staging.cache_evict_until_free(
+            cache, target_free_bytes=10 ** 18,  # impossibly large → would evict everything
+            skip_keys=set(),
+        )
+        assert entry.exists()
+        # n could be 0 (only the .gc.lock.d isn't a candidate) or include
+        # malformed entries, but the populating one survives.
+    finally:
+        (entry / ".populating").rmdir()
+
+
+def test_acquire_cache_populate_returns_handle(tmp_path):
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    outcome, lock = staging.acquire_cache_populate(cache, src, timeout_sec=5)
+    assert outcome == "populate"
+    assert lock is not None
+    populating = cache / staging._cache_key(src) / ".populating"
+    assert populating.exists()
+    with lock:
+        pass  # release on exit
+    assert not populating.exists()
+
+
+def test_acquire_cache_populate_returns_hit_when_already_cached(tmp_path):
+    """If another worker beat us, the call sees an existing valid entry
+    via the post-mkdir cache_lookup probe and returns ``hit``."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    # Pre-populate the cache so the next acquire_cache_populate sees the
+    # entry as valid before it even attempts mkdir of .populating.  We
+    # simulate the populator already having released by manually dropping
+    # an entry + sidecar in.
+    fp = staging._compute_fingerprint(src)
+    entry = cache / staging._cache_key(src)
+    entry.mkdir(parents=True)
+    import shutil as _sh
+    _sh.copytree(src, entry / src.name)
+    staging._write_sidecar_atomic(entry, src, fp)
+    # Hold the populating lock externally so the new caller cannot become
+    # the populator and instead sees the populated cache via the
+    # post-mkdir lookup.
+    populating = entry / ".populating"
+    populating.mkdir()
+    try:
+        outcome, lock = staging.acquire_cache_populate(
+            cache, src, timeout_sec=2, poll_sleep=(0.01, 0.02),
+        )
+    finally:
+        # Release the externally-held .populating
+        import shutil as _sh2
+        _sh2.rmtree(populating, ignore_errors=True)
+    # The lookup happens BEFORE we held .populating, so the second caller
+    # should see the valid cache and return "hit" without becoming
+    # populator.  (If it timed out instead, that's also a valid mode but
+    # we'd want the test to see the happy path; assert hit OR populate.)
+    assert outcome in ("hit", "populate")
+
+
+# ---------------------------------------------------------------------------
+# TokenLease (lazy NAS gate)
+# ---------------------------------------------------------------------------
+
+def test_token_lease_acquires_only_on_demand(tmp_path):
+    tokens = tmp_path / "tokens"
+    lease = staging.TokenLease(tokens, n_slots=2, holder_id="test/1")
+    # No tokens acquired yet
+    assert staging.list_held_tokens(tokens) == []
+    lease.acquire_if_needed()
+    assert len(staging.list_held_tokens(tokens)) == 1
+    # Idempotent — second call doesn't acquire another
+    lease.acquire_if_needed()
+    assert len(staging.list_held_tokens(tokens)) == 1
+    lease.release()
+    assert staging.list_held_tokens(tokens) == []
+    # Release is idempotent
+    lease.release()
+
+
+def test_token_lease_no_tokens_dir_is_noop(tmp_path):
+    lease = staging.TokenLease(None, n_slots=2, holder_id="test/1")
+    lease.acquire_if_needed()  # no-op
+    lease.release()             # no-op
+    assert lease.stats == {"token_acquires": 0, "token_wait_sec": 0.0}
+
+
+def test_stage_one_cache_hit_does_not_acquire_token(tmp_path):
+    """Cache hits must not touch the NAS staging gate — that's the whole
+    point of the cache."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    tokens = tmp_path / "tokens"
+
+    # First call: cache miss → token acquired.
+    lease1 = staging.TokenLease(tokens, n_slots=1, holder_id="t/1")
+    final, source = staging.stage_one(
+        str(src), tmp_path / "dst1", method="cp", bucket="ms",
+        cache_root=cache, token_lease=lease1,
+    )
+    lease1.release()
+    assert source == "cache_miss"
+    assert lease1.stats["token_acquires"] == 1
+
+    # Second call: cache hit → token NOT acquired.
+    lease2 = staging.TokenLease(tokens, n_slots=1, holder_id="t/2")
+    final2, source2 = staging.stage_one(
+        str(src), tmp_path / "dst2", method="cp", bucket="ms",
+        cache_root=cache, token_lease=lease2,
+    )
+    lease2.release()
+    assert source2 == "cache_hit"
+    assert lease2.stats["token_acquires"] == 0
+
+
+def test_stage_one_no_cache_uses_token(tmp_path):
+    """With ``cache_root=None`` we always go NAS-direct AND acquire token."""
+    src = _fake_ms(tmp_path / "src")
+    tokens = tmp_path / "tokens"
+    lease = staging.TokenLease(tokens, n_slots=1, holder_id="t/x")
+    final, source = staging.stage_one(
+        str(src), tmp_path / "dst", method="cp", bucket="ms",
+        cache_root=None, token_lease=lease,
+    )
+    lease.release()
+    assert source == "nas_direct"
+    assert lease.stats["token_acquires"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Codex-review fixes (regression tests)
+# ---------------------------------------------------------------------------
+
+def test_acquire_cache_populate_lookup_first_returns_hit(tmp_path):
+    """Regression: if a valid cache entry already exists, the wait-loop
+    must observe it BEFORE attempting mkdir — otherwise a peer that
+    already finished + removed .populating would be re-populated by us."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    # Pre-populate to a valid state (no .populating).
+    fp = staging._compute_fingerprint(src)
+    entry = cache / staging._cache_key(src)
+    entry.mkdir(parents=True)
+    import shutil as _sh
+    _sh.copytree(src, entry / src.name)
+    staging._write_sidecar_atomic(entry, src, fp)
+    # Now any new caller must see a HIT, not become a populator.
+    outcome, lock = staging.acquire_cache_populate(
+        cache, src, timeout_sec=2, poll_sleep=(0.01, 0.02),
+    )
+    assert outcome == "hit"
+    assert lock is None
+
+
+def test_compute_fingerprint_raises_on_zero_du(tmp_path, monkeypatch):
+    """Regression: a du failure must NOT silently commit size_bytes=0."""
+    src = _fake_ms(tmp_path / "src")
+    monkeypatch.setattr(staging, "_du_bytes", lambda _p: 0)
+    with pytest.raises(OSError):
+        staging._compute_fingerprint(src)
+
+
+def test_chmod_readonly_files_raises_when_permission_denied(tmp_path, monkeypatch):
+    """Regression: chmod failure must propagate so populate aborts
+    before sidecar commit."""
+    src = _fake_ms(tmp_path / "src")
+    def _bad_chmod(*_a, **_kw):
+        raise PermissionError("nope")
+    monkeypatch.setattr("os.chmod", _bad_chmod)
+    with pytest.raises(PermissionError):
+        staging._chmod_readonly_files(src)
+
+
+def test_chmod_readonly_files_skips_symlinks(tmp_path):
+    """Regression: must NOT chmod symlink targets (would mutate files
+    outside the cache entry)."""
+    root = tmp_path / "entry"
+    root.mkdir()
+    target = tmp_path / "outside.txt"
+    target.write_bytes(b"x")
+    target.chmod(0o644)
+    (root / "link").symlink_to(target)
+    staging._chmod_readonly_files(root)
+    # Symlink target's mode unchanged
+    assert target.stat().st_mode & 0o777 == 0o644
+
+
+def test_failed_populate_does_not_leak_cache_partial(tmp_path, monkeypatch):
+    """End-to-end: populate fails inside _do_nas_read — finally cleans
+    cache.partial; outer stage_one falls back to NAS-direct (which
+    succeeds since the source is a real local dir)."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+
+    real_nas = staging._do_nas_read
+    calls = {"n": 0}
+
+    def _fail_first_then_real(src_p, dst_p, method):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Populate the partial first to verify we clean it
+            dst_p.mkdir(parents=True, exist_ok=True)
+            (dst_p / "leaked.bin").write_bytes(b"oops")
+            raise RuntimeError("simulated NAS failure mid-stage")
+        return real_nas(src_p, dst_p, method)
+
+    monkeypatch.setattr(staging, "_do_nas_read", _fail_first_then_real)
+    final, source = staging.stage_one(
+        str(src), tmp_path / "dst", method="cp", bucket="ms",
+        cache_root=cache,
+    )
+    assert source == "nas_direct"
+    # The cache directory exists (created by populate path) but its
+    # ``.partial`` must not.
+    entry_dir = cache / staging._cache_key(src)
+    leftover_partials = list(entry_dir.glob(f".*.partial"))
+    assert leftover_partials == [], f"partial leaked: {leftover_partials}"
+
+
+def test_acquire_cache_populate_releases_lock_on_post_mkdir_race(tmp_path, monkeypatch):
+    """Regression for codex-flagged race: peer A finishes + removes
+    .populating BETWEEN our top-of-loop cache_lookup and our mkdir win.
+    The post-mkdir recheck (with ignore_populating=True) must catch
+    this, release our lock, and return ('hit', None) rather than
+    becoming a populator that re-stages from NAS."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    entry = cache / staging._cache_key(src)
+    entry.mkdir(parents=True)
+
+    # The orchestration:
+    # 1. We patch ``populating.mkdir`` to first inject a valid entry into
+    #    the cache (simulating peer A finishing during the gap), then
+    #    succeed our own mkdir.
+    # 2. With ignore_populating=True the post-mkdir recheck inside
+    #    acquire_cache_populate sees the valid entry and returns ("hit",
+    #    None) instead of ("populate", lock).
+
+    real_mkdir = type(entry).mkdir
+    fp = staging._compute_fingerprint(src)
+    import shutil as _sh
+    inject = {"done": False}
+    def _injecting_mkdir(self, *a, **kw):
+        if not inject["done"] and self.name == ".populating":
+            # Pretend peer A finished just now: stage data + sidecar.
+            _sh.copytree(src, entry / src.name)
+            staging._write_sidecar_atomic(entry, src, fp)
+            inject["done"] = True
+        return real_mkdir(self, *a, **kw)
+    monkeypatch.setattr(type(entry), "mkdir", _injecting_mkdir)
+
+    outcome, lock = staging.acquire_cache_populate(
+        cache, src, timeout_sec=2, poll_sleep=(0.01, 0.02),
+    )
+    assert outcome == "hit"
+    assert lock is None
+    # Our .populating must have been released, not held.
+    assert not (entry / ".populating").exists()
+
+
+def test_cache_link_into_handles_file_source(tmp_path):
+    """Regression: cache_link_into must work on FILE sources (TP FITS)
+    too, not only directory sources (CASA tables)."""
+    src_file = tmp_path / "src.fits"
+    src_file.write_bytes(b"FITS-like-bytes" * 1024)
+    dst = tmp_path / "dst" / "src.fits"
+    staging.cache_link_into(src_file, dst)
+    assert dst.exists() and dst.is_file()
+    # Same inode → real hard-link, not a copy.
+    assert dst.stat().st_ino == src_file.stat().st_ino
+
+
+def test_cache_caches_tp_fits_file(tmp_path):
+    """End-to-end: a TP FITS file source caches and yields a hit
+    on the second stage (was a silent NAS-direct fallback before)."""
+    tp = tmp_path / "tp.fits"
+    tp.write_bytes(b"FITS-data" * 4096)
+    cache = tmp_path / "cache"
+
+    final1, source1 = staging.stage_one(
+        str(tp), tmp_path / "dst1", method="cp", bucket="tp",
+        cache_root=cache,
+    )
+    assert source1 == "cache_miss"
+    # The cached file is read-only (canary)
+    cache_file = cache / staging._cache_key(tp) / "tp.fits"
+    assert cache_file.exists()
+    assert cache_file.stat().st_mode & 0o777 == 0o444
+
+    final2, source2 = staging.stage_one(
+        str(tp), tmp_path / "dst2", method="cp", bucket="tp",
+        cache_root=cache,
+    )
+    assert source2 == "cache_hit"
+    # Hard-linked
+    assert final2.stat().st_ino == cache_file.stat().st_ino
+
+
+def test_acquire_cache_populate_retries_if_entry_disappears(tmp_path, monkeypatch):
+    """Regression for codex round-3: GC rmtree's entry_dir between our
+    parent-create and our leaf-create / holder write.  Must restart the
+    iteration and eventually succeed (or hit deadline)."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    entry = cache / staging._cache_key(src)
+
+    # Fake the populating-mkdir to fail with FNF the first time
+    # (simulating a parent rmtree race), then succeed.
+    real_mkdir = type(entry).mkdir
+    calls = {"n": 0}
+    def _flaky_mkdir(self, *a, **kw):
+        if self.name == ".populating":
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise FileNotFoundError("simulated parent rmtree race")
+        return real_mkdir(self, *a, **kw)
+    monkeypatch.setattr(type(entry), "mkdir", _flaky_mkdir)
+
+    outcome, lock = staging.acquire_cache_populate(
+        cache, src, timeout_sec=5, poll_sleep=(0.01, 0.02),
+    )
+    assert outcome == "populate"
+    assert calls["n"] >= 2
+    if lock is not None:
+        with lock:
+            pass
+
+
+def test_cache_evict_rechecks_populating_before_rmtree(tmp_path, monkeypatch):
+    """Regression: GC's eviction must re-check ``.populating`` right
+    before rmtree.  Otherwise a populator that wins between the
+    candidate-collection sweep and the rmtree gets nuked.
+
+    Injection: ``_du_free_bytes`` is called once at the top of
+    ``cache_evict_until_free`` and then once per loop iteration (for
+    the break condition) BEFORE the populating-recheck.  We use the
+    second call to publish ``.populating`` — which happens after the
+    candidate was collected (at ``cache_root.iterdir()``) but before
+    the recheck.  If the recheck is missing, the entry will be
+    rmtree'd; if the recheck works, the entry is preserved."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    entry = cache / staging._cache_key(src)
+    entry.mkdir(parents=True)
+    # Pretend the entry is malformed (no sidecar) — GC will pick it
+    # as an eviction candidate.
+
+    calls = {"n": 0}
+    def _injecting_free(_root):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            # Race: a populator wins between candidate-collection and
+            # the in-loop recheck.
+            (entry / ".populating").mkdir()
+        return 0  # always tight to keep eviction running
+    monkeypatch.setattr(staging, "_du_free_bytes", _injecting_free)
+
+    n = staging.cache_evict_until_free(cache, target_free_bytes=1)
+    # Entry must be preserved because .populating was published before
+    # the rmtree got a chance.
+    assert entry.exists()
+    assert (entry / ".populating").exists()
+    assert n == 0
+
+
+def test_chmod_readonly_files_handles_file_root(tmp_path):
+    """Regression: a single-file root (TP FITS) must be chmod'd 0o444
+    (was a silent no-op when root was a file)."""
+    f = tmp_path / "x.fits"
+    f.write_bytes(b"x")
+    staging._chmod_readonly_files(f)
+    assert f.stat().st_mode & 0o777 == 0o444
+
+
+def test_cache_link_into_cleans_partial_on_rename_failure(tmp_path, monkeypatch):
+    """Regression: cache_link_into's os.rename was outside the try; if
+    it fails, the .partial would leak."""
+    src = _fake_ms(tmp_path / "cache" / "key", name="ms")
+    dst = tmp_path / "dst" / "ms"
+    real_rename = os.rename
+    monkeypatch.setattr(
+        os, "rename",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("simulated")),
+    )
+    with pytest.raises(OSError):
+        staging.cache_link_into(src, dst)
+    leftover_partials = list(dst.parent.glob(f".*.partial"))
+    assert leftover_partials == [], f"partial leaked: {leftover_partials}"

--- a/tests/test_unit_selection.py
+++ b/tests/test_unit_selection.py
@@ -1,0 +1,150 @@
+"""Tests for panta_rei.imaging.unit_selection."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+
+from panta_rei.db.connection import DatabaseManager
+from panta_rei.db.models import (
+    DispatchesQueries,
+    DispatchState,
+    ImagingParamsQueries,
+    ImagingParamsStatus,
+    ImagingRunsQueries,
+    ImagingRunStatus,
+)
+from panta_rei.imaging.matching import ImagingUnit
+from panta_rei.imaging.unit_selection import (
+    SelectionFilters,
+    select_units_to_image,
+)
+
+
+def _ready_unit(gous="G", source="SRC1", spw="23", params_id=1):
+    return ImagingUnit(
+        gous_uid=gous, source_name=source, line_group="N2H+",
+        spw_id=spw, params_id=params_id, ready=True,
+    )
+
+
+def _seed_recovered_param(db, **kwargs):
+    defaults = {
+        "gous_uid": "X3833_X64b9",
+        "source_name": "SRC1",
+        "line_group": "N2H+",
+        "spw_id": "23",
+        "mous_uids_tm": ["X3833_X64bc"],
+        "params_json_path": "/some/path.json",
+        "params_source": "weblog",
+        "weblog_path": "/p/weblog",
+        "status": ImagingParamsStatus.RECOVERED,
+        "imsize": "[100,100]",
+        "cell": "[0.5arcsec]",
+        "nchan": 100,
+        "phasecenter": "",
+        "robust": 0.5,
+    }
+    defaults.update(kwargs)
+    with db.connect() as con:
+        return ImagingParamsQueries.upsert(con, **defaults)
+
+
+def test_selection_returns_empty_when_no_recovered(tmp_path):
+    db = DatabaseManager(":memory:")
+    csv = tmp_path / "targets.csv"
+    csv.write_text("source_name,array,sb_name,sgous_id,gous_id,mous_ids,Line group\n")
+    res = select_units_to_image(
+        db, csv, tmp_path, SelectionFilters(scales=[0, 5, 10, 15, 20]),
+    )
+    assert res.ready == []
+    assert res.skipped_already_done == 0
+
+
+def test_exclude_active_drops_in_flight_under_running_dispatch(tmp_path):
+    """Selection must NOT enqueue a new row for a unit whose previous run
+    is still active under a non-terminal dispatch."""
+    db = DatabaseManager(":memory:")
+    pid = _seed_recovered_param(db)
+
+    # Seed a running dispatch + running run for this params_id
+    with db.connect() as con:
+        DispatchesQueries.insert(
+            con, dispatch_id="d_old",
+            coordinator_host="h", coordinator_pid=42,
+            machines_json="{}", cli_args="",
+        )
+        ImagingRunsQueries.insert_row(
+            con,
+            params_id=pid, gous_uid="X3833_X64b9",
+            source_name="SRC1", line_group="N2H+", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=ImagingRunStatus.RUNNING,
+            dispatch_id="d_old",
+            method="tclean_feather",
+            deconvolver="multiscale",
+            scales=json.dumps([0, 5, 10, 15, 20]),
+        )
+        con.commit()
+
+    csv = tmp_path / "targets.csv"
+    csv.write_text(
+        "source_name,array,sb_name,sgous_id,gous_id,mous_ids,Line group\n"
+        "SRC1,TM,sb,X3833_X64b8,X3833_X64b9,X3833_X64bc,N2H+\n"
+    )
+
+    with mock.patch(
+        "panta_rei.imaging.unit_selection.build_imaging_units_advisory",
+        return_value=[_ready_unit(params_id=pid)],
+    ):
+        res = select_units_to_image(
+            db, csv, tmp_path,
+            SelectionFilters(scales=[0, 5, 10, 15, 20], exclude_active=True),
+        )
+    assert res.skipped_active == 1
+    assert res.ready == []
+
+
+def test_exclude_active_allows_when_prior_dispatch_terminal(tmp_path):
+    """Once the prior dispatch is marked DONE, the selection can enqueue
+    a fresh row even if a stale row from that dispatch lingers."""
+    db = DatabaseManager(":memory:")
+    pid = _seed_recovered_param(db)
+    with db.connect() as con:
+        DispatchesQueries.insert(
+            con, dispatch_id="d_old",
+            coordinator_host="h", coordinator_pid=42,
+            machines_json="{}", cli_args="",
+        )
+        ImagingRunsQueries.insert_row(
+            con,
+            params_id=pid, gous_uid="X3833_X64b9",
+            source_name="SRC1", line_group="N2H+", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=ImagingRunStatus.FAILED,   # terminal
+            dispatch_id="d_old",
+            method="tclean_feather",
+            deconvolver="multiscale",
+            scales=json.dumps([0, 5, 10, 15, 20]),
+        )
+        DispatchesQueries.mark_terminal(con, "d_old", DispatchState.DONE)
+        con.commit()
+
+    csv = tmp_path / "targets.csv"
+    csv.write_text(
+        "source_name,array,sb_name,sgous_id,gous_id,mous_ids,Line group\n"
+        "SRC1,TM,sb,X3833_X64b8,X3833_X64b9,X3833_X64bc,N2H+\n"
+    )
+    with mock.patch(
+        "panta_rei.imaging.unit_selection.build_imaging_units_advisory",
+        return_value=[_ready_unit(params_id=pid)],
+    ):
+        res = select_units_to_image(
+            db, csv, tmp_path,
+            SelectionFilters(scales=[0, 5, 10, 15, 20], exclude_active=True),
+        )
+    # Terminal status row → not active.  Unit should pass through.
+    assert res.skipped_active == 0
+    assert len(res.ready) == 1


### PR DESCRIPTION
Adds a distributed `tclean+feather` imaging dispatcher that fans cube imaging out across multiple `/raid`-equipped hosts via SSH + mpicasa, with an NFS-mediated staging gate, a cross-dispatch hard-link cache, atomic NAS publish, and crash recovery.