### PR TITLE
download: strip project-code wrapper dir from ALMA tarballs on extract

### DIFF
--- a/panta_rei/alma/download.py
+++ b/panta_rei/alma/download.py
@@ -56,15 +56,28 @@ def retrieve_uids(alma: Alma, uids: List[str]) -> List[Path]:
     return paths
 
 
-def extract_single_tar(tar_path: Path, base_dir: Path) -> Tuple[int, int, bool]:
+def extract_single_tar(
+    tar_path: Path,
+    base_dir: Path,
+    *,
+    strip_top_level: Optional[str] = None,
+) -> Tuple[int, int, bool]:
     """Extract one tarball into *base_dir*.
+
+    *strip_top_level* is forwarded to :func:`safe_extract_tar` to
+    handle ALMA tarballs whose internal layout is
+    ``<project_code>/<sg>/<g>/<member>/…``.  Without stripping, those
+    cause the triple-nested ``…/<project>/<project>/<project>/<sg>/…``
+    layout when *base_dir* is the project's data_dir.
 
     Returns ``(extracted_count, skipped_count, ok)``.
     """
     log.info(f"Extracting {tar_path.name} -> {base_dir}")
     try:
         with tarfile.open(tar_path, "r") as tf:
-            extracted, skipped = safe_extract_tar(tf, base_dir)
+            extracted, skipped = safe_extract_tar(
+                tf, base_dir, strip_top_level=strip_top_level,
+            )
         log.info(f"Completed {tar_path.name}: extracted {extracted}, skipped {skipped}")
         return extracted, skipped, True
     except tarfile.TarError as e:
@@ -150,7 +163,12 @@ def retrieve_and_extract(
                 if tar_path.suffix.lower() != ".tar":
                     continue
                 uidc = extract_uid_from_path(tar_path.name) or "unknown"
-                extracted, skipped, ok = extract_single_tar(tar_path, base_dir)
+                # Strip the project_code top-level dir if the archive
+                # wraps everything under it — this avoids the
+                # triple-nesting issue (see safe_extract_tar docstring).
+                extracted, skipped, ok = extract_single_tar(
+                    tar_path, base_dir, strip_top_level=project_code,
+                )
                 if ok:
                     tar_deleted = False
                     try:

--- a/panta_rei/core/tar.py
+++ b/panta_rei/core/tar.py
@@ -6,6 +6,7 @@ import logging
 import os
 import tarfile
 from pathlib import Path
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -21,14 +22,61 @@ def _is_within_directory(base: Path, target: Path) -> bool:
     return str(target) == str(base) or str(target).startswith(str(base) + os.sep)
 
 
-def safe_extract_tar(tf: tarfile.TarFile, dest_dir: Path) -> tuple[int, int]:
+def safe_extract_tar(
+    tf: tarfile.TarFile,
+    dest_dir: Path,
+    *,
+    strip_top_level: Optional[str] = None,
+) -> tuple[int, int]:
     """Safely extract a tarball, skipping path traversal attempts and existing files.
 
-    Returns (extracted_count, skipped_count).
+    If *strip_top_level* is provided and **every** non-empty member's
+    name starts with ``<strip_top_level>/`` (or equals the bare top
+    level), that prefix is removed from each member before extraction.
+    This handles ALMA archive tarballs whose internal layout is
+    ``<project_code>/<sg>/<g>/<member>/…`` — without stripping, those
+    extract into ``<dest_dir>/<project_code>/<sg>/…`` and produce the
+    triple-nested ``…/<project>/<project>/<project>/<sg>/…`` layout
+    when *dest_dir* is itself the project's data_dir
+    (``<base>/<project>``).
+
+    The strip is conditional on *all-or-nothing* matching: if any member
+    falls outside the prefix, no stripping happens (defence against
+    mixed-content tarballs that we don't yet know about).
+
+    Returns ``(extracted_count, skipped_count)``.
     """
+    members = tf.getmembers()
+
+    if strip_top_level:
+        bare = strip_top_level.rstrip("/")
+        prefix = bare + "/"
+        all_prefixed = all(
+            (not m.name) or m.name == bare or m.name.startswith(prefix)
+            for m in members
+        )
+        if all_prefixed:
+            log.info(
+                "tarball wraps under %r; stripping top-level prefix on extract",
+                bare,
+            )
+            for m in members:
+                if m.name == bare:
+                    m.name = ""  # placeholder, will be skipped below
+                elif m.name.startswith(prefix):
+                    m.name = m.name[len(prefix):]
+        else:
+            log.debug(
+                "strip_top_level=%r requested but tarball is not uniformly "
+                "wrapped — extracting members verbatim",
+                bare,
+            )
+
     extracted = 0
     skipped = 0
-    for member in tf.getmembers():
+    for member in members:
+        if not member.name:
+            continue  # placeholder from a fully-stripped top-level dir
         member_path = dest_dir / member.name
         if not _is_within_directory(dest_dir, member_path):
             log.warning("Skipping unsafe member path: %s", member.name)

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -1,0 +1,149 @@
+"""Tests for panta_rei.core.tar — tarball extraction helpers."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+from panta_rei.core.tar import safe_extract_tar
+
+
+def _make_tar(tmp_path: Path, members: dict[str, bytes]) -> Path:
+    """Build a tarball at *tmp_path/archive.tar* with the given member
+    name → bytes mapping (or empty bytes for directory entries)."""
+    tar_path = tmp_path / "archive.tar"
+    with tarfile.open(tar_path, "w") as tf:
+        for name, content in members.items():
+            if content is None:
+                # Directory entry
+                ti = tarfile.TarInfo(name=name)
+                ti.type = tarfile.DIRTYPE
+                ti.mode = 0o755
+                tf.addfile(ti)
+            else:
+                ti = tarfile.TarInfo(name=name)
+                ti.size = len(content)
+                ti.mode = 0o644
+                tf.addfile(ti, io.BytesIO(content))
+    return tar_path
+
+
+class TestSafeExtractTar:
+    def test_basic_extract(self, tmp_path):
+        """Without strip_top_level, members extract verbatim."""
+        tar = _make_tar(tmp_path, {
+            "file1.txt": b"hello",
+            "subdir/file2.txt": b"world",
+        })
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with tarfile.open(tar) as tf:
+            extracted, skipped = safe_extract_tar(tf, dest)
+        assert extracted == 2
+        assert (dest / "file1.txt").read_bytes() == b"hello"
+        assert (dest / "subdir/file2.txt").read_bytes() == b"world"
+
+    def test_strip_top_level_removes_uniform_prefix(self, tmp_path):
+        """When all members share a top-level dir matching strip_top_level,
+        the prefix is removed during extraction.  This is the ALMA
+        archive case: tarball wraps under <project_code>/."""
+        tar = _make_tar(tmp_path, {
+            "2025.1.00383.L/": None,
+            "2025.1.00383.L/science_goal.uid___A001_X3833_X65c4/": None,
+            "2025.1.00383.L/science_goal.uid___A001_X3833_X65c4/group.uid___A001_X3833_X65c5/": None,
+            "2025.1.00383.L/science_goal.uid___A001_X3833_X65c4/group.uid___A001_X3833_X65c5/data.txt": b"science",
+        })
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with tarfile.open(tar) as tf:
+            extracted, skipped = safe_extract_tar(
+                tf, dest, strip_top_level="2025.1.00383.L",
+            )
+        # The placeholder root dir entry produces 0 extracts; the
+        # nested dirs are mkdir'd and don't count as extracted.  The
+        # leaf file extracts.
+        assert extracted == 1
+        # Files now live at dest/<sg>/<g>/, not dest/<project>/<sg>/<g>/.
+        assert (dest / "science_goal.uid___A001_X3833_X65c4" /
+                "group.uid___A001_X3833_X65c5" / "data.txt").read_bytes() == b"science"
+        # The project_code dir level should NOT exist at dest.
+        assert not (dest / "2025.1.00383.L").exists()
+
+    def test_strip_no_op_when_prefix_absent(self, tmp_path):
+        """If members don't share the prefix, strip is a no-op (members
+        extract verbatim)."""
+        tar = _make_tar(tmp_path, {
+            "science_goal.uid___A001_X3833_X65c4/data.txt": b"hi",
+            "other.txt": b"unrelated",
+        })
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with tarfile.open(tar) as tf:
+            extracted, skipped = safe_extract_tar(
+                tf, dest, strip_top_level="2025.1.00383.L",
+            )
+        assert extracted == 2
+        assert (dest / "science_goal.uid___A001_X3833_X65c4" / "data.txt").exists()
+        assert (dest / "other.txt").exists()
+
+    def test_strip_no_op_on_mixed_content(self, tmp_path):
+        """If SOME members have the prefix but others don't, do not
+        strip — extracts everything verbatim (defensive)."""
+        tar = _make_tar(tmp_path, {
+            "2025.1.00383.L/inside.txt": b"a",
+            "outside.txt": b"b",  # no prefix
+        })
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with tarfile.open(tar) as tf:
+            extracted, skipped = safe_extract_tar(
+                tf, dest, strip_top_level="2025.1.00383.L",
+            )
+        # Both extracted at their declared paths.
+        assert extracted == 2
+        assert (dest / "2025.1.00383.L" / "inside.txt").exists()
+        assert (dest / "outside.txt").exists()
+
+    def test_strip_preserves_path_traversal_guard(self, tmp_path):
+        """The strip step must not let path-traversal members slip
+        through — the guard still applies after stripping."""
+        tar = _make_tar(tmp_path, {
+            "2025.1.00383.L/../escapee.txt": b"oops",
+            "2025.1.00383.L/legit.txt": b"ok",
+        })
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with tarfile.open(tar) as tf:
+            extracted, skipped = safe_extract_tar(
+                tf, dest, strip_top_level="2025.1.00383.L",
+            )
+        # Traversal member is rejected by the guard; legit one extracts.
+        assert (dest / "legit.txt").exists()
+        assert not (tmp_path / "escapee.txt").exists()
+
+    def test_strip_handles_trailing_slash_arg(self, tmp_path):
+        """strip_top_level='X/' should work the same as 'X'."""
+        tar = _make_tar(tmp_path, {
+            "X/a.txt": b"a",
+        })
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with tarfile.open(tar) as tf:
+            extracted, skipped = safe_extract_tar(tf, dest, strip_top_level="X/")
+        assert (dest / "a.txt").read_bytes() == b"a"
+        assert not (dest / "X").exists()
+
+    def test_strip_skips_existing_files(self, tmp_path):
+        """Existing files in dest are skipped (counted), not overwritten."""
+        tar = _make_tar(tmp_path, {
+            "X/a.txt": b"new",
+        })
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "a.txt").write_bytes(b"old")
+        with tarfile.open(tar) as tf:
+            extracted, skipped = safe_extract_tar(tf, dest, strip_top_level="X")
+        assert extracted == 0
+        assert skipped == 1
+        assert (dest / "a.txt").read_bytes() == b"old"


### PR DESCRIPTION
Add an optional ``strip_top_level`` parameter to ``safe_extract_tar``. When provided, the function checks whether *every* non-empty member is under that prefix and, if so, strips it before extraction.  Mixed tarballs (some members under the prefix, some not) are extracted verbatim — defence against unknown archive shapes.

The retrieval call site passes the project_code as the strip prefix, so prefixed and prefix-less ALMA tarballs both end up at the correct data_dir/sg/g/member layout.