### PR TITLE
Feature/clean diagnostics

### DIFF
--- a/panta_rei/analysis/clean_diagnostics.py
+++ b/panta_rei/analysis/clean_diagnostics.py
@@ -78,6 +78,11 @@ DEFAULT_ARRAY_COMBOS: tuple[str, ...] = ("12m7m",)
 AUX_SUBDIR = "aux"
 
 SIBLING_KINDS: tuple[str, ...] = ("pbcor", "mask", "residual", "pb")
+# Optional siblings: tclean's auto-masking emits no ``.cube.mask.fits`` when
+# nothing rose above the masking threshold (i.e. no detectable emission).
+# Treating the mask as required would drop the still-useful intensity maps
+# for those cubes; instead we synthesise an all-zero mask in that case.
+OPTIONAL_SIBLING_KINDS: tuple[str, ...] = ("mask",)
 
 
 # ---------------------------- typed exceptions -----------------------------
@@ -151,19 +156,31 @@ def _split_base(pbcor_path: Path) -> str:
     return m.group("base")
 
 
-def resolve_siblings(pbcor_path: Path) -> dict[str, Path]:
-    """Return a ``{kind: Path}`` map for pbcor / mask / residual / pb.
+def resolve_siblings(pbcor_path: Path) -> dict[str, Path | None]:
+    """Return a ``{kind: Path | None}`` map for pbcor / mask / residual / pb.
 
-    Raises :class:`MissingSibling` if any of the three siblings is absent.
+    Required siblings (``pbcor``, ``residual``, ``pb``) must exist on disk
+    or :class:`MissingSibling` is raised. Optional siblings (``mask``)
+    are returned as ``None`` when absent so the caller can synthesise a
+    sensible default (an all-zero mask, in the mask case).
     """
     base = _split_base(pbcor_path)
     parent = pbcor_path.parent
-    paths = {kind: parent / f"{base}.cube.{kind}.fits" for kind in SIBLING_KINDS}
-    missing = [kind for kind, p in paths.items() if not p.is_file()]
-    if missing:
+    candidate: dict[str, Path] = {
+        kind: parent / f"{base}.cube.{kind}.fits" for kind in SIBLING_KINDS
+    }
+    missing_required = [
+        kind for kind in SIBLING_KINDS
+        if kind not in OPTIONAL_SIBLING_KINDS and not candidate[kind].is_file()
+    ]
+    if missing_required:
         raise MissingSibling(
-            f"missing sibling(s) {missing} for {pbcor_path.name}"
+            f"missing required sibling(s) {missing_required} for {pbcor_path.name}"
         )
+    paths: dict[str, Path | None] = dict(candidate)
+    for kind in OPTIONAL_SIBLING_KINDS:
+        if not candidate[kind].is_file():
+            paths[kind] = None
     return paths
 
 
@@ -197,14 +214,15 @@ def derive_plot_paths(
 # ---------------------------- mtime logic ----------------------------------
 
 
-def input_mtime(sibling_paths: dict[str, Path]) -> float:
-    """Return ``max(mtime)`` across the 4 sibling cubes.
+def input_mtime(sibling_paths: dict[str, Path | None]) -> float:
+    """Return ``max(mtime)`` across the present sibling cubes.
 
     Outputs are considered fresh when their mtime is ``>=`` this value
     (uses ``>=`` rather than ``>`` to tolerate same-second writes on
-    NFS).
+    NFS). Optional siblings that are absent (``None`` in the map) are
+    skipped — they have no clock to honour.
     """
-    return max(p.stat().st_mtime for p in sibling_paths.values())
+    return max(p.stat().st_mtime for p in sibling_paths.values() if p is not None)
 
 
 def needs_regeneration(input_clock: float, output_path: Path, force: bool) -> bool:
@@ -283,18 +301,24 @@ class CubeBundle:
 
 
 def _open_cube_arrays(
-    sibling_paths: dict[str, Path],
+    sibling_paths: dict[str, Path | None],
     exit_stack: contextlib.ExitStack,
 ) -> CubeBundle:
-    """Open the 4 cubes, squeeze Stokes, validate cross-cube consistency.
+    """Open the cubes, squeeze Stokes, validate cross-cube consistency.
 
-    All four HDULs are kept open via ``exit_stack`` for the lifetime of
-    the bundle; arrays are numpy views over memmap'd data.
+    HDULs are kept open via ``exit_stack`` for the lifetime of the
+    bundle; arrays are numpy views over memmap'd data. Optional siblings
+    that are absent (``None``) are synthesised — for mask this is an
+    all-zero ``(n_chan, ny, nx)`` array taken from pbcor's shape.
     """
     arrays: dict[str, np.ndarray] = {}
     pbcor_header: fits.Header | None = None
     for kind in SIBLING_KINDS:
         path = sibling_paths[kind]
+        if path is None:
+            # Optional sibling absent — handled after pbcor is loaded.
+            assert kind in OPTIONAL_SIBLING_KINDS, kind
+            continue
         hdul = exit_stack.enter_context(fits.open(str(path), memmap=True))
         primary = hdul[0]
         data = primary.data
@@ -307,9 +331,17 @@ def _open_cube_arrays(
 
     assert pbcor_header is not None  # SIBLING_KINDS starts with pbcor
 
-    # Cross-cube shape consistency. We bind the canonical (n_chan, ny, nx)
-    # from pbcor and compare the other three against it.
+    # Synthesise any absent optional siblings now that we know the
+    # canonical shape from pbcor.
     n_chan, ny, nx = arrays["pbcor"].shape
+    if sibling_paths.get("mask") is None:
+        logger.info(
+            "%s: no .cube.mask.fits — synthesising empty mask (no clean components)",
+            sibling_paths["pbcor"].name,
+        )
+        arrays["mask"] = np.zeros((n_chan, ny, nx), dtype=np.uint8)
+
+    # Cross-cube shape consistency.
     for kind in ("residual", "mask", "pb"):
         if arrays[kind].shape != (n_chan, ny, nx):
             raise ShapeMismatch(
@@ -529,7 +561,15 @@ def _build_2d_header(
     hdr["PRODUCT"] = (product_kind, "clean-diagnostics product kind")
     hdr["SIB_PB"] = (bundle.sibling_paths["pb"].name, "pb sibling")
     hdr["SIB_RESI"] = (bundle.sibling_paths["residual"].name, "residual sibling")
-    hdr["SIB_MASK"] = (bundle.sibling_paths["mask"].name, "mask sibling")
+    mask_path = bundle.sibling_paths.get("mask")
+    if mask_path is None:
+        hdr["SIB_MASK"] = ("(absent - empty mask synthesised)", "mask sibling")
+        hdr.add_history(
+            "panta-rei-clean-diagnostics: no .cube.mask.fits - "
+            "mask synthesised as all-zero (no detectable emission)."
+        )
+    else:
+        hdr["SIB_MASK"] = (mask_path.name, "mask sibling")
     if jytok is not None:
         hdr["JYTOK"] = (float(jytok), "K per (Jy/beam) at RESTFRQ (pbcor beam)")
     if mask_projection is not None:
@@ -537,7 +577,7 @@ def _build_2d_header(
     hdr.add_history(
         "panta-rei-clean-diagnostics: "
         "RECON_IMG = pbcor * pb (valid where both finite); "
-        "may differ from CASA .image in PB-tapered / blanked regions."
+        "may differ from CASA .image in PB-tapered or blanked regions."
     )
     return hdr
 
@@ -607,7 +647,11 @@ def _write_spectrum_fits(
     bintable.header["MASKKIND"] = (mask_kind, "2D mask used for spatial averaging")
     bintable.header["SIB_PB"] = (bundle.sibling_paths["pb"].name, "pb sibling")
     bintable.header["SIB_RESI"] = (bundle.sibling_paths["residual"].name, "residual sibling")
-    bintable.header["SIB_MASK"] = (bundle.sibling_paths["mask"].name, "mask sibling")
+    mask_path = bundle.sibling_paths.get("mask")
+    bintable.header["SIB_MASK"] = (
+        mask_path.name if mask_path is not None else "(absent - empty mask synthesised)",
+        "mask sibling",
+    )
     bintable.header["SPECCONV"] = (spectral_unit, "SPECTRAL column units")
 
     primary = fits.PrimaryHDU()

--- a/panta_rei/analysis/clean_diagnostics.py
+++ b/panta_rei/analysis/clean_diagnostics.py
@@ -1,0 +1,905 @@
+"""Clean-imaging diagnostics for the 12m+7m (no TP) product.
+
+Per pbcor cube under ``imaging/output/aux/<group>/`` we resolve its 3
+sibling products (residual, mask, pb) and emit:
+
+- Reconstructed-image moment-0 and peak (image = pbcor * pb)
+- Residual moment-0 and peak
+- Two 2D clean masks (peak / integrated — identical projection; both
+  files written for symmetry with the user-facing summary plots)
+- Four mean spectra (cube + residual, within each mask)
+
+All Jy/beam → K conversion uses the **pbcor's beam** as the canonical
+source for every product, so image and residual sit on the same Tb
+scale and are directly comparable in the summary plots.
+
+The compute kernel is pure-Python / numpy; CLI driver lives in
+``panta_rei.cli.run_clean_diagnostics``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from astropy import constants as const
+from astropy import units as u
+from astropy.io import fits
+
+logger = logging.getLogger(__name__)
+
+
+# Per-cube product kinds. Order matters only for log readability.
+PRODUCT_KINDS: tuple[str, ...] = (
+    "integrated_intensity_image",
+    "integrated_intensity_residual",
+    "peak_intensity_image",
+    "peak_intensity_residual",
+    "clean_mask",
+    "mean_spectrum_image_in_mask",
+    "mean_spectrum_residual_in_mask",
+)
+
+# Multi-panel summary plot kinds (PNG-only — no FITS counterpart).
+SUMMARY_PLOT_KINDS: tuple[str, ...] = (
+    "summary_integrated",
+    "summary_peak",
+)
+
+# Paired-spectrum PNG kind — image + residual on a single axis. FITS
+# above stays split into two BinTables for lossless per-product storage.
+PAIRED_SPECTRUM_PLOT_KINDS: tuple[str, ...] = (
+    "mean_spectra_in_mask",
+)
+
+# Single-panel map PNG kinds (one per FITS intensity / mask product). Mean
+# spectra do not get individual PNGs — they're paired (see above).
+SINGLE_PANEL_MAP_PNG_KINDS: tuple[str, ...] = (
+    "integrated_intensity_image",
+    "integrated_intensity_residual",
+    "peak_intensity_image",
+    "peak_intensity_residual",
+    "clean_mask",
+)
+
+
+CUBE_GLOB = "*.cube.pbcor.fits"
+DEFAULT_ARRAY_COMBOS: tuple[str, ...] = ("12m7m",)
+
+# Aux products live under <imaging_dir>/aux/group.*.lp_nperetto/. The
+# moments CLI uses imaging_dir/group.*.lp_nperetto/ directly — different
+# subtree.
+AUX_SUBDIR = "aux"
+
+SIBLING_KINDS: tuple[str, ...] = ("pbcor", "mask", "residual", "pb")
+
+
+# ---------------------------- typed exceptions -----------------------------
+
+
+class CleanDiagError(Exception):
+    """Base class for clean-diagnostics compute failures."""
+
+    short_tag = "error"
+
+
+class MissingSibling(CleanDiagError):
+    short_tag = "missing_sibling"
+
+
+class ShapeMismatch(CleanDiagError):
+    short_tag = "shape_mismatch"
+
+
+class NonSingletonStokes(CleanDiagError):
+    short_tag = "non_singleton_stokes"
+
+
+class PbOutOfRange(CleanDiagError):
+    short_tag = "pb_out_of_range"
+
+
+class MaskNotBinary(CleanDiagError):
+    short_tag = "mask_not_binary"
+
+
+class MissingSpectralAxis(CleanDiagError):
+    short_tag = "missing_spectral_axis"
+
+
+# ---------------------------- result dataclasses ---------------------------
+
+
+@dataclass
+class CleanDiagResult:
+    """Per-cube outcome from :func:`process_cube`.
+
+    ``products`` maps each requested kind to one of:
+    ``"written"``, ``"skipped"``, ``"dry-run"``, or ``"failed:<reason>"``.
+    """
+
+    cube: Path
+    products: dict[str, str]
+
+    @property
+    def any_failed(self) -> bool:
+        return any(s.startswith("failed:") for s in self.products.values())
+
+
+# ---------------------------- path helpers ---------------------------------
+
+
+_BASE_RE = re.compile(r"^(?P<base>.+)\.cube\.pbcor\.fits$")
+
+
+def _split_base(pbcor_path: Path) -> str:
+    """Strip ``.cube.pbcor.fits`` from a pbcor filename.
+
+    Used by both sibling resolution and output-path derivation so that
+    sibling-derived FITS share the same ``<base>.<kind>.fits`` stem as
+    the moments outputs.
+    """
+    m = _BASE_RE.match(pbcor_path.name)
+    if m is None:
+        raise ValueError(f"not a pbcor cube filename: {pbcor_path.name}")
+    return m.group("base")
+
+
+def resolve_siblings(pbcor_path: Path) -> dict[str, Path]:
+    """Return a ``{kind: Path}`` map for pbcor / mask / residual / pb.
+
+    Raises :class:`MissingSibling` if any of the three siblings is absent.
+    """
+    base = _split_base(pbcor_path)
+    parent = pbcor_path.parent
+    paths = {kind: parent / f"{base}.cube.{kind}.fits" for kind in SIBLING_KINDS}
+    missing = [kind for kind, p in paths.items() if not p.is_file()]
+    if missing:
+        raise MissingSibling(
+            f"missing sibling(s) {missing} for {pbcor_path.name}"
+        )
+    return paths
+
+
+def derive_output_paths(
+    pbcor_path: Path,
+    analysis_dir: Path,
+    products: Iterable[str] = PRODUCT_KINDS,
+) -> dict[str, Path]:
+    """Map a pbcor path to its FITS output paths.
+
+    Layout mirrors moments: ``<analysis_dir>/<group_dir>/fits/<base>.<kind>.fits``.
+    """
+    group_dir = pbcor_path.parent.name
+    base = _split_base(pbcor_path)
+    target_dir = analysis_dir / group_dir / "fits"
+    return {kind: target_dir / f"{base}.{kind}.fits" for kind in products}
+
+
+def derive_plot_paths(
+    pbcor_path: Path,
+    analysis_dir: Path,
+    kinds: Iterable[str],
+) -> dict[str, Path]:
+    """PNG paths under ``<analysis_dir>/<group_dir>/png/``."""
+    group_dir = pbcor_path.parent.name
+    base = _split_base(pbcor_path)
+    target_dir = analysis_dir / group_dir / "png"
+    return {kind: target_dir / f"{base}.{kind}.png" for kind in kinds}
+
+
+# ---------------------------- mtime logic ----------------------------------
+
+
+def input_mtime(sibling_paths: dict[str, Path]) -> float:
+    """Return ``max(mtime)`` across the 4 sibling cubes.
+
+    Outputs are considered fresh when their mtime is ``>=`` this value
+    (uses ``>=`` rather than ``>`` to tolerate same-second writes on
+    NFS).
+    """
+    return max(p.stat().st_mtime for p in sibling_paths.values())
+
+
+def needs_regeneration(input_clock: float, output_path: Path, force: bool) -> bool:
+    """True if the output is missing, older than input_clock, or forced."""
+    if force or not output_path.exists():
+        return True
+    return output_path.stat().st_mtime < input_clock
+
+
+# ---------------------------- spectral-axis helpers ------------------------
+
+
+def _spectral_axis_index(header: fits.Header) -> int:
+    """Return the 1-based FITS axis number whose CTYPE starts with FREQ."""
+    for i in range(1, int(header.get("NAXIS", 0)) + 1):
+        ctype = str(header.get(f"CTYPE{i}", "")).upper()
+        if ctype.startswith("FREQ"):
+            return i
+    raise MissingSpectralAxis(f"no FREQ-like axis in header: {header.get('NAXIS')}D")
+
+
+def compute_dv_kms(header: fits.Header) -> float:
+    """Channel width in km/s (radio convention) from a FITS header.
+
+    Uses ``|CDELT_freq|`` and RESTFRQ; sign is dropped because moment-0
+    magnitude is independent of axis direction.
+    """
+    axis = _spectral_axis_index(header)
+    cdelt_hz = float(header[f"CDELT{axis}"])
+    rest_hz = None
+    for key in ("RESTFRQ", "RESTFREQ"):
+        val = header.get(key)
+        if val:
+            rest_hz = float(val)
+            break
+    if rest_hz is None or rest_hz <= 0:
+        raise MissingSpectralAxis("RESTFRQ missing — cannot compute dv in km/s")
+    c_kms = const.c.to(u.km / u.s).value
+    return abs(cdelt_hz) * c_kms / rest_hz
+
+
+def freq_axis_hz(header: fits.Header, n_chan: int) -> np.ndarray:
+    """Return per-channel sky frequencies (Hz) from a FITS header."""
+    axis = _spectral_axis_index(header)
+    crval = float(header[f"CRVAL{axis}"])
+    cdelt = float(header[f"CDELT{axis}"])
+    crpix = float(header[f"CRPIX{axis}"])
+    return crval + (np.arange(1, n_chan + 1) - crpix) * cdelt
+
+
+# ---------------------------- FITS open + validate -------------------------
+
+
+def _squeeze_stokes(data: np.ndarray, path: Path) -> np.ndarray:
+    """Return the 3D ``(n_chan, ny, nx)`` view, asserting singleton Stokes."""
+    if data.ndim == 3:
+        return data
+    if data.ndim == 4 and data.shape[0] == 1:
+        return data[0]
+    raise NonSingletonStokes(
+        f"{path.name}: expected 3D or (1, n_chan, ny, nx); got shape={data.shape}"
+    )
+
+
+@dataclass
+class CubeBundle:
+    """Memory-mapped view of the 4 sibling cubes plus their canonical header."""
+
+    pbcor: np.ndarray  # (n_chan, ny, nx) float
+    residual: np.ndarray  # (n_chan, ny, nx) float
+    mask: np.ndarray  # (n_chan, ny, nx) numeric (0/1)
+    pb: np.ndarray  # (n_chan, ny, nx) float
+    header: fits.Header  # pbcor primary header (canonical)
+    pbcor_path: Path
+    sibling_paths: dict[str, Path]
+
+
+def _open_cube_arrays(
+    sibling_paths: dict[str, Path],
+    exit_stack: contextlib.ExitStack,
+) -> CubeBundle:
+    """Open the 4 cubes, squeeze Stokes, validate cross-cube consistency.
+
+    All four HDULs are kept open via ``exit_stack`` for the lifetime of
+    the bundle; arrays are numpy views over memmap'd data.
+    """
+    arrays: dict[str, np.ndarray] = {}
+    pbcor_header: fits.Header | None = None
+    for kind in SIBLING_KINDS:
+        path = sibling_paths[kind]
+        hdul = exit_stack.enter_context(fits.open(str(path), memmap=True))
+        primary = hdul[0]
+        data = primary.data
+        if data is None:
+            raise CleanDiagError(f"{path.name}: no primary HDU data")
+        arr = _squeeze_stokes(data, path)
+        arrays[kind] = arr
+        if kind == "pbcor":
+            pbcor_header = primary.header
+
+    assert pbcor_header is not None  # SIBLING_KINDS starts with pbcor
+
+    # Cross-cube shape consistency. We bind the canonical (n_chan, ny, nx)
+    # from pbcor and compare the other three against it.
+    n_chan, ny, nx = arrays["pbcor"].shape
+    for kind in ("residual", "mask", "pb"):
+        if arrays[kind].shape != (n_chan, ny, nx):
+            raise ShapeMismatch(
+                f"{kind} shape {arrays[kind].shape} != pbcor {(n_chan, ny, nx)}"
+            )
+
+    # pb sanity check: values should be in [0, ~1]. Allow 5% numerical slack
+    # and ignore NaNs.
+    pb_min = float(np.nanmin(arrays["pb"]))
+    pb_max = float(np.nanmax(arrays["pb"]))
+    if pb_min < -1e-3 or pb_max > 1.05:
+        raise PbOutOfRange(
+            f"pb data out of [0, 1.05]: min={pb_min}, max={pb_max}"
+        )
+
+    # mask sanity check: integer-valued 0/1. CASA emits float32 0.0/1.0;
+    # accept anything that compares equal once cast to int.
+    mask_arr = arrays["mask"]
+    sample = mask_arr[:: max(1, mask_arr.shape[0] // 8)]  # sparse sample
+    sample = sample[np.isfinite(sample)]
+    if sample.size > 0:
+        non_binary = np.any((sample != 0.0) & (sample != 1.0))
+        if non_binary:
+            raise MaskNotBinary(
+                "mask cube has values outside {0, 1} (sampled along spectral axis)"
+            )
+
+    return CubeBundle(
+        pbcor=arrays["pbcor"],
+        residual=arrays["residual"],
+        mask=arrays["mask"],
+        pb=arrays["pb"],
+        header=pbcor_header,
+        pbcor_path=sibling_paths["pbcor"],
+        sibling_paths=sibling_paths,
+    )
+
+
+# ---------------------------- compute --------------------------------------
+
+
+@dataclass
+class ComputeResult:
+    """Numpy outputs from a single streaming pass over the 4 cubes."""
+
+    integ_image_jy: np.ndarray  # (ny, nx) — already multiplied by dv
+    integ_resid_jy: np.ndarray
+    peak_image_jy: np.ndarray  # (ny, nx)
+    peak_resid_jy: np.ndarray
+    mask_2d: np.ndarray  # (ny, nx) uint8 0/1
+    spec_image_jy: np.ndarray  # (n_chan,) Jy/beam — mean within mask_2d
+    spec_resid_jy: np.ndarray  # (n_chan,) Jy/beam — mean within mask_2d
+    dv_kms: float
+    freq_hz: np.ndarray  # (n_chan,)
+
+
+def compute_diagnostics(bundle: CubeBundle) -> ComputeResult:
+    """Single streaming pass over the 4 cubes.
+
+    Returns numpy arrays in raw Jy/beam units (integration multiplied by
+    ``dv`` already). K conversion happens in the writer / plot layer
+    using the pbcor beam metadata.
+    """
+    n_chan, ny, nx = bundle.pbcor.shape
+    dv = compute_dv_kms(bundle.header)
+    freqs = freq_axis_hz(bundle.header, n_chan)
+
+    # 2D accumulators — float64 for stability of running sums on long
+    # spectral axes. Peak arrays start at -inf so np.fmax-ing finite
+    # values always wins; peak_seen tracks whether any finite channel
+    # contributed (so we can emit NaN where nothing did).
+    integ_image = np.zeros((ny, nx), dtype=np.float64)
+    integ_resid = np.zeros((ny, nx), dtype=np.float64)
+    valid_count_image = np.zeros((ny, nx), dtype=np.int32)
+    valid_count_resid = np.zeros((ny, nx), dtype=np.int32)
+    peak_image = np.full((ny, nx), -np.inf, dtype=np.float32)
+    peak_resid = np.full((ny, nx), -np.inf, dtype=np.float32)
+    peak_seen_image = np.zeros((ny, nx), dtype=bool)
+    peak_seen_resid = np.zeros((ny, nx), dtype=bool)
+    mask_2d = np.zeros((ny, nx), dtype=bool)
+
+    # Pass 1: stream channel-at-a-time and accumulate.
+    for c in range(n_chan):
+        pbc = bundle.pbcor[c].astype(np.float32, copy=False)
+        rsc = bundle.residual[c].astype(np.float32, copy=False)
+        pbm = bundle.pb[c].astype(np.float32, copy=False)
+        msk = bundle.mask[c]
+
+        valid_recon = np.isfinite(pbc) & np.isfinite(pbm)
+        valid_resid = np.isfinite(rsc)
+
+        un_pbcor = pbc * pbm  # NaN where either is NaN
+
+        # Sums (NaNs already contribute 0 because we mask out invalid)
+        integ_image += np.where(valid_recon, un_pbcor, 0.0)
+        integ_resid += np.where(valid_resid, rsc, 0.0)
+        valid_count_image += valid_recon
+        valid_count_resid += valid_resid
+
+        # Peaks — np.fmax propagates the non-NaN operand; peak_seen
+        # remembers whether any finite value was ever offered so we can
+        # restore NaN at write time.
+        peak_image = np.fmax(peak_image, un_pbcor)
+        peak_resid = np.fmax(peak_resid, rsc)
+        peak_seen_image |= valid_recon
+        peak_seen_resid |= valid_resid
+
+        mask_2d |= (msk > 0)
+
+    # Post-pass: scale moment-0 by dv, restore NaN where nothing valid
+    # contributed.
+    integ_image = np.where(valid_count_image > 0, integ_image * dv, np.nan)
+    integ_resid = np.where(valid_count_resid > 0, integ_resid * dv, np.nan)
+    peak_image = np.where(peak_seen_image, peak_image, np.nan)
+    peak_resid = np.where(peak_seen_resid, peak_resid, np.nan)
+
+    # Pass 2 (light): per-channel masked spatial mean of reconstructed
+    # image and residual.
+    mask_2d_bool = mask_2d  # alias for clarity
+    n_in_mask = int(mask_2d_bool.sum())
+    spec_image = np.full(n_chan, np.nan, dtype=np.float64)
+    spec_resid = np.full(n_chan, np.nan, dtype=np.float64)
+    if n_in_mask > 0:
+        for c in range(n_chan):
+            pbc = bundle.pbcor[c].astype(np.float32, copy=False)
+            rsc = bundle.residual[c].astype(np.float32, copy=False)
+            pbm = bundle.pb[c].astype(np.float32, copy=False)
+            un_pbcor = pbc * pbm
+            spec_image[c] = float(np.nanmean(un_pbcor[mask_2d_bool]))
+            spec_resid[c] = float(np.nanmean(rsc[mask_2d_bool]))
+    else:
+        logger.warning(
+            "%s: clean mask is empty (no clean components) — spectra all NaN",
+            bundle.pbcor_path.name,
+        )
+
+    return ComputeResult(
+        integ_image_jy=integ_image,
+        integ_resid_jy=integ_resid,
+        peak_image_jy=peak_image,
+        peak_resid_jy=peak_resid,
+        mask_2d=mask_2d_bool.astype(np.uint8),
+        spec_image_jy=spec_image,
+        spec_resid_jy=spec_resid,
+        dv_kms=dv,
+        freq_hz=freqs,
+    )
+
+
+# ---------------------------- discovery ------------------------------------
+
+
+def discover_cubes(
+    imaging_dir: Path,
+    group_filters: Iterable[str] | None = None,
+    array_combos: Iterable[str] | None = DEFAULT_ARRAY_COMBOS,
+) -> list[Path]:
+    """List 12m7m pbcor cubes under ``<imaging_dir>/aux/group.*.lp_nperetto/``.
+
+    Mirrors :func:`panta_rei.analysis.moments.discover_cubes` but globs the
+    ``aux/`` subtree where the deferred-aux-products patch publishes the
+    12m7m quad sets.
+    """
+    aux_dir = imaging_dir / AUX_SUBDIR
+    cubes = sorted(aux_dir.glob(f"group.*.lp_nperetto/{CUBE_GLOB}"))
+    filters = list(group_filters or [])
+    if filters:
+        cubes = [c for c in cubes if any(f in c.parent.name for f in filters)]
+    combos = list(array_combos or [])
+    if combos:
+        tokens = tuple(f".{c}." for c in combos)
+        cubes = [c for c in cubes if any(t in c.name for t in tokens)]
+    return cubes
+
+
+# ---------------------------- FITS writers ---------------------------------
+
+
+def _atomic_write_fits(hdul: fits.HDUList, out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = out_path.with_name(out_path.name + ".tmp")
+    if tmp_path.exists():
+        tmp_path.unlink()
+    hdul.writeto(str(tmp_path))
+    os.replace(tmp_path, out_path)
+
+
+def _build_2d_header(
+    src_header: fits.Header,
+    *,
+    bunit: str,
+    product_kind: str,
+    bundle: CubeBundle,
+    jytok: float | None,
+    mask_projection: str | None = None,
+) -> fits.Header:
+    """Construct a 2D FITS header from a 4D pbcor header.
+
+    Preserves spatial WCS + beam keys; strips spectral / Stokes WCS.
+    """
+    hdr = fits.Header()
+    hdr["NAXIS"] = 2
+    # Direct passthroughs for spatial WCS + beam metadata. Each key is
+    # optional in the source; missing keys are silently skipped.
+    passthrough = (
+        "CTYPE1", "CTYPE2", "CRVAL1", "CRVAL2", "CRPIX1", "CRPIX2",
+        "CDELT1", "CDELT2", "CUNIT1", "CUNIT2",
+        "PC1_1", "PC1_2", "PC2_1", "PC2_2",
+        "RADESYS", "EQUINOX", "LONPOLE", "LATPOLE",
+        "BMAJ", "BMIN", "BPA", "RESTFRQ", "SPECSYS", "OBJECT",
+    )
+    for key in passthrough:
+        if key in src_header:
+            hdr[key] = src_header[key]
+    hdr["BUNIT"] = bunit
+    hdr["SRCFILE"] = (bundle.pbcor_path.name, "pbcor input cube")
+    hdr["PRODUCT"] = (product_kind, "clean-diagnostics product kind")
+    hdr["SIB_PB"] = (bundle.sibling_paths["pb"].name, "pb sibling")
+    hdr["SIB_RESI"] = (bundle.sibling_paths["residual"].name, "residual sibling")
+    hdr["SIB_MASK"] = (bundle.sibling_paths["mask"].name, "mask sibling")
+    if jytok is not None:
+        hdr["JYTOK"] = (float(jytok), "K per (Jy/beam) at RESTFRQ (pbcor beam)")
+    if mask_projection is not None:
+        hdr["PROJ"] = (mask_projection, "spectral->2D projection rule")
+    hdr.add_history(
+        "panta-rei-clean-diagnostics: "
+        "RECON_IMG = pbcor * pb (valid where both finite); "
+        "may differ from CASA .image in PB-tapered / blanked regions."
+    )
+    return hdr
+
+
+def _write_map_fits(
+    arr_k: np.ndarray,
+    out_path: Path,
+    *,
+    bunit: str,
+    product_kind: str,
+    bundle: CubeBundle,
+    jytok: float,
+) -> None:
+    hdr = _build_2d_header(
+        bundle.header,
+        bunit=bunit,
+        product_kind=product_kind,
+        bundle=bundle,
+        jytok=jytok,
+    )
+    hdu = fits.PrimaryHDU(data=arr_k.astype(np.float32), header=hdr)
+    _atomic_write_fits(fits.HDUList([hdu]), out_path)
+
+
+def _write_mask_fits(
+    mask_2d: np.ndarray,
+    out_path: Path,
+    *,
+    product_kind: str,
+    bundle: CubeBundle,
+) -> None:
+    hdr = _build_2d_header(
+        bundle.header,
+        bunit="",
+        product_kind=product_kind,
+        bundle=bundle,
+        jytok=None,
+        mask_projection="max(axis=0)",
+    )
+    hdu = fits.PrimaryHDU(data=mask_2d.astype(np.uint8), header=hdr)
+    _atomic_write_fits(fits.HDUList([hdu]), out_path)
+
+
+def _write_spectrum_fits(
+    values_k: np.ndarray,
+    spectral_values: np.ndarray,
+    spectral_unit: str,
+    out_path: Path,
+    *,
+    product_kind: str,
+    bundle: CubeBundle,
+    mask_kind: str,
+) -> None:
+    col_spec = fits.Column(
+        name="SPECTRAL", format="D", unit=spectral_unit,
+        array=np.asarray(spectral_values, dtype=np.float64),
+    )
+    col_flux = fits.Column(
+        name="FLUX", format="D", unit="K",
+        array=np.asarray(values_k, dtype=np.float64),
+    )
+    bintable = fits.BinTableHDU.from_columns(
+        [col_spec, col_flux], name="SPECTRUM",
+    )
+    bintable.header["SRCFILE"] = (bundle.pbcor_path.name, "pbcor input cube")
+    bintable.header["PRODUCT"] = (product_kind, "clean-diagnostics product kind")
+    bintable.header["MASKKIND"] = (mask_kind, "2D mask used for spatial averaging")
+    bintable.header["SIB_PB"] = (bundle.sibling_paths["pb"].name, "pb sibling")
+    bintable.header["SIB_RESI"] = (bundle.sibling_paths["residual"].name, "residual sibling")
+    bintable.header["SIB_MASK"] = (bundle.sibling_paths["mask"].name, "mask sibling")
+    bintable.header["SPECCONV"] = (spectral_unit, "SPECTRAL column units")
+
+    primary = fits.PrimaryHDU()
+    primary.header["SRCFILE"] = (bundle.pbcor_path.name, "pbcor input cube")
+    primary.header["PRODUCT"] = (product_kind, "clean-diagnostics product kind")
+    _atomic_write_fits(fits.HDUList([primary, bintable]), out_path)
+
+
+# ---------------------------- process_cube ---------------------------------
+
+
+_FILENAME_RE = re.compile(
+    r"\.lp_nperetto\.(?P<src>.+?)\.12m7m\."
+    r"(?P<lo>[\d.]+)-(?P<hi>[\d.]+)GHz\.cube\.pbcor\.fits$"
+)
+
+
+def human_source_label(pbcor_path: Path) -> str | None:
+    """Short ``<source> | <lo>-<hi> GHz`` label for plot titles."""
+    m = _FILENAME_RE.search(pbcor_path.name)
+    if m is None:
+        return None
+    src = re.sub(
+        r"(?<=\d)([pm])(?=\d)",
+        lambda mm: {"p": "+", "m": "-"}[mm.group(1)],
+        m.group("src"),
+    )
+    return f"{src} | {m.group('lo')}-{m.group('hi')} GHz"
+
+
+def _all_output_kinds(
+    products: tuple[str, ...],
+    plot: bool,
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    """Return (fits_kinds, single_panel_png_kinds, summary_png_kinds).
+
+    All three are filtered by the caller's ``products`` selection plus a
+    plot flag. ``products`` carries PRODUCT_KINDS + (optionally)
+    SUMMARY_PLOT_KINDS — the latter only meaningful when ``plot=True``.
+    """
+    fits_kinds = tuple(k for k in PRODUCT_KINDS if k in products)
+    if not plot:
+        return fits_kinds, (), ()
+    single = tuple(k for k in SINGLE_PANEL_MAP_PNG_KINDS if k in products)
+    paired = tuple(k for k in PAIRED_SPECTRUM_PLOT_KINDS if k in products)
+    summary = tuple(k for k in SUMMARY_PLOT_KINDS if k in products)
+    return fits_kinds, single + paired, summary
+
+
+def process_cube(
+    pbcor_path: Path,
+    analysis_dir: Path,
+    *,
+    products: Iterable[str] = PRODUCT_KINDS + SUMMARY_PLOT_KINDS
+                              + PAIRED_SPECTRUM_PLOT_KINDS,
+    force: bool = False,
+    dry_run: bool = False,
+    plot: bool = True,
+) -> CleanDiagResult:
+    """Generate clean-diagnostics products for a single 12m7m pbcor cube.
+
+    Catches per-cube exceptions, logs, and returns ``failed:<reason>``
+    statuses; never raises. When ``plot=True`` PNG plots accompany each
+    FITS product, plus the two multi-panel summary PNGs.
+    """
+    requested = tuple(products)
+    statuses: dict[str, str] = {}
+
+    try:
+        sibling_paths = resolve_siblings(pbcor_path)
+    except MissingSibling as exc:
+        # Surface as failed:missing_<kind> on every requested product.
+        reason = f"failed:{exc.short_tag}:{exc}"
+        for kind in requested:
+            statuses[kind] = reason
+        logger.error("%s: %s", pbcor_path.name, reason)
+        return CleanDiagResult(cube=pbcor_path, products=statuses)
+
+    clock = input_mtime(sibling_paths)
+
+    fits_paths = derive_output_paths(pbcor_path, analysis_dir, PRODUCT_KINDS)
+    all_png_kinds = SINGLE_PANEL_MAP_PNG_KINDS + PAIRED_SPECTRUM_PLOT_KINDS + SUMMARY_PLOT_KINDS
+    png_paths = derive_plot_paths(pbcor_path, analysis_dir, all_png_kinds)
+
+    fits_kinds, single_png_kinds, summary_png_kinds = _all_output_kinds(
+        requested, plot,
+    )
+
+    needed_fits = {
+        kind: fits_paths[kind] for kind in fits_kinds
+        if needs_regeneration(clock, fits_paths[kind], force)
+    }
+    needed_png = {
+        kind: png_paths[kind] for kind in single_png_kinds
+        if needs_regeneration(clock, png_paths[kind], force)
+    }
+    needed_summary = {
+        kind: png_paths[kind] for kind in summary_png_kinds
+        if needs_regeneration(clock, png_paths[kind], force)
+    }
+    for kind in fits_kinds:
+        if kind not in needed_fits:
+            statuses[kind] = "skipped"
+    for kind in single_png_kinds:
+        key = f"plot:{kind}"
+        if kind not in needed_png:
+            statuses[key] = "skipped"
+    for kind in summary_png_kinds:
+        key = f"plot:{kind}"
+        if kind not in needed_summary:
+            statuses[key] = "skipped"
+
+    if dry_run:
+        for kind in needed_fits:
+            statuses[kind] = "dry-run"
+            logger.info("[dry-run] would write %s", needed_fits[kind])
+        for kind in needed_png:
+            statuses[f"plot:{kind}"] = "dry-run"
+            logger.info("[dry-run] would write %s", needed_png[kind])
+        for kind in needed_summary:
+            statuses[f"plot:{kind}"] = "dry-run"
+            logger.info("[dry-run] would write %s", needed_summary[kind])
+        return CleanDiagResult(cube=pbcor_path, products=statuses)
+
+    if not needed_fits and not needed_png and not needed_summary:
+        return CleanDiagResult(cube=pbcor_path, products=statuses)
+
+    # Heavy work begins here.
+    try:
+        with contextlib.ExitStack() as stack:
+            bundle = _open_cube_arrays(sibling_paths, stack)
+            result = compute_diagnostics(bundle)
+
+            # K conversion uses pbcor's beam via SpectralCube (metadata-only).
+            from spectral_cube import SpectralCube
+            from panta_rei.analysis.plots import (
+                jtok_scalar,
+                jtok_per_channel,
+                cube_frequency_axis_hz,
+            )
+
+            pbcor_cube = SpectralCube.read(str(bundle.pbcor_path))
+            jytok = jtok_scalar(pbcor_cube)
+            if jytok is None:
+                logger.warning(
+                    "%s: cannot derive jtok (missing RESTFRQ or beam) — "
+                    "FITS will be in Jy/beam units",
+                    pbcor_path.name,
+                )
+                map_factor = 1.0
+                map_bunit_2d = "Jy/beam"
+                map_bunit_mom0 = "Jy/beam km/s"
+                spec_factor = np.ones(result.freq_hz.size, dtype=np.float64)
+                spec_unit = "Jy/beam"
+            else:
+                map_factor = jytok
+                map_bunit_2d = "K"
+                map_bunit_mom0 = "K km/s"
+                spec_factor = jtok_per_channel(
+                    pbcor_cube, cube_frequency_axis_hz(pbcor_cube),
+                )
+                spec_unit = "K"
+
+            # Build the data we'll feed to the FITS writers, indexed by kind.
+            map_payloads = {
+                "integrated_intensity_image":
+                    (result.integ_image_jy * map_factor, map_bunit_mom0),
+                "integrated_intensity_residual":
+                    (result.integ_resid_jy * map_factor, map_bunit_mom0),
+                "peak_intensity_image":
+                    (result.peak_image_jy * map_factor, map_bunit_2d),
+                "peak_intensity_residual":
+                    (result.peak_resid_jy * map_factor, map_bunit_2d),
+            }
+            for kind, (arr, bunit) in map_payloads.items():
+                if kind in needed_fits:
+                    try:
+                        _write_map_fits(
+                            arr, needed_fits[kind],
+                            bunit=bunit, product_kind=kind,
+                            bundle=bundle,
+                            jytok=jytok if jytok is not None else 1.0,
+                        )
+                        statuses[kind] = "written"
+                        logger.info("wrote %s", needed_fits[kind])
+                    except Exception as exc:  # pragma: no cover
+                        reason = f"failed:write_map:{type(exc).__name__}:{exc}"
+                        logger.error("%s: %s", pbcor_path.name, reason)
+                        statuses[kind] = reason
+
+            if "clean_mask" in needed_fits:
+                try:
+                    _write_mask_fits(
+                        result.mask_2d, needed_fits["clean_mask"],
+                        product_kind="clean_mask", bundle=bundle,
+                    )
+                    statuses["clean_mask"] = "written"
+                    logger.info("wrote %s", needed_fits["clean_mask"])
+                except Exception as exc:  # pragma: no cover
+                    reason = f"failed:write_mask:{type(exc).__name__}:{exc}"
+                    logger.error("%s: %s", pbcor_path.name, reason)
+                    statuses["clean_mask"] = reason
+
+            # Spectra. spec_factor is per-channel; works for the unit
+            # fallback path because it's all-ones in that case.
+            spec_payloads = {
+                "mean_spectrum_image_in_mask":
+                    (result.spec_image_jy * spec_factor, "clean_mask"),
+                "mean_spectrum_residual_in_mask":
+                    (result.spec_resid_jy * spec_factor, "clean_mask"),
+            }
+            # Spectral-axis values: use km/s (radio convention) if RESTFRQ
+            # is set, else Hz.
+            try:
+                spec_cube_kms = pbcor_cube.with_spectral_unit(
+                    u.km / u.s, velocity_convention="radio",
+                    rest_value=pbcor_cube.header.get("RESTFRQ") * u.Hz
+                    if pbcor_cube.header.get("RESTFRQ") else None,
+                )
+                spectral_values = np.asarray(
+                    spec_cube_kms.spectral_axis.to(u.km / u.s).value,
+                    dtype=np.float64,
+                )
+                spectral_unit = "km/s"
+            except Exception:
+                spectral_values = result.freq_hz
+                spectral_unit = "Hz"
+
+            for kind, (vals, mask_kind) in spec_payloads.items():
+                if kind in needed_fits:
+                    try:
+                        _write_spectrum_fits(
+                            vals, spectral_values, spectral_unit,
+                            needed_fits[kind],
+                            product_kind=kind, bundle=bundle, mask_kind=mask_kind,
+                        )
+                        statuses[kind] = "written"
+                        logger.info("wrote %s", needed_fits[kind])
+                    except Exception as exc:  # pragma: no cover
+                        reason = f"failed:write_spectrum:{type(exc).__name__}:{exc}"
+                        logger.error("%s: %s", pbcor_path.name, reason)
+                        statuses[kind] = reason
+
+            # Plots — defer to the plot module so the heavy compute work
+            # above remains import-light.
+            if needed_png or needed_summary:
+                from panta_rei.analysis.clean_diagnostics_plots import (
+                    plot_payload_for_cube,
+                )
+                # Pre-compute K-space arrays for plotting (independent of
+                # whether the matching FITS was selected).
+                k_payloads = {
+                    "integ_image_k": result.integ_image_jy * map_factor,
+                    "integ_resid_k": result.integ_resid_jy * map_factor,
+                    "peak_image_k":  result.peak_image_jy  * map_factor,
+                    "peak_resid_k":  result.peak_resid_jy  * map_factor,
+                    "spec_image_k":  result.spec_image_jy  * spec_factor,
+                    "spec_resid_k":  result.spec_resid_jy  * spec_factor,
+                    "spectral_values": spectral_values,
+                    "spectral_unit":   spectral_unit,
+                    "mask_2d":         result.mask_2d,
+                    "map_bunit_2d":    map_bunit_2d,
+                    "map_bunit_mom0":  map_bunit_mom0,
+                    "spec_unit":       spec_unit,
+                }
+                source_label = human_source_label(pbcor_path)
+                plot_payload_for_cube(
+                    bundle=bundle,
+                    payload=k_payloads,
+                    needed_png=needed_png,
+                    needed_summary=needed_summary,
+                    statuses=statuses,
+                    source_label=source_label,
+                )
+
+    except CleanDiagError as exc:
+        reason = f"failed:{exc.short_tag}:{exc}"
+        logger.error("%s: %s", pbcor_path.name, reason)
+        for kind in fits_kinds:
+            statuses.setdefault(kind, reason)
+        for kind in single_png_kinds:
+            statuses.setdefault(f"plot:{kind}", reason)
+        for kind in summary_png_kinds:
+            statuses.setdefault(f"plot:{kind}", reason)
+    except Exception as exc:  # pragma: no cover - cube-payload-dependent
+        reason = f"failed:compute:{type(exc).__name__}:{exc}"
+        logger.error("%s: %s", pbcor_path.name, reason)
+        for kind in fits_kinds:
+            statuses.setdefault(kind, reason)
+        for kind in single_png_kinds:
+            statuses.setdefault(f"plot:{kind}", reason)
+        for kind in summary_png_kinds:
+            statuses.setdefault(f"plot:{kind}", reason)
+
+    return CleanDiagResult(cube=pbcor_path, products=statuses)

--- a/panta_rei/analysis/clean_diagnostics_plots.py
+++ b/panta_rei/analysis/clean_diagnostics_plots.py
@@ -1,0 +1,375 @@
+"""QA plot generation for the 12m+7m clean-diagnostics products.
+
+Two flavours of plot:
+
+- **Per-product PNGs** — one PNG per intensity map and mask, plus a
+  paired-spectrum PNG per mask (cube + residual on one axis).
+- **Summary multi-panel PNGs** — two 3-panel summaries (integrated, peak)
+  with shared colour scale across the map panels and the mask contour
+  overlaid on both.
+
+All map values are in K (or K·km/s for moment-0); the conversion from
+Jy/beam → K happens in the compute layer using the pbcor's beam as the
+canonical source.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from astropy.wcs import WCS  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+ARRAY_TAG = "12m7m"
+CMAP_MAP = "inferno"
+CMAP_MASK = "Greys"
+COLOR_IMAGE = "cornflowerblue"
+COLOR_RESIDUAL = "firebrick"
+LINESTYLE_IMAGE = "-"
+LINESTYLE_RESIDUAL = "--"
+MASK_CONTOUR_COLOR = "white"
+
+
+def _atomic_savefig(fig, out_path: Path, dpi: int = 150) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_name(out_path.name + ".tmp")
+    fig.savefig(tmp, dpi=dpi, bbox_inches="tight", format="png")
+    os.replace(tmp, out_path)
+
+
+def _percentile_limits(*arrays: np.ndarray) -> tuple[float, float]:
+    """Joint 1st / 99.5th percentile across multiple 2D arrays."""
+    stacked = np.concatenate([
+        np.asarray(a).ravel() for a in arrays if a is not None
+    ])
+    finite = stacked[np.isfinite(stacked)]
+    if finite.size == 0:
+        return 0.0, 1.0
+    vmin = float(np.nanpercentile(finite, 1.0))
+    vmax = float(np.nanpercentile(finite, 99.5))
+    if vmax <= vmin:
+        vmin = float(np.nanmin(finite))
+        vmax = float(np.nanmax(finite))
+        if vmax <= vmin:
+            vmax = vmin + 1.0
+    return vmin, vmax
+
+
+def _wcs_from_header(header) -> WCS | None:
+    try:
+        return WCS(header).celestial
+    except Exception:
+        return None
+
+
+def _cbar_label_for(map_bunit: str, kind: str) -> str:
+    if kind.startswith("integrated"):
+        if map_bunit.startswith("K"):
+            return r"Integrated $T_B$ (K km s$^{-1}$)"
+        return f"Integrated intensity ({map_bunit})"
+    if kind.startswith("peak"):
+        if map_bunit.startswith("K"):
+            return r"Peak $T_B$ (K)"
+        return f"Peak intensity ({map_bunit})"
+    return map_bunit
+
+
+def _title_for_kind(kind: str, source_label: str | None) -> str:
+    pretty = kind.replace("_", " ")
+    title = f"{ARRAY_TAG} | {pretty}"
+    if source_label:
+        title = f"{title} | {source_label}"
+    return title
+
+
+def _plot_single_map(
+    arr: np.ndarray,
+    header,
+    out_path: Path,
+    kind: str,
+    bunit: str,
+    *,
+    source_label: str | None,
+) -> None:
+    wcs = _wcs_from_header(header)
+    fig = plt.figure(figsize=(7.5, 6.0))
+    if wcs is not None:
+        ax = fig.add_subplot(111, projection=wcs)
+        ax.set_xlabel("RA (J2000)")
+        ax.set_ylabel("Dec (J2000)")
+    else:
+        ax = fig.add_subplot(111)
+        ax.set_xlabel("x (pix)")
+        ax.set_ylabel("y (pix)")
+    try:
+        vmin, vmax = _percentile_limits(arr)
+        im = ax.imshow(
+            arr, origin="lower", cmap=CMAP_MAP,
+            vmin=vmin, vmax=vmax, interpolation="nearest",
+        )
+        fig.colorbar(im, ax=ax, label=_cbar_label_for(bunit, kind),
+                     fraction=0.046, pad=0.04)
+        ax.set_title(_title_for_kind(kind, source_label), fontsize=10)
+        fig.tight_layout()
+        _atomic_savefig(fig, out_path)
+    finally:
+        plt.close(fig)
+
+
+def _plot_mask(
+    mask_2d: np.ndarray,
+    header,
+    out_path: Path,
+    kind: str,
+    *,
+    source_label: str | None,
+) -> None:
+    wcs = _wcs_from_header(header)
+    fig = plt.figure(figsize=(7.5, 6.0))
+    if wcs is not None:
+        ax = fig.add_subplot(111, projection=wcs)
+        ax.set_xlabel("RA (J2000)")
+        ax.set_ylabel("Dec (J2000)")
+    else:
+        ax = fig.add_subplot(111)
+    try:
+        ax.imshow(mask_2d, origin="lower", cmap=CMAP_MASK,
+                  vmin=0, vmax=1, interpolation="nearest")
+        ax.set_title(_title_for_kind(kind, source_label), fontsize=10)
+        fig.tight_layout()
+        _atomic_savefig(fig, out_path)
+    finally:
+        plt.close(fig)
+
+
+def _plot_paired_spectrum(
+    spec_image_k: np.ndarray,
+    spec_resid_k: np.ndarray,
+    spectral_values: np.ndarray,
+    spectral_unit: str,
+    spec_unit: str,
+    out_path: Path,
+    mask_kind: str,
+    *,
+    source_label: str | None,
+) -> None:
+    fig, ax = plt.subplots(figsize=(8.0, 4.5))
+    try:
+        x = spectral_values
+        if spectral_unit == "Hz":
+            x = x / 1e9
+            xlabel = "Frequency (GHz)"
+        elif spectral_unit == "km/s":
+            xlabel = "Velocity (km/s, radio)"
+        else:
+            xlabel = f"Spectral ({spectral_unit})"
+        ax.axhline(0.0, color="black", linewidth=0.6, alpha=0.4)
+        if np.any(np.isfinite(spec_image_k)):
+            ax.plot(x, spec_image_k, color=COLOR_IMAGE, linewidth=1.5,
+                    linestyle=LINESTYLE_IMAGE, label="image (no pbcor)")
+        else:
+            ax.text(0.5, 0.6, "image spectrum: all NaN",
+                    transform=ax.transAxes, ha="center", color=COLOR_IMAGE)
+        if np.any(np.isfinite(spec_resid_k)):
+            ax.plot(x, spec_resid_k, color=COLOR_RESIDUAL, linewidth=1.5,
+                    linestyle=LINESTYLE_RESIDUAL, label="residual")
+        else:
+            ax.text(0.5, 0.5, "residual spectrum: all NaN",
+                    transform=ax.transAxes, ha="center", color=COLOR_RESIDUAL)
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(rf"Mean within mask ({spec_unit})")
+        ax.grid(True, which="both", linestyle="--", linewidth=0.5, alpha=0.5)
+        ax.legend(loc="upper right", fontsize=9)
+        kind_pretty = mask_kind.replace("_", " ")
+        title = f"{ARRAY_TAG} | {kind_pretty}"
+        if source_label:
+            title = f"{title} | {source_label}"
+        ax.set_title(title, fontsize=10)
+        fig.tight_layout()
+        _atomic_savefig(fig, out_path)
+    finally:
+        plt.close(fig)
+
+
+def _plot_summary(
+    map_image_k: np.ndarray,
+    map_resid_k: np.ndarray,
+    mask_2d: np.ndarray,
+    map_bunit: str,
+    header,
+    out_path: Path,
+    flavour: str,  # "integrated" or "peak"
+    *,
+    source_label: str | None,
+) -> None:
+    """Two-panel summary: map(image) and map(residual) with shared cbar.
+
+    Layout: 3-column gridspec — two equal map columns + a narrow cbar
+    column. The shared colour scale (joint 1st/99.5th percentile) makes
+    image vs residual directly comparable. The clean-mask contour is
+    overlaid on both panels.
+
+    The mask-averaged spectrum is its own product
+    (``mean_spectra_in_mask.png``) and is not duplicated here.
+    """
+    wcs = _wcs_from_header(header)
+    fig = plt.figure(figsize=(11.0, 4.7))
+    gs = fig.add_gridspec(
+        1, 3,
+        width_ratios=[1.0, 1.0, 0.05],
+        wspace=0.15,
+    )
+    if wcs is not None:
+        ax1 = fig.add_subplot(gs[0, 0], projection=wcs)
+        ax2 = fig.add_subplot(gs[0, 1], projection=wcs)
+    else:
+        ax1 = fig.add_subplot(gs[0, 0])
+        ax2 = fig.add_subplot(gs[0, 1])
+    cax = fig.add_subplot(gs[0, 2])
+
+    try:
+        vmin, vmax = _percentile_limits(map_image_k, map_resid_k)
+        im1 = ax1.imshow(map_image_k, origin="lower", cmap=CMAP_MAP,
+                         vmin=vmin, vmax=vmax, interpolation="nearest")
+        ax2.imshow(map_resid_k, origin="lower", cmap=CMAP_MAP,
+                   vmin=vmin, vmax=vmax, interpolation="nearest")
+        if mask_2d.any():
+            ax1.contour(mask_2d.astype(np.float32), levels=[0.5],
+                        colors=MASK_CONTOUR_COLOR, linewidths=0.7, alpha=0.9)
+            ax2.contour(mask_2d.astype(np.float32), levels=[0.5],
+                        colors=MASK_CONTOUR_COLOR, linewidths=0.7, alpha=0.9)
+
+        fig.colorbar(im1, cax=cax, label=_cbar_label_for(map_bunit, flavour))
+
+        for ax, panel in ((ax1, "image"), (ax2, "residual")):
+            ax.set_title(f"{flavour}: {panel}", fontsize=10)
+            if wcs is not None:
+                ax.set_xlabel("RA (J2000)")
+                ax.set_ylabel("Dec (J2000)")
+        # ax2 shares ax1's WCS exactly — hide the residual panel's Dec
+        # axis label + tick labels so they don't bleed into ax1's frame.
+        # On WCSAxes we use coords[1] (Dec); on plain axes the regular
+        # ylabel API.
+        if wcs is not None:
+            ax2.coords[1].set_ticklabel_visible(False)
+            ax2.coords[1].set_axislabel("")
+        else:
+            ax2.set_yticklabels([])
+            ax2.set_ylabel("")
+
+        suptitle = f"{ARRAY_TAG} | {flavour} summary"
+        if source_label:
+            suptitle = f"{suptitle} | {source_label}"
+        fig.suptitle(suptitle, fontsize=11)
+        _atomic_savefig(fig, out_path)
+    finally:
+        plt.close(fig)
+
+
+def plot_payload_for_cube(
+    *,
+    bundle,
+    payload: dict[str, Any],
+    needed_png: dict[str, Path],
+    needed_summary: dict[str, Path],
+    statuses: dict[str, str],
+    source_label: str | None,
+) -> None:
+    """Driver: turn a compute result into the requested PNGs.
+
+    Called from :func:`process_cube` so the heavy compute / FITS-write
+    work stays in ``clean_diagnostics.py`` and the matplotlib import
+    happens lazily.
+    """
+    header = bundle.header
+
+    # Per-product map / mask / paired-spectrum PNGs.
+    map_dispatch = {
+        "integrated_intensity_image":
+            (payload["integ_image_k"], payload["map_bunit_mom0"]),
+        "integrated_intensity_residual":
+            (payload["integ_resid_k"], payload["map_bunit_mom0"]),
+        "peak_intensity_image":
+            (payload["peak_image_k"], payload["map_bunit_2d"]),
+        "peak_intensity_residual":
+            (payload["peak_resid_k"], payload["map_bunit_2d"]),
+    }
+    for kind, (arr, bunit) in map_dispatch.items():
+        if kind in needed_png:
+            try:
+                _plot_single_map(
+                    arr, header, needed_png[kind],
+                    kind=kind, bunit=bunit, source_label=source_label,
+                )
+                statuses[f"plot:{kind}"] = "written"
+                logger.info("wrote %s", needed_png[kind])
+            except Exception as exc:  # pragma: no cover
+                reason = f"failed:plot_{kind}:{type(exc).__name__}:{exc}"
+                logger.error("%s: %s", bundle.pbcor_path.name, reason)
+                statuses[f"plot:{kind}"] = reason
+
+    if "clean_mask" in needed_png:
+        try:
+            _plot_mask(
+                payload["mask_2d"], header, needed_png["clean_mask"],
+                kind="clean_mask", source_label=source_label,
+            )
+            statuses["plot:clean_mask"] = "written"
+            logger.info("wrote %s", needed_png["clean_mask"])
+        except Exception as exc:  # pragma: no cover
+            reason = f"failed:plot_clean_mask:{type(exc).__name__}:{exc}"
+            logger.error("%s: %s", bundle.pbcor_path.name, reason)
+            statuses["plot:clean_mask"] = reason
+
+    if "mean_spectra_in_mask" in needed_png:
+        try:
+            _plot_paired_spectrum(
+                payload["spec_image_k"], payload["spec_resid_k"],
+                payload["spectral_values"], payload["spectral_unit"],
+                payload["spec_unit"],
+                needed_png["mean_spectra_in_mask"],
+                mask_kind="clean_mask",
+                source_label=source_label,
+            )
+            statuses["plot:mean_spectra_in_mask"] = "written"
+            logger.info("wrote %s", needed_png["mean_spectra_in_mask"])
+        except Exception as exc:  # pragma: no cover
+            reason = f"failed:plot_mean_spectra_in_mask:{type(exc).__name__}:{exc}"
+            logger.error("%s: %s", bundle.pbcor_path.name, reason)
+            statuses["plot:mean_spectra_in_mask"] = reason
+
+    # Summary plots (image | residual, with shared cbar + mask contour).
+    summary_inputs = {
+        "summary_integrated": (
+            payload["integ_image_k"], payload["integ_resid_k"],
+            payload["map_bunit_mom0"], "integrated",
+        ),
+        "summary_peak": (
+            payload["peak_image_k"], payload["peak_resid_k"],
+            payload["map_bunit_2d"], "peak",
+        ),
+    }
+    for kind, (map_img, map_res, map_bunit, flavour) in summary_inputs.items():
+        if kind in needed_summary:
+            try:
+                _plot_summary(
+                    map_img, map_res, payload["mask_2d"],
+                    map_bunit, header, needed_summary[kind],
+                    flavour=flavour, source_label=source_label,
+                )
+                statuses[f"plot:{kind}"] = "written"
+                logger.info("wrote %s", needed_summary[kind])
+            except Exception as exc:  # pragma: no cover
+                reason = f"failed:plot_{kind}:{type(exc).__name__}:{exc}"
+                logger.error("%s: %s", bundle.pbcor_path.name, reason)
+                statuses[f"plot:{kind}"] = reason

--- a/panta_rei/cli/run_calibration.py
+++ b/panta_rei/cli/run_calibration.py
@@ -29,6 +29,31 @@ from panta_rei.db.models import PIRunsQueries, PIRunStatus
 log = logging.getLogger(__name__)
 
 
+_FALLBACK_CASA_CMD = 'casa --nologger --nogui --pipeline -c "{script}"'
+
+
+def _default_casa_cmd() -> str:
+    """Resolve the default --casa-cmd template from .env / environment.
+
+    Delegates to :class:`panta_rei.config.PipelineConfig`, which already
+    knows how to read ``CASA_PATH`` from ``.env`` (or the live
+    environment) and assemble the canonical CASA invocation. Appends
+    the ``-c "{script}"`` suffix this CLI uses.
+
+    Falls back to bare ``casa`` on PATH if config loading fails for
+    any reason (e.g. ``PANTA_REI_BASE`` not set, no ``.env``) so the
+    CLI never crashes at argparse-default time over config plumbing.
+    """
+    try:
+        from panta_rei.config import PipelineConfig
+        cfg = PipelineConfig.from_env()
+        if cfg.casa_cmd:
+            return f'{cfg.casa_cmd} -c "{{script}}"'
+    except Exception:
+        pass
+    return _FALLBACK_CASA_CMD
+
+
 # ---------------------------------------------------------------------------
 # Helpers (ported from legacy run_script_for_pi.py)
 # ---------------------------------------------------------------------------
@@ -368,8 +393,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ap.add_argument(
         "--casa-cmd",
-        default='casa --nologger --nogui --pipeline -c "{script}"',
-        help='Command template to run CASA. Must include {script}.',
+        default=_default_casa_cmd(),
+        help=(
+            "Command template to run CASA. Must include {script}. "
+            "Defaults to $CASA_PATH/bin/casa ... when CASA_PATH is set "
+            "(via .env), else bare 'casa' on PATH."
+        ),
     )
     ap.add_argument(
         "--dry-run", action="store_true",

--- a/panta_rei/cli/run_clean_diagnostics.py
+++ b/panta_rei/cli/run_clean_diagnostics.py
@@ -1,0 +1,226 @@
+"""CLI entry point for the 12m+7m clean-diagnostics QA pipeline.
+
+Discovers ``*.cube.pbcor.fits`` files under
+``<base-dir>/imaging/output/aux/group.*.lp_nperetto/`` (the aux subtree
+where the deferred-aux-products patch publishes mask/residual/pb
+alongside each 12m7m pbcor) and produces:
+
+- 10 FITS products per cube (4 intensity maps in K / K·km/s, 2 uint8
+  mask projections, 4 mean-spectrum BinTables)
+- 8 single-panel PNGs per cube (4 maps, 2 masks, 2 paired-spectrum)
+- 2 three-panel summary PNGs per cube (integrated, peak)
+
+Output goes under ``<base-dir>/analysis/<group_dir>/{fits,png}/`` —
+same shard layout as ``panta-rei-moments``. Idempotent: re-runs only
+regenerate outputs older than the **newest** of their 4 input siblings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from panta_rei.analysis.clean_diagnostics import (
+    DEFAULT_ARRAY_COMBOS,
+    PAIRED_SPECTRUM_PLOT_KINDS,
+    PRODUCT_KINDS,
+    SUMMARY_PLOT_KINDS,
+    discover_cubes,
+    process_cube,
+)
+from panta_rei.core.logging import setup_logging
+
+logger = logging.getLogger("panta_rei.cli.run_clean_diagnostics")
+
+
+ALL_PRODUCT_KINDS = PRODUCT_KINDS + SUMMARY_PLOT_KINDS + PAIRED_SPECTRUM_PLOT_KINDS
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Generate clean-imaging QA diagnostics (image / residual moment "
+            "and peak maps, 2D mask projections, mask-averaged spectra, plus "
+            "3-panel summary plots) for 12m+7m pbcor cubes."
+        ),
+    )
+    ap.add_argument(
+        "--base-dir", required=True,
+        help="Project base directory (e.g. ./2025.1.00383.L)",
+    )
+    ap.add_argument(
+        "--imaging-dir", default=None,
+        help="Imaging output dir (default: <base-dir>/imaging/output)",
+    )
+    ap.add_argument(
+        "--analysis-dir", default=None,
+        help="Analysis output dir (default: <base-dir>/analysis)",
+    )
+    ap.add_argument(
+        "--group", action="append", default=None, metavar="SUBSTR",
+        help="Substring filter on group dirname (repeatable).",
+    )
+    ap.add_argument(
+        "--match", default=None, metavar="REGEX",
+        help="Regex filter on pbcor filename (e.g. 'AG310.8797').",
+    )
+    ap.add_argument(
+        "--products", nargs="+", default=list(ALL_PRODUCT_KINDS),
+        choices=ALL_PRODUCT_KINDS,
+        help="Products to generate (default: all).",
+    )
+    ap.add_argument(
+        "--force", action="store_true",
+        help="Regenerate outputs even when newer than the input siblings.",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true",
+        help="List planned actions without writing files.",
+    )
+    ap.add_argument(
+        "--plots", action=argparse.BooleanOptionalAction, default=True,
+        help="Render PNGs alongside each FITS product (default on).",
+    )
+    ap.add_argument(
+        "--jobs", type=int, default=1, metavar="N",
+        help="Parallel cubes to process (default: 1; 4 is a safe ceiling).",
+    )
+    ap.add_argument(
+        "--limit", type=int, default=None, metavar="N",
+        help="Process at most N cubes (debugging).",
+    )
+    ap.add_argument(
+        "--log-file", default=None,
+        help=(
+            "Optional log file (default: <analysis-dir>/.clean_diagnostics.log). "
+            "Pass an empty string to disable file logging."
+        ),
+    )
+    return ap
+
+
+def _resolve_paths(args: argparse.Namespace) -> tuple[Path, Path, Path]:
+    base_dir = Path(args.base_dir).resolve()
+    imaging_dir = (
+        Path(args.imaging_dir).resolve() if args.imaging_dir
+        else base_dir / "imaging" / "output"
+    )
+    analysis_dir = (
+        Path(args.analysis_dir).resolve() if args.analysis_dir
+        else base_dir / "analysis"
+    )
+    return base_dir, imaging_dir, analysis_dir
+
+
+def _resolve_log_file(args: argparse.Namespace, analysis_dir: Path) -> Path | None:
+    if args.log_file is None:
+        return analysis_dir / ".clean_diagnostics.log"
+    if args.log_file == "":
+        return None
+    return Path(args.log_file)
+
+
+def _filter_cubes(cubes, match_regex, limit):
+    if match_regex:
+        pattern = re.compile(match_regex)
+        cubes = [c for c in cubes if pattern.search(c.name)]
+    if limit is not None:
+        cubes = cubes[:limit]
+    return cubes
+
+
+def _summarize(results, total):
+    n_written = n_skipped = n_failed = 0
+    for r in results:
+        for status in r.products.values():
+            if status == "written":
+                n_written += 1
+            elif status == "skipped":
+                n_skipped += 1
+            elif status.startswith("failed:"):
+                n_failed += 1
+    logger.info(
+        "Done: %d cubes processed; products written=%d skipped=%d failed=%d",
+        len(results), n_written, n_skipped, n_failed,
+    )
+    return n_written, n_skipped, n_failed
+
+
+def _run_serial(cubes, analysis_dir, products, force, dry_run, plot):
+    results = []
+    for cube in cubes:
+        results.append(process_cube(
+            cube, analysis_dir, products=products,
+            force=force, dry_run=dry_run, plot=plot,
+        ))
+    return results
+
+
+def _run_parallel(cubes, analysis_dir, products, force, dry_run, jobs, plot):
+    results = []
+    with ProcessPoolExecutor(max_workers=jobs) as pool:
+        futures = {
+            pool.submit(
+                process_cube, cube, analysis_dir,
+                products=products, force=force, dry_run=dry_run, plot=plot,
+            ): cube for cube in cubes
+        }
+        for fut in as_completed(futures):
+            cube = futures[fut]
+            try:
+                results.append(fut.result())
+            except Exception as exc:
+                logger.error("%s: worker crashed: %s", cube.name, exc)
+    return results
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+
+    _, imaging_dir, analysis_dir = _resolve_paths(args)
+    log_file = _resolve_log_file(args, analysis_dir)
+    if log_file is not None:
+        analysis_dir.mkdir(parents=True, exist_ok=True)
+    setup_logging(log_file=log_file)
+
+    if not imaging_dir.is_dir():
+        logger.error("imaging dir does not exist: %s", imaging_dir)
+        return 2
+
+    cubes = discover_cubes(imaging_dir, args.group, array_combos=DEFAULT_ARRAY_COMBOS)
+    cubes = _filter_cubes(cubes, args.match, args.limit)
+    if not cubes:
+        logger.warning(
+            "No cubes matched (imaging_dir=%s, group=%s, match=%r)",
+            imaging_dir, args.group, args.match,
+        )
+        return 0
+
+    logger.info(
+        "Processing %d cube(s) -> %s [products=%s, plots=%s, force=%s, "
+        "dry_run=%s, jobs=%d]",
+        len(cubes), analysis_dir, ",".join(args.products),
+        args.plots, args.force, args.dry_run, args.jobs,
+    )
+
+    products = tuple(args.products)
+    if args.jobs <= 1:
+        results = _run_serial(
+            cubes, analysis_dir, products, args.force, args.dry_run, args.plots,
+        )
+    else:
+        results = _run_parallel(
+            cubes, analysis_dir, products, args.force, args.dry_run, args.jobs,
+            args.plots,
+        )
+
+    _, _, n_failed = _summarize(results, len(cubes))
+    return 0 if n_failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ panta-rei-imaging = "panta_rei.cli.run_imaging:main"
 panta-rei-imaging-dispatch = "panta_rei.cli.run_imaging_dispatch:main"
 panta-rei-contsub = "panta_rei.cli.run_contsub:main"
 panta-rei-moments = "panta_rei.cli.run_moments:main"
+panta-rei-clean-diagnostics = "panta_rei.cli.run_clean_diagnostics:main"
 
 [tool.setuptools.packages.find]
 include = ["panta_rei*"]

--- a/tests/test_clean_diagnostics.py
+++ b/tests/test_clean_diagnostics.py
@@ -1,0 +1,376 @@
+"""Tests for ``panta_rei.analysis.clean_diagnostics``."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+
+# ---------- path / discovery tests (no FITS payload) ----------
+
+
+def test_discover_cubes_only_12m7m_under_aux(tmp_path: Path):
+    from panta_rei.analysis.clean_diagnostics import discover_cubes
+
+    imaging = tmp_path / "imaging" / "output"
+    aux_group = imaging / "aux" / "group.uid___A001_X3833_X64b9.lp_nperetto"
+    plain_group = imaging / "group.uid___A001_X3833_X64b9.lp_nperetto"
+    aux_group.mkdir(parents=True)
+    plain_group.mkdir(parents=True)
+
+    # 12m7m pbcor under aux/ — should be picked up
+    (aux_group / "src.AG.12m7m.86-86.GHz.cube.pbcor.fits").write_bytes(b"")
+    # 12m7mTP sibling under aux/ — same setup but different combo, must NOT match
+    (aux_group / "src.AG.12m7mTP.86-86.GHz.cube.pbcor.fits").write_bytes(b"")
+    # 12m7m pbcor outside aux/ — must NOT match (lives in plain group)
+    (plain_group / "src.AG.12m7m.86-86.GHz.cube.pbcor.fits").write_bytes(b"")
+    # mask/residual/pb under aux/ — must not appear as 'cubes'
+    (aux_group / "src.AG.12m7m.86-86.GHz.cube.mask.fits").write_bytes(b"")
+
+    found = discover_cubes(imaging)
+    assert [p.name for p in found] == ["src.AG.12m7m.86-86.GHz.cube.pbcor.fits"]
+    assert all(p.parent == aux_group for p in found)
+
+
+def test_resolve_siblings_returns_four_paths(tmp_path: Path):
+    from panta_rei.analysis.clean_diagnostics import resolve_siblings
+
+    aux_group = tmp_path / "aux" / "group.uid___A001_X3833_X.lp_nperetto"
+    aux_group.mkdir(parents=True)
+    base = aux_group / "s.AG.12m7m.86-86.GHz.cube"
+    for kind in ("pbcor", "mask", "residual", "pb"):
+        (Path(f"{base}.{kind}.fits")).write_bytes(b"")
+    pbcor = Path(f"{base}.pbcor.fits")
+    sibs = resolve_siblings(pbcor)
+    assert set(sibs) == {"pbcor", "mask", "residual", "pb"}
+    for kind, p in sibs.items():
+        assert p.name.endswith(f".cube.{kind}.fits")
+
+
+def test_resolve_siblings_raises_when_pb_missing(tmp_path: Path):
+    from panta_rei.analysis.clean_diagnostics import MissingSibling, resolve_siblings
+
+    aux_group = tmp_path / "aux" / "group.uid___A001_X3833_X.lp_nperetto"
+    aux_group.mkdir(parents=True)
+    base = aux_group / "s.AG.12m7m.86-86.GHz.cube"
+    # All siblings EXCEPT pb
+    for kind in ("pbcor", "mask", "residual"):
+        (Path(f"{base}.{kind}.fits")).write_bytes(b"")
+    with pytest.raises(MissingSibling) as excinfo:
+        resolve_siblings(Path(f"{base}.pbcor.fits"))
+    assert "pb" in str(excinfo.value)
+
+
+# ---------- synthetic 4D quad ----------
+
+
+def _write_4d_cube(
+    path: Path, data_3d: np.ndarray, *, bunit: str, with_beam: bool,
+) -> None:
+    """Write a (1, n_chan, ny, nx) FITS cube with FREQ axis 3 + STOKES axis 4."""
+    data_4d = data_3d[np.newaxis, ...].astype(np.float32)  # add Stokes axis
+    n_chan, ny, nx = data_3d.shape
+
+    hdr = fits.Header()
+    hdr["NAXIS"] = 4
+    hdr["NAXIS1"] = nx
+    hdr["NAXIS2"] = ny
+    hdr["NAXIS3"] = n_chan
+    hdr["NAXIS4"] = 1
+    hdr["CTYPE1"] = "RA---SIN"
+    hdr["CTYPE2"] = "DEC--SIN"
+    hdr["CTYPE3"] = "FREQ"
+    hdr["CTYPE4"] = "STOKES"
+    hdr["CUNIT1"] = "deg"
+    hdr["CUNIT2"] = "deg"
+    hdr["CUNIT3"] = "Hz"
+    hdr["CRVAL1"] = 0.0
+    hdr["CRVAL2"] = 0.0
+    hdr["CRVAL3"] = 86.0e9
+    hdr["CRVAL4"] = 1.0
+    hdr["CDELT1"] = -0.0001
+    hdr["CDELT2"] = 0.0001
+    hdr["CDELT3"] = 1.0e6  # 1 MHz channels — dv ≈ 3.487 km/s at 86 GHz
+    hdr["CDELT4"] = 1.0
+    hdr["CRPIX1"] = 1.0
+    hdr["CRPIX2"] = 1.0
+    hdr["CRPIX3"] = 1.0
+    hdr["CRPIX4"] = 1.0
+    hdr["BUNIT"] = bunit
+    if with_beam:
+        hdr["BMAJ"] = 1.0e-4
+        hdr["BMIN"] = 8.0e-5
+        hdr["BPA"] = 0.0
+    hdr["RESTFRQ"] = 86.0e9
+    hdr["EQUINOX"] = 2000.0
+    hdr["RADESYS"] = "ICRS"
+    hdr["SPECSYS"] = "LSRK"
+    fits.PrimaryHDU(data=data_4d, header=hdr).writeto(str(path))
+
+
+@pytest.fixture
+def quad_4d(tmp_path: Path) -> dict:
+    """Synthetic 4-cube 4D-singleton-Stokes set under aux/<group>/."""
+    pytest.importorskip("spectral_cube")
+
+    n_chan, ny, nx = 8, 6, 6
+    rng = np.random.default_rng(42)
+
+    pbcor = rng.normal(0.0, 0.01, size=(n_chan, ny, nx)).astype(np.float32)
+    # Inject signal at channel 3 in a 2×2 block
+    pbcor[3, 2:4, 2:4] = 5.0
+    # Residual is the unmodelled flux — small, with a small spike
+    residual = rng.normal(0.0, 0.005, size=(n_chan, ny, nx)).astype(np.float32)
+    residual[3, 2, 2] = 0.3
+    # PB taper from centre — values in [0, 1]
+    yy, xx = np.indices((ny, nx))
+    r = np.sqrt((yy - (ny - 1) / 2) ** 2 + (xx - (nx - 1) / 2) ** 2)
+    pb_plane = np.clip(1.0 - r / (1.5 * (ny / 2)), 0.0, 1.0).astype(np.float32)
+    pb = np.broadcast_to(pb_plane, (n_chan, ny, nx)).copy()
+    # Mask: 1 around the signal pixel only at the signal channel
+    mask = np.zeros((n_chan, ny, nx), dtype=np.float32)
+    mask[3, 2:4, 2:4] = 1.0
+
+    imaging = tmp_path / "imaging" / "output"
+    aux_group = imaging / "aux" / "group.uid___A001_X3833_TEST.lp_nperetto"
+    aux_group.mkdir(parents=True)
+
+    base = aux_group / "synth.AG.12m7m.86-86.GHz.cube"
+    _write_4d_cube(Path(f"{base}.pbcor.fits"), pbcor, bunit="Jy/beam", with_beam=True)
+    _write_4d_cube(Path(f"{base}.mask.fits"), mask, bunit="", with_beam=False)
+    _write_4d_cube(Path(f"{base}.residual.fits"), residual, bunit="", with_beam=False)
+    _write_4d_cube(Path(f"{base}.pb.fits"), pb, bunit="", with_beam=False)
+
+    return {
+        "imaging_dir": imaging,
+        "analysis_dir": tmp_path / "analysis",
+        "pbcor_path": Path(f"{base}.pbcor.fits"),
+        "n_chan": n_chan, "ny": ny, "nx": nx,
+    }
+
+
+# ---------- compute / writer tests ----------
+
+
+def test_process_cube_writes_seven_fits_six_png_two_summary(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import (
+        PRODUCT_KINDS, SUMMARY_PLOT_KINDS, PAIRED_SPECTRUM_PLOT_KINDS,
+        SINGLE_PANEL_MAP_PNG_KINDS,
+        process_cube,
+    )
+
+    res = process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=True)
+
+    # No failures.
+    failures = [k for k, v in res.products.items() if v.startswith("failed:")]
+    assert not failures, f"unexpected failures: {failures}"
+
+    # 7 FITS + 5 single-panel map/mask PNGs + 1 paired-spectrum PNG + 2 summaries.
+    expected_status_keys = set(PRODUCT_KINDS)
+    expected_status_keys |= {f"plot:{k}" for k in SINGLE_PANEL_MAP_PNG_KINDS}
+    expected_status_keys |= {f"plot:{k}" for k in PAIRED_SPECTRUM_PLOT_KINDS}
+    expected_status_keys |= {f"plot:{k}" for k in SUMMARY_PLOT_KINDS}
+    assert set(res.products) == expected_status_keys
+
+    base = quad_4d["pbcor_path"].name[: -len(".cube.pbcor.fits")]
+    group = quad_4d["pbcor_path"].parent.name
+    fits_dir = quad_4d["analysis_dir"] / group / "fits"
+    png_dir = quad_4d["analysis_dir"] / group / "png"
+    for kind in PRODUCT_KINDS:
+        assert (fits_dir / f"{base}.{kind}.fits").exists(), kind
+    for kind in SINGLE_PANEL_MAP_PNG_KINDS + PAIRED_SPECTRUM_PLOT_KINDS + SUMMARY_PLOT_KINDS:
+        assert (png_dir / f"{base}.{kind}.png").exists(), kind
+
+
+def test_squeeze_stokes_via_open_cube_arrays(quad_4d):
+    from contextlib import ExitStack
+
+    from panta_rei.analysis.clean_diagnostics import (
+        _open_cube_arrays, resolve_siblings,
+    )
+
+    sibs = resolve_siblings(quad_4d["pbcor_path"])
+    with ExitStack() as stack:
+        bundle = _open_cube_arrays(sibs, stack)
+        assert bundle.pbcor.shape == (quad_4d["n_chan"], quad_4d["ny"], quad_4d["nx"])
+        assert bundle.residual.shape == bundle.pbcor.shape
+        assert bundle.mask.shape == bundle.pbcor.shape
+        assert bundle.pb.shape == bundle.pbcor.shape
+
+
+def test_shape_mismatch_detected(quad_4d, tmp_path: Path):
+    """If residual has wrong n_chan, ShapeMismatch is raised."""
+    from contextlib import ExitStack
+
+    from panta_rei.analysis.clean_diagnostics import (
+        ShapeMismatch, _open_cube_arrays, resolve_siblings,
+    )
+
+    # Overwrite the residual with a wrong-shape cube.
+    sibs = resolve_siblings(quad_4d["pbcor_path"])
+    bad = np.zeros((quad_4d["n_chan"] + 1, quad_4d["ny"], quad_4d["nx"]),
+                   dtype=np.float32)
+    sibs["residual"].unlink()
+    _write_4d_cube(sibs["residual"], bad, bunit="", with_beam=False)
+
+    with pytest.raises(ShapeMismatch):
+        with ExitStack() as stack:
+            _open_cube_arrays(sibs, stack)
+
+
+def test_dv_kms_from_header_radio_convention():
+    from panta_rei.analysis.clean_diagnostics import compute_dv_kms
+
+    hdr = fits.Header()
+    hdr["NAXIS"] = 3
+    hdr["CTYPE3"] = "FREQ"
+    hdr["CDELT3"] = 1.0e6
+    hdr["RESTFRQ"] = 86.0e9
+    # dv = c * |CDELT3| / RESTFRQ = 299792.458 * 1e6 / 86e9 = 3.4859... km/s
+    assert compute_dv_kms(hdr) == pytest.approx(299792.458 * 1.0e6 / 86.0e9, rel=1e-6)
+
+
+def test_dv_kms_handles_negative_cdelt():
+    from panta_rei.analysis.clean_diagnostics import compute_dv_kms
+
+    hdr = fits.Header()
+    hdr["NAXIS"] = 3
+    hdr["CTYPE3"] = "FREQ"
+    hdr["CDELT3"] = -1.0e6  # flipped sign — must still give positive dv
+    hdr["RESTFRQ"] = 86.0e9
+    assert compute_dv_kms(hdr) > 0
+
+
+def test_mask_is_uint8_zero_one_and_records_projection(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import process_cube
+
+    process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    base = quad_4d["pbcor_path"].name[: -len(".cube.pbcor.fits")]
+    group = quad_4d["pbcor_path"].parent.name
+    out = quad_4d["analysis_dir"] / group / "fits" / f"{base}.clean_mask.fits"
+    with fits.open(out) as hdul:
+        data = hdul[0].data
+        hdr = hdul[0].header
+    assert data.dtype == np.uint8
+    assert set(np.unique(data).tolist()) <= {0, 1}
+    assert hdr["PROJ"] == "max(axis=0)"
+
+
+def test_provenance_keywords_recorded(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import process_cube
+
+    process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    base = quad_4d["pbcor_path"].name[: -len(".cube.pbcor.fits")]
+    group = quad_4d["pbcor_path"].parent.name
+    out = (
+        quad_4d["analysis_dir"] / group / "fits"
+        / f"{base}.peak_intensity_image.fits"
+    )
+    with fits.open(out) as hdul:
+        hdr = hdul[0].header
+    assert hdr["SRCFILE"] == quad_4d["pbcor_path"].name
+    assert hdr["PRODUCT"] == "peak_intensity_image"
+    assert hdr["SIB_PB"].endswith(".cube.pb.fits")
+    assert hdr["SIB_RESI"].endswith(".cube.residual.fits")
+    assert hdr["SIB_MASK"].endswith(".cube.mask.fits")
+    assert "JYTOK" in hdr
+    assert any("RECON_IMG" in str(line) for line in hdr.get("HISTORY", []))
+
+
+def test_output_units_are_kelvin(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import process_cube
+
+    process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    base = quad_4d["pbcor_path"].name[: -len(".cube.pbcor.fits")]
+    group = quad_4d["pbcor_path"].parent.name
+    fits_dir = quad_4d["analysis_dir"] / group / "fits"
+    # Peak in K
+    with fits.open(fits_dir / f"{base}.peak_intensity_image.fits") as hdul:
+        assert hdul[0].header["BUNIT"] == "K"
+    # Moment-0 in K km/s
+    with fits.open(fits_dir / f"{base}.integrated_intensity_image.fits") as hdul:
+        assert hdul[0].header["BUNIT"] == "K km/s"
+    # Spectra FLUX column unit = K
+    with fits.open(fits_dir / f"{base}.mean_spectrum_image_in_mask.fits") as hdul:
+        flux_col = hdul["SPECTRUM"].columns["FLUX"]
+        assert flux_col.unit == "K"
+
+
+def test_idempotent_skip_on_rerun(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import process_cube
+
+    process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    res2 = process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    # All FITS products report skipped (no failures, no rewrites).
+    for kind, status in res2.products.items():
+        assert status == "skipped", (kind, status)
+
+
+def test_mtime_skip_uses_max_of_inputs(quad_4d):
+    """Touching the residual must invalidate the existing outputs."""
+    from panta_rei.analysis.clean_diagnostics import process_cube, resolve_siblings
+
+    process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    sibs = resolve_siblings(quad_4d["pbcor_path"])
+    # Advance the residual's mtime past the just-written outputs.
+    future = time.time() + 5.0
+    os.utime(sibs["residual"], (future, future))
+    res2 = process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    # Outputs must regenerate because input clock advanced.
+    assert any(s == "written" for s in res2.products.values())
+
+
+def test_dry_run_writes_nothing(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import process_cube
+
+    res = process_cube(
+        quad_4d["pbcor_path"], quad_4d["analysis_dir"],
+        plot=False, dry_run=True,
+    )
+    assert any(s == "dry-run" for s in res.products.values())
+    assert not quad_4d["analysis_dir"].exists()
+
+
+def test_force_regenerates(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import process_cube
+
+    process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    res2 = process_cube(
+        quad_4d["pbcor_path"], quad_4d["analysis_dir"],
+        plot=False, force=True,
+    )
+    # Every FITS product reports written (none skipped).
+    assert all(s == "written" for s in res2.products.values()), res2.products
+
+
+def test_missing_sibling_surfaces_per_product(quad_4d):
+    from panta_rei.analysis.clean_diagnostics import process_cube, resolve_siblings
+
+    sibs = resolve_siblings(quad_4d["pbcor_path"])
+    sibs["pb"].unlink()
+    res = process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    assert any(s.startswith("failed:missing_sibling") for s in res.products.values())
+
+
+def test_peak_image_value_is_positive_in_signal_pixel(quad_4d):
+    """Sanity check: the synthetic signal at chan 3, pixel (2,2) drives a
+    positive K value at that pixel in the peak_intensity_image map."""
+    from panta_rei.analysis.clean_diagnostics import process_cube
+
+    process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+    base = quad_4d["pbcor_path"].name[: -len(".cube.pbcor.fits")]
+    group = quad_4d["pbcor_path"].parent.name
+    out = (
+        quad_4d["analysis_dir"] / group / "fits"
+        / f"{base}.peak_intensity_image.fits"
+    )
+    with fits.open(out) as hdul:
+        data = hdul[0].data
+    # signal lives at (y=2,x=2); pb taper attenuates but keeps it well above zero.
+    assert np.isfinite(data[2, 2])
+    assert data[2, 2] > 0

--- a/tests/test_clean_diagnostics.py
+++ b/tests/test_clean_diagnostics.py
@@ -348,13 +348,60 @@ def test_force_regenerates(quad_4d):
     assert all(s == "written" for s in res2.products.values()), res2.products
 
 
-def test_missing_sibling_surfaces_per_product(quad_4d):
+def test_missing_required_sibling_surfaces_per_product(quad_4d):
+    """pb absent → every product fails with missing_sibling (pb is required)."""
     from panta_rei.analysis.clean_diagnostics import process_cube, resolve_siblings
 
     sibs = resolve_siblings(quad_4d["pbcor_path"])
     sibs["pb"].unlink()
     res = process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
     assert any(s.startswith("failed:missing_sibling") for s in res.products.values())
+
+
+def test_missing_mask_synthesises_empty_mask(quad_4d):
+    """mask absent → process continues; mask FITS is all-zero, spectra all-NaN.
+
+    Mirrors the real-world case where tclean's auto-masking found
+    nothing to mask (no detectable emission). The 4 intensity maps
+    remain valuable QA so we still emit them.
+    """
+    from panta_rei.analysis.clean_diagnostics import (
+        PRODUCT_KINDS, process_cube, resolve_siblings,
+    )
+
+    # Delete the mask sibling before processing.
+    sibs = resolve_siblings(quad_4d["pbcor_path"])
+    sibs["mask"].unlink()
+
+    res = process_cube(quad_4d["pbcor_path"], quad_4d["analysis_dir"], plot=False)
+
+    # No failures; all 7 FITS produced.
+    failures = [k for k, v in res.products.items() if v.startswith("failed:")]
+    assert not failures, f"unexpected failures: {failures}"
+
+    base = quad_4d["pbcor_path"].name[: -len(".cube.pbcor.fits")]
+    group = quad_4d["pbcor_path"].parent.name
+    fits_dir = quad_4d["analysis_dir"] / group / "fits"
+    for kind in PRODUCT_KINDS:
+        assert (fits_dir / f"{base}.{kind}.fits").exists(), kind
+
+    # 2D mask is all-zero.
+    with fits.open(fits_dir / f"{base}.clean_mask.fits") as hdul:
+        data = hdul[0].data
+        hdr = hdul[0].header
+    assert data.dtype == np.uint8
+    assert data.sum() == 0
+    assert hdr["SIB_MASK"].startswith("(absent")
+
+    # Image moment / peak maps still finite where signal lived.
+    with fits.open(fits_dir / f"{base}.peak_intensity_image.fits") as hdul:
+        peak = hdul[0].data
+    assert np.isfinite(peak).any()
+
+    # Spectra are all-NaN (mask is empty).
+    with fits.open(fits_dir / f"{base}.mean_spectrum_image_in_mask.fits") as hdul:
+        flux = hdul["SPECTRUM"].data["FLUX"]
+    assert np.all(np.isnan(flux))
 
 
 def test_peak_image_value_is_positive_in_signal_pixel(quad_4d):


### PR DESCRIPTION
## Summary

Adds `panta-rei-clean-diagnostics`, a new CLI for QA of the 12m+7m clean products
(image, residual, mask, pb). For every pbcor cube under `imaging/output/aux/<group>/`
it produces 7 FITS + 8 PNG products per cube, mirroring `panta-rei-moments`:

- **Moment maps** in K / K·km/s: image (`pbcor*pb`) and residual, integrated and peak
- **Clean mask**
- **Averaged spectra within clean masks** in K for image and residual
- **Summary plots**: 2-panel (image | residual) with shared cbar + mask contour
  (`summary_integrated.png`, `summary_peak.png`) plus a paired spectrum
  (`mean_spectra_in_mask.png`)

Plus a few small follow-ups to properly handle missing masks (i.e. tclean found no emission to mask), and automatically passing CASA path via env file.