### PR TITLE
imaging: split tclean diagnostics into output_dir/aux/ subtree

### DIFF
--- a/panta_rei/imaging/matching.py
+++ b/panta_rei/imaging/matching.py
@@ -440,6 +440,13 @@ def build_output_path(
     return output_dir / subdir / filename
 
 
+# Tclean diagnostics (the 12m7m pbcor cube and the aux QA products) live
+# under this sub-directory so the canonical ``group.*.lp_nperetto/`` dirs
+# only contain the feathered 12m7mTP science cubes. Keeps the consumer-
+# facing layout free of intermediate-array diagnostic files.
+AUX_SUBDIR = "aux"
+
+
 def build_tclean_only_output_path(
     output_dir: Path,
     gous_id: str,
@@ -449,7 +456,7 @@ def build_tclean_only_output_path(
 ) -> Path:
     """Build the output FITS path for the tclean-only 12m+7m product.
 
-    Pattern: ``{output_dir}/group.uid___A001_{gous_id}.lp_nperetto/
+    Pattern: ``{output_dir}/aux/group.uid___A001_{gous_id}.lp_nperetto/
     group.uid___A001_{gous_id}.lp_nperetto.{source}.12m7m.{freq}GHz.cube.pbcor.fits``
     """
     sanitized = sanitize_source_name(source_name)
@@ -459,11 +466,11 @@ def build_tclean_only_output_path(
         f"group.uid___A001_{gous_id}.lp_nperetto."
         f"{sanitized}.12m7m.{freq_range}GHz.cube.pbcor.fits"
     )
-    return output_dir / subdir / filename
+    return output_dir / AUX_SUBDIR / subdir / filename
 
 
 # Aux products (QA artefacts produced by tclean) — each is published as
-# FITS alongside the canonical .pbcor pair.  Order is just for stable
+# FITS under the ``aux/`` sub-directory.  Order is just for stable
 # logging.
 AUX_PRODUCT_KINDS: tuple[str, ...] = ("mask", "residual", "pb")
 
@@ -480,7 +487,7 @@ def build_aux_output_path(
 
     Aux products (mask, residual, pb) come from the tclean step and so
     inherit the 12m7m naming.  Pattern:
-    ``{output_dir}/group.uid___A001_{gous_id}.lp_nperetto/
+    ``{output_dir}/aux/group.uid___A001_{gous_id}.lp_nperetto/
     group.uid___A001_{gous_id}.lp_nperetto.{source}.12m7m.{freq}GHz.cube.{kind}.fits``
     """
     if kind not in AUX_PRODUCT_KINDS:
@@ -495,7 +502,7 @@ def build_aux_output_path(
         f"group.uid___A001_{gous_id}.lp_nperetto."
         f"{sanitized}.12m7m.{freq_range}GHz.cube.{kind}.fits"
     )
-    return output_dir / subdir / filename
+    return output_dir / AUX_SUBDIR / subdir / filename
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -178,11 +178,38 @@ class TestBuildOutputPath:
         )
         assert "group.uid___A001_X3833_X64b9.lp_nperetto" in str(p.parent)
 
+    def test_feathered_cube_not_under_aux(self):
+        # The feathered 12m7mTP cube is the science product and lives in
+        # the canonical group subdir, NOT in the aux/ tree.
+        p = build_output_path(
+            Path("/out"), "X3833_X64b9", "AG231.7986-1.9684", 86e9, 87e9,
+        )
+        assert "/aux/" not in str(p)
+
+
+class TestBuildTcleanOnlyOutputPath:
+    """The tclean-only 12m7m pbcor cube is a diagnostic intermediate
+    (the feathered 12m7mTP is the science product), so it lives under
+    the aux/ sub-directory alongside the other tclean aux products."""
+
+    def test_lives_under_aux(self):
+        from panta_rei.imaging.matching import build_tclean_only_output_path
+        p = build_tclean_only_output_path(
+            Path("/out"), "X3833_X64b9", "AG231.7986-1.9684", 86e9, 87e9,
+        )
+        assert p.name == (
+            "group.uid___A001_X3833_X64b9.lp_nperetto."
+            "AG231.7986m1.9684.12m7m.86.0-87.0GHz.cube.pbcor.fits"
+        )
+        assert p.parent == Path(
+            "/out/aux/group.uid___A001_X3833_X64b9.lp_nperetto"
+        )
+
 
 class TestBuildAuxOutputPath:
     """Aux QA products inherit the 12m7m naming (they come from tclean,
-    not from feather), so their canonical paths sit alongside the
-    .pbcor.fits pair in the same group subdir."""
+    not from feather), and live under the aux/ sub-directory next to
+    the tclean-only pbcor cube."""
 
     def test_each_kind(self):
         from panta_rei.imaging.matching import build_aux_output_path
@@ -197,7 +224,9 @@ class TestBuildAuxOutputPath:
                 "group.uid___A001_X3833_X64b9.lp_nperetto."
                 f"AG231.7986m1.9684.12m7m.86.0-87.0GHz.cube.{kind}.fits"
             )
-            assert "group.uid___A001_X3833_X64b9.lp_nperetto" in str(p.parent)
+            assert p.parent == Path(
+                "/out/aux/group.uid___A001_X3833_X64b9.lp_nperetto"
+            )
 
     def test_unknown_kind_rejected(self):
         from panta_rei.imaging.matching import build_aux_output_path
@@ -207,7 +236,7 @@ class TestBuildAuxOutputPath:
                 86e9, 87e9, "psf",
             )
 
-    def test_lives_in_same_group_subdir_as_pbcor(self):
+    def test_lives_in_same_subdir_as_tclean_pbcor(self):
         from panta_rei.imaging.matching import (
             build_aux_output_path, build_tclean_only_output_path,
         )
@@ -221,6 +250,22 @@ class TestBuildAuxOutputPath:
         pbcor = build_tclean_only_output_path(**kw)
         residual = build_aux_output_path(kind="residual", **kw)
         assert residual.parent == pbcor.parent
+
+    def test_disjoint_from_feathered_cube_subdir(self):
+        # The feathered cube parent dir and the aux parent dir must be
+        # different — the whole point of the aux/ split is keeping the
+        # consumer-facing group dir free of diagnostic intermediates.
+        from panta_rei.imaging.matching import build_aux_output_path
+        kw = dict(
+            output_dir=Path("/out"),
+            gous_id="X3833_X64b9",
+            source_name="AG231.7986-1.9684",
+            freq_min_hz=86e9,
+            freq_max_hz=87e9,
+        )
+        feathered = build_output_path(**kw)
+        residual = build_aux_output_path(kind="residual", **kw)
+        assert feathered.parent != residual.parent
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -782,7 +782,7 @@ class TestRunTcleanFeatherParallel:
 
     def test_subprocess_success_publishes_aux_products(self, basic_unit, tmp_path):
         """When the CASA script reports aux_fits, the runner publishes
-        each alongside the canonical pair using the canonical aux paths
+        each under the aux/ sub-directory using the canonical aux paths
         passed in the job spec."""
         casa_path = tmp_path / "casa"
         (casa_path / "bin").mkdir(parents=True)
@@ -837,10 +837,14 @@ class TestRunTcleanFeatherParallel:
         # job spec should advertise the 3 default aux products + canonical
         # paths for each
         assert observed_spec["aux_products"] == ["mask", "residual", "pb"]
+        # Aux products live under output_dir/aux/group.../, separate from
+        # the feathered cube which stays in output_dir/group.../.
+        feathered_parent = Path(output).parent
         for kind in ("mask", "residual", "pb"):
             canonical = Path(observed_spec["canonical_paths"]["aux"][kind])
-            # Lives in same group subdir as the .pbcor.fits, named .cube.<kind>.fits
-            assert canonical.parent == Path(output).parent
+            assert canonical.parent != feathered_parent
+            assert canonical.parent.parent.name == "aux"
+            assert canonical.parent.name == feathered_parent.name
             assert canonical.name.endswith(f".cube.{kind}.fits")
             assert "12m7m." in canonical.name and "12m7mTP" not in canonical.name
             assert canonical.exists()


### PR DESCRIPTION
The canonical group.*.lp_nperetto/ dirs were mixing the feathered 12m7mTP science cube with the tclean-only 12m7m pbcor and the aux QA products (mask, pb, residual).

Move the tclean diagnostics (12m7m pbcor + mask/pb/residual) under a dedicated aux/ sub-directory:

  before: output/group.<GOUS>.lp_nperetto/<cube>.12m7m.<freq>.cube.pbcor.fits
   after: output/aux/group.<GOUS>.lp_nperetto/<cube>.12m7m.<freq>.cube.pbcor.fits

The feathered 12m7mTP cube stays in the original location. Filenames are unchanged; only the parent directory shifts.