### PR TITLE
recovery: repair dash-linebreak artefact in tclean parser

### DIFF
--- a/panta_rei/imaging/recovery.py
+++ b/panta_rei/imaging/recovery.py
@@ -30,6 +30,18 @@ _CUBE_SECTION_RE = re.compile(
 # Regex to detect the start of a tclean call
 _TCLEAN_START_RE = re.compile(r"^tclean\(")
 
+# Repair the dash-space artefact introduced by the multi-line tclean
+# assembler: when ``casa_commands.log`` line-wraps a hyphenated value
+# like ``auto-multithresh`` between the ``-`` and ``multithresh``, the
+# ``" ".join(stripped_lines)`` step in ``parse_tclean_calls`` produces
+# ``"auto- multithresh"``.  Collapse whitespace that sits between an
+# ASCII hyphen+letter boundary and another ASCII letter — narrow enough
+# that legitimate values containing hyphens followed by space-then-word
+# would never be touched (no such CASA tclean param value exists; all
+# affected enums are single hyphenated tokens like ``auto-multithresh``,
+# ``pb-based`` etc.).
+_HYPHEN_LINEBREAK_RE = re.compile(r"(?<=[A-Za-z])-\s+(?=[A-Za-z])")
+
 # Parameters that identify an iter1 (final) tclean call
 _ITER1_MARKERS = {"restoration": True, "pbcor": True}
 
@@ -211,12 +223,21 @@ def _normalize_string_values(params: dict) -> dict:
 
     The multi-line tclean parser joins lines with ``" ".join()``, which
     can introduce spaces inside string values when a value is split
-    across lines in ``casa_commands.log`` (e.g. ``'auto-\\nmultithresh'``
-    becomes ``'auto- multithresh'``).
+    across lines in ``casa_commands.log``.  Two cleanups happen here:
+
+    1. ``re.sub(_HYPHEN_LINEBREAK_RE, "-", v)`` rejoins hyphenated
+       identifiers that got split across a line break — e.g.
+       ``'auto-\\nmultithresh'`` → joined as ``'auto- multithresh'`` →
+       repaired to ``'auto-multithresh'``.  Without this, tclean
+       rejects ``usemask='auto- multithresh'`` with
+       ``{'usemask': ['unallowed value auto- multithresh']}``.
+    2. ``" ".join(v.split())`` collapses any other run of internal
+       whitespace into a single space.
     """
     cleaned = {}
     for k, v in params.items():
         if isinstance(v, str):
+            v = _HYPHEN_LINEBREAK_RE.sub("-", v)
             cleaned[k] = " ".join(v.split())
         else:
             cleaned[k] = v

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -137,6 +137,54 @@ class TestExtractByFieldSpw:
         result = extract_by_field_spw(iter1)
         assert ("AG231.7986-1.9684", "23") in result
 
+    def test_repairs_dash_linebreak_in_usemask(self, tmp_path):
+        """When the multi-line tclean assembler line-wraps a hyphenated
+        value (e.g. 'auto-multithresh'), the resulting ' ' join produces
+        'auto- multithresh', which tclean rejects.  The post-parse
+        normalizer must rejoin it.
+
+        Reproduction: a real ALMA pipeline weblog from this project's
+        recovered/ tree shows ``usemask='auto-`` at the end of one line
+        and ``multithresh'`` at the start of the next.  This test pins
+        the repair behaviour."""
+        log_text = (
+            "# 2026-01-23 ... cube imaging\n"
+            "# hif_makeimlist(specmode='cube')\n"
+            "tclean(field='SRC1', spw=['23', '23'], specmode='cube', "
+            "usemask='auto-\n"
+            "multithresh', restoration=True, pbcor=True, "
+            "imagename='/x/SRC1.cube.iter1', niter=100)\n"
+        )
+        p = tmp_path / "casa_commands.log"
+        p.write_text(log_text)
+        calls = parse_tclean_calls(p)
+        iter1 = filter_cube_iter1_calls(calls, p)
+        result = extract_by_field_spw(iter1)
+
+        params = result.get(("SRC1", "23"))
+        assert params is not None, result
+        assert params["usemask"] == "auto-multithresh", repr(params["usemask"])
+
+    def test_normalize_preserves_unrelated_strings(self):
+        """The dash-space repair must only affect ``letter-WS-letter``;
+        legitimate strings containing hyphens or spaces are untouched."""
+        from panta_rei.imaging.recovery import _normalize_string_values
+        out = _normalize_string_values({
+            "specmode": "cube",
+            "outframe": "LSRK",
+            "weighting": "briggsbwtaper",
+            "usemask": "auto- multithresh",  # the bug we fix
+            "phasecenter": "ICRS 12:00:00.000 -30.00.00.000",  # has dash, no fix
+            "field": "AG231.7986-1.9684",  # source name with dash
+        })
+        assert out["usemask"] == "auto-multithresh"
+        # Numeric/space-after-dash patterns inside coords/names must not change:
+        assert out["phasecenter"] == "ICRS 12:00:00.000 -30.00.00.000"
+        assert out["field"] == "AG231.7986-1.9684"
+        # Unrelated values pass through with internal whitespace collapsed:
+        assert out["specmode"] == "cube"
+        assert out["weighting"] == "briggsbwtaper"
+
 
 # ---------------------------------------------------------------------------
 # find_casa_commands_log


### PR DESCRIPTION
When ``casa_commands.log`` line-wraps a hyphenated tclean parameter value such as ``auto-multithresh`` between the ``-`` and the trailing identifier, the multi-line assembler in ``parse_tclean_calls`` joins the stripped lines with ``" "`` and produces ``"auto- multithresh"``. tclean rejects that with::

    {'usemask': ['unallowed value auto- multithresh']}

Add a regex-driven repair scoped to ``letter-WS-letter`` that tightens the dash and add tests pinning both the recovery (``'auto- multithresh'`` → ``'auto-multithresh'``) and the no-touch behaviour for legitimate strings containing hyphens followed by spaces (coords, source names).

Encountered in production where 196 recovered/*.json files across 7 unimaged GOUSs (X65ad, X652f, X6547, X65b9, X65c5, X65d1, X65dd) contain the typo.