### PR TITLE
infra: imaging dispatch hardening

### DIFF
--- a/panta_rei/imaging/dispatch.py
+++ b/panta_rei/imaging/dispatch.py
@@ -71,11 +71,26 @@ class GlobalCfg:
     heartbeat_interval_sec: int = 30
     heartbeat_stale_threshold_sec: int = 300
     max_stale_alive_sec: int = 3600
-    state_appeared_timeout_sec: int = 60
+    # Raised from 60s (v5 plan F2.e): cold-cache NFS-backed worker startup
+    # can need several minutes under contention.  Bounded waste per failed
+    # unit is now ~300s + verify-or-quarantine flow.
+    state_appeared_timeout_sec: int = 300
     poll_interval_sec: int = 10
     cleanup_interval_sec: int = 30
     token_reaper_interval_sec: int = 60
     ssh_timeout_sec: int = 30
+    # How long to wait for ``worker.pidfile`` to appear after a launch
+    # whose wrapper_pid is unknown (ssh-timeout, ssh rc!=0, or successful
+    # ssh with unparsable pidfile).  See F2.c + Delta 3.
+    launch_pidfile_wait_sec: int = 30
+    # Single grace knob applied to BOTH worker-side (graceful publish
+    # finish) and orchestrator-side (SIGTERM-to-SIGKILL wait, plus 30s
+    # buffer).  See v4 Delta 6.
+    worker_shutdown_grace_sec: int = 300
+    # If state.json reappears as ``publishing``/``running`` after the
+    # initial state_appeared_timeout, resume polling for up to this many
+    # seconds before quarantining the host.  See F2.h.
+    late_state_grace_sec: int = 1800
 
 
 @dataclass
@@ -304,7 +319,25 @@ class SchedulerState:
     # target for each (machine, gous) pair.  Adopted units inherit the
     # *prior* dispatch_id; new units use the current one.
     pair_dispatch_id: dict[tuple[str, str], str] = field(default_factory=dict)
+    # Per-dispatch host quarantine (v3 F2.d): a host added here is
+    # excluded from pick(), causes its MachineSlot.run() to exit, and
+    # blocks GousCleaner / end-of-run sweep from touching anything on it.
+    quarantined_machines: set[str] = field(default_factory=set)
     lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def quarantine(self, machine: str, *, reason: str = "") -> None:
+        with self.lock:
+            self.quarantined_machines.add(machine)
+
+    def quarantine_all(self, machines) -> None:
+        with self.lock:
+            for m in machines:
+                if m:
+                    self.quarantined_machines.add(m)
+
+    def is_quarantined(self, machine: str) -> bool:
+        with self.lock:
+            return machine in self.quarantined_machines
 
     def queued_for_gous_on_machine(self, gous: str, machine: str) -> int:
         with self.lock:
@@ -321,6 +354,9 @@ class SchedulerState:
     def pick(self, machine: str, run_id_assigner) -> Optional[ImagingUnit]:
         """Return a unit for *machine* per the affinity strategy."""
         with self.lock:
+            # Quarantined host: refuse to assign new work (F2.d).
+            if machine in self.quarantined_machines:
+                return None
             # 1. mapped + staged on this machine
             for i, u in enumerate(self.queue):
                 if (self.gous_machine.get(u.gous_uid) == machine
@@ -547,6 +583,107 @@ def ssh_kill_pgid(machine: str, pgid: int, signal_name: str = "TERM",
 
 
 # ---------------------------------------------------------------------------
+# Verify-or-quarantine cleanup (shared by _dispatch_one + AdoptionPoller +
+# reconcile_prior).  See plan v3 F2.b/v4 Delta 1.
+# ---------------------------------------------------------------------------
+
+# Outcomes from verify_and_kill_worker:
+VERIFY_DEAD = "dead"                # confirmed not running (or PID reused)
+VERIFY_KILLED = "killed"            # alive but TERM/KILL confirmed it dead
+VERIFY_INCONCLUSIVE = "inconclusive"  # ssh-unreachable or kill didn't take
+
+
+def verify_and_kill_worker(
+    machine: str,
+    wrapper_pid: Optional[int],
+    expected_tokens: list[str],
+    g: GlobalCfg,
+    *,
+    sleep_fn=time.sleep,
+) -> tuple[str, str]:
+    """Verify worker ownership, kill if needed, return outcome.
+
+    Returns ``(outcome, message)`` where ``outcome`` is one of
+    ``VERIFY_DEAD``, ``VERIFY_KILLED``, ``VERIFY_INCONCLUSIVE``.
+
+    - ``VERIFY_DEAD``: worker confirmed not running (genuinely dead per
+      ``__DEAD__`` or PID reused for unrelated cmdline).  Safe to
+      MARK_DONE FAILED.
+    - ``VERIFY_KILLED``: worker was alive and we successfully killed it
+      (verified dead after TERM, or after escalation to KILL).  Safe to
+      MARK_DONE FAILED.
+    - ``VERIFY_INCONCLUSIVE``: ssh failed or kill didn't take.  Caller
+      MUST quarantine the host — cleanup is unverified.
+    """
+    if not wrapper_pid:
+        # No PID to verify or kill; caller should treat as inconclusive
+        # (worker may exist with unknown pid).
+        return VERIFY_INCONCLUSIVE, "no wrapper_pid to verify"
+
+    alive, info = ssh_pid_alive(
+        machine, int(wrapper_pid), expected_tokens, timeout=10,
+    )
+    if alive is None:
+        return VERIFY_INCONCLUSIVE, f"ssh-unreachable: {info}"
+    if alive is False:
+        if info:
+            # PID reused for an unrelated process; our worker is gone.
+            return VERIFY_DEAD, f"pid_reused_or_token_mismatch: {info!r}"
+        # __DEAD__ — worker is genuinely not running anymore.
+        return VERIFY_DEAD, "worker_already_exited"
+
+    # alive is True — send SIGTERM, wait the grace, verify.
+    ssh_kill_pgid(machine, int(wrapper_pid), "TERM")
+    sleep_fn(g.worker_shutdown_grace_sec + 30)
+    alive2, info2 = ssh_pid_alive(
+        machine, int(wrapper_pid), expected_tokens, timeout=10,
+    )
+    if alive2 is False:
+        return VERIFY_KILLED, f"sigterm_killed: {info2!r}"
+    if alive2 is None:
+        return VERIFY_INCONCLUSIVE, f"ssh-unreachable post-TERM: {info2}"
+
+    # Still alive — escalate to SIGKILL.
+    ssh_kill_pgid(machine, int(wrapper_pid), "KILL")
+    sleep_fn(5)
+    alive3, info3 = ssh_pid_alive(
+        machine, int(wrapper_pid), expected_tokens, timeout=10,
+    )
+    if alive3 is False:
+        return VERIFY_KILLED, f"sigkill_killed: {info3!r}"
+    if alive3 is None:
+        return VERIFY_INCONCLUSIVE, f"ssh-unreachable post-KILL: {info3}"
+    return VERIFY_INCONCLUSIVE, f"still alive after SIGKILL: {info3!r}"
+
+
+def _read_pidfile(nas_unit_dir: Path) -> Optional[int]:
+    """Return the wrapper_pid recorded in worker.pidfile, or None."""
+    p = Path(nas_unit_dir) / "worker.pidfile"
+    try:
+        return int(p.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _wait_for_pidfile(
+    nas_unit_dir: Path,
+    wait_sec: float,
+    *,
+    sleep_fn=time.sleep,
+    poll_interval: float = 1.0,
+) -> Optional[int]:
+    """Poll for worker.pidfile up to wait_sec; return parsed PID or None."""
+    deadline = time.monotonic() + max(0.0, float(wait_sec))
+    while True:
+        pid = _read_pidfile(nas_unit_dir)
+        if pid is not None:
+            return pid
+        if time.monotonic() >= deadline:
+            return None
+        sleep_fn(poll_interval)
+
+
+# ---------------------------------------------------------------------------
 # Remote launch via a NAS-resident shell launcher script
 # ---------------------------------------------------------------------------
 
@@ -653,6 +790,33 @@ def launch_detached(
 # Polling
 # ---------------------------------------------------------------------------
 
+# Synthetic reasons returned by poll_state_until_terminal when the caller
+# must run the verify-or-quarantine flow (i.e. the worker state was NOT
+# directly observed as terminal).
+_SYNTHETIC_REASONS = frozenset({
+    "state_missing_timeout",
+    "heartbeat_stale_alive",
+    "state_appeared_after_timeout",
+})
+
+
+def _is_observed_terminal(final: Optional[dict]) -> bool:
+    """Return True iff *final* represents a worker-observed terminal state.
+
+    Synthetic terminals produced by orchestrator timeouts (missing
+    state.json, stale-alive heartbeat, grace expiry) are NOT observed:
+    the remote worker may still be alive and a successor must NOT be
+    spawned without first verifying or quarantining.
+    """
+    if not final:
+        return False
+    if final.get("phase") not in {"done", "failed"}:
+        return False
+    if final.get("reason") in _SYNTHETIC_REASONS:
+        return False
+    return True
+
+
 def poll_state_until_terminal(
     machine: str,
     nas_unit_dir: Path,
@@ -689,10 +853,14 @@ def poll_state_until_terminal(
                 state_appeared = True
             else:
                 if time.monotonic() - started > g.state_appeared_timeout_sec:
-                    # Worker never wrote state — likely crashed at launch
+                    # Worker never wrote state — possibly cold-NFS slow
+                    # startup (worker still alive) or crashed at launch.
+                    # Caller (F2.b) decides between verify+kill and
+                    # quarantine; we just signal the synthetic reason.
                     return {
                         "phase": "failed",
                         "success": False,
+                        "reason": "state_missing_timeout",
                         "error_message": (
                             f"state.json never appeared within "
                             f"{g.state_appeared_timeout_sec}s"
@@ -750,17 +918,20 @@ def poll_state_until_terminal(
                     state.get("run_id"), machine, info,
                 )
                 continue
-            # Alive but heartbeat stale — bound by max_stale_alive
+            # Alive but heartbeat stale — bound by max_stale_alive.
+            # v4 Delta 1: do NOT kill here.  We return a synthetic reason
+            # and let the caller run the verify-or-quarantine flow so an
+            # unverified kill can never silently drop the slot.
             if hb_age > g.max_stale_alive_sec:
-                ssh_kill_pgid(machine, state.get("worker_pgid") or 0, "TERM")
                 return {
                     **state,
                     "phase": "failed",
                     "success": False,
+                    "reason": "heartbeat_stale_alive",
                     "error_message": (
                         f"worker pid {pid} alive but heartbeat stale "
                         f"{hb_age:.0f}s > max_stale_alive "
-                        f"{g.max_stale_alive_sec}s — killed"
+                        f"{g.max_stale_alive_sec}s"
                     ),
                 }
 
@@ -840,14 +1011,43 @@ def write_unit_manifest(
 # Reconciliation pass
 # ---------------------------------------------------------------------------
 
+@dataclass
+class ReconcileResult:
+    """Outcome of reconcile_prior().
+
+    ``adoptable`` is the list of adopt-candidate dicts (back-compat with
+    callers that ignore quarantine).  ``quarantined_hosts`` is a set of
+    hosts whose prior-dispatch cleanup was inconclusive — the orchestrator
+    must seed these into Scheduler.quarantined_machines before preflight
+    and slot creation so they are excluded for the whole new dispatch.
+    """
+    adoptable: list[dict] = field(default_factory=list)
+    quarantined_hosts: set[str] = field(default_factory=set)
+
+    # Back-compat: iterate / len() should behave like the old `list[dict]`
+    # return so callers that simply did ``adoptable = reconcile_prior(...)``
+    # keep working until they migrate to the named field.
+    def __iter__(self):
+        return iter(self.adoptable)
+
+    def __len__(self):
+        return len(self.adoptable)
+
+    def __bool__(self):
+        return bool(self.adoptable) or bool(self.quarantined_hosts)
+
+    def __getitem__(self, idx):
+        return self.adoptable[idx]
+
+
 def reconcile_prior(
     db_manager: DatabaseManager,
     base_dir: Path,
     g: GlobalCfg,
     *,
     abandon: bool = False,
-) -> list[dict]:
-    """Reconcile prior dispatches.  Returns a list of adoptable runs.
+) -> ReconcileResult:
+    """Reconcile prior dispatches.  Returns a ReconcileResult.
 
     For each non-terminal dispatch in the DB:
 
@@ -860,14 +1060,17 @@ def reconcile_prior(
         - Non-terminal + stale heartbeat + ssh-unreachable → keep,
           log warning (coordinator can't safely declare dead).
     - Additionally iterate DB rows in non-terminal state for which no
-      state file exists → if the launch_log shows failure or the
-      heartbeat is missing entirely → MARK_FAILED.
+      state file exists.  v4 Delta 4: this is INCONCLUSIVE, not safe:
+        - ``worker.pidfile`` present → verify+kill; quarantine on
+          inconclusive cleanup.
+        - ``worker.pidfile`` absent → quarantine the host AND leave
+          the row ACTIVE for the next dispatch to recover.
 
     ``abandon=True`` skips all adoption and force-FAILs in-flight units
     of prior dispatches.
     """
     dispatch_root = base_dir / "imaging" / "dispatch"
-    adoptable: list[dict] = []
+    result = ReconcileResult()
 
     with db_manager.connect() as con:
         prior = DispatchesQueries.list_running(con)
@@ -896,7 +1099,7 @@ def reconcile_prior(
                 seen_run_ids.add(run_id)
                 _reconcile_state_entry(
                     db_manager, d_id, run_id, state, run_subdir, g,
-                    adoptable, abandon=abandon,
+                    result, abandon=abandon,
                 )
 
         # Pass 2: DB rows for this dispatch with no state file
@@ -905,11 +1108,69 @@ def reconcile_prior(
         for row in db_rows:
             if row["id"] in seen_run_ids:
                 continue
-            # No state.json — this row's launch likely failed
-            _mark_failed(
-                db_manager, row["id"],
-                error="no state.json found at reconciliation",
-            )
+            if abandon:
+                # --abandon-prior overrides Delta 4 — operator has
+                # explicitly asked to drop the prior dispatch.
+                _mark_failed(
+                    db_manager, row["id"],
+                    error="abandoned by --abandon-prior (no state.json)",
+                )
+                continue
+            # F5 + Delta 4: no state.json may mean (a) launch never
+            # wrote state and crashed, or (b) launch was in progress
+            # when the prior orchestrator died, and the worker may
+            # still be alive on a host we don't know.  Treat as
+            # INCONCLUSIVE.
+            unit_dir = units_dir / str(row["id"])
+            pid = _read_pidfile(unit_dir) if unit_dir.exists() else None
+            machine = (row.get("hostname") or "").split(".", 1)[0]
+            if pid and machine:
+                expected_tokens = [
+                    f"--dispatch-id {d_id}",
+                    f"--run-id {int(row['id'])}",
+                ]
+                outcome, detail = verify_and_kill_worker(
+                    machine, pid, expected_tokens, g,
+                )
+                log.info(
+                    "reconcile: pidfile verify run_id=%d machine=%s "
+                    "outcome=%s detail=%s",
+                    row["id"], machine, outcome, detail,
+                )
+                if outcome == VERIFY_INCONCLUSIVE:
+                    result.quarantined_hosts.add(machine)
+                    log.warning(
+                        "reconcile: QUARANTINE machine=%s run_id=%d "
+                        "(pidfile present, cleanup unverified) — leaving "
+                        "row ACTIVE",
+                        machine, row["id"],
+                    )
+                else:
+                    _mark_failed(
+                        db_manager, row["id"],
+                        error=f"reconcile: no state.json; "
+                              f"worker {outcome} ({detail})",
+                    )
+            else:
+                # No pidfile — Delta 4: still inconclusive.  Quarantine
+                # the host (if we know it) and leave the row active.
+                if machine:
+                    result.quarantined_hosts.add(machine)
+                    log.warning(
+                        "reconcile: QUARANTINE machine=%s run_id=%d "
+                        "(no state.json, no pidfile) — leaving row ACTIVE "
+                        "for next reconcile",
+                        machine, row["id"],
+                    )
+                else:
+                    # No host known — fall back to MARK_DONE FAILED so
+                    # the row doesn't pile up forever (we have no host
+                    # to quarantine and no evidence of liveness).
+                    _mark_failed(
+                        db_manager, row["id"],
+                        error="no state.json found at reconciliation "
+                              "(no pidfile, no recorded host)",
+                    )
 
     # Mark prior dispatches done if they have no surviving non-terminal rows
     for d in prior:
@@ -942,12 +1203,12 @@ def reconcile_prior(
             expected_tokens=["run_imaging_dispatch"],
         )
 
-    return adoptable
+    return result
 
 
 def _reconcile_state_entry(
     db_manager, dispatch_id, run_id, state, unit_dir,
-    g: GlobalCfg, adoptable, *, abandon: bool,
+    g: GlobalCfg, result: "ReconcileResult", *, abandon: bool,
 ) -> None:
     """Apply one prior unit's state to the DB; possibly mark for adoption."""
     phase = state.get("phase", "starting")
@@ -978,7 +1239,7 @@ def _reconcile_state_entry(
         hb_age = float("inf")
 
     if hb_age < g.heartbeat_stale_threshold_sec:
-        adoptable.append({
+        result.adoptable.append({
             "machine": machine, "run_id": run_id,
             "unit_dir": unit_dir, "state": state,
             "expected_tokens": expected_tokens,
@@ -993,7 +1254,7 @@ def _reconcile_state_entry(
             "%.0fs (cmdline ok)",
             run_id, machine, hb_age,
         )
-        adoptable.append({
+        result.adoptable.append({
             "machine": machine, "run_id": run_id,
             "unit_dir": unit_dir, "state": state,
             "expected_tokens": expected_tokens,
@@ -1006,12 +1267,26 @@ def _reconcile_state_entry(
             error=f"abandoned (no heartbeat {hb_age:.0f}s, pid {pid} dead/reused: {info!r})",
         )
         return
-    # alive is None — ssh failed; do NOT mark failed
-    log.warning(
-        "ssh-unreachable during reconcile of run_id=%d on %s: %s; "
-        "leaving row active (rerun --reconcile or use --abandon-prior)",
-        run_id, machine, info,
-    )
+    # alive is None — ssh-unreachable.  Same fail-closed treatment as the
+    # F5 no-pidfile path: we cannot prove the worker is dead, so quarantine
+    # the host (if we know it) and leave the row ACTIVE for the next
+    # reconcile_prior to recover.  Logging the warning is not enough on its
+    # own; without quarantine the next dispatch would happily schedule new
+    # work onto a host with an unverified live worker.
+    if machine:
+        result.quarantined_hosts.add(machine)
+        log.warning(
+            "reconcile: QUARANTINE machine=%s run_id=%d "
+            "(stale heartbeat, ssh-unreachable: %s) — leaving row ACTIVE",
+            machine, run_id, info,
+        )
+    else:
+        log.warning(
+            "ssh-unreachable during reconcile of run_id=%d on %s: %s; "
+            "leaving row active (no host known to quarantine; rerun "
+            "--reconcile or use --abandon-prior)",
+            run_id, machine, info,
+        )
 
 
 def _apply_terminal_to_db(db_manager, run_id, state, unit_dir) -> None:
@@ -1355,6 +1630,14 @@ class GousCleaner(threading.Thread):
         m = self.cfg.machines.get(machine)
         if m is None:
             return
+        # v3 F2.d: never rm -rf on a quarantined host — its worker may
+        # still be alive and reading inputs.
+        if self.scheduler.is_quarantined(machine):
+            log.info(
+                "cleaner: skipping cleanup for %s on quarantined %s",
+                gous, machine,
+            )
+            return
         # Adopted prior-dispatch units live under /raid/d_<prior_id>/...
         # (not /raid/d_<new_id>/...), so we resolve the dispatch_id per
         # pair before building the rm path.
@@ -1409,15 +1692,49 @@ class MachineSlot(threading.Thread):
 
     def run(self) -> None:
         while not self._stop_event.is_set():
+            # Quarantine check BEFORE pick so a quarantine raced into the
+            # scheduler between iterations also exits the slot.
+            if self.ctx.scheduler.is_quarantined(self.machine.name):
+                log.warning(
+                    "slot %s exiting: %s quarantined",
+                    self.slot_id, self.machine.name,
+                )
+                return
             unit = self.ctx.scheduler.pick(self.machine.name, self._next_run_id)
             if unit is None:
                 # Drained — exit slot
+                return
+            # Non-blocking 5: another thread (e.g. an AdoptionPoller
+            # finishing on this host, or _dispatch_one in a sibling slot)
+            # may have quarantined this host between the pre-pick check
+            # above and now.  Re-check immediately before dispatching so
+            # we don't oversubscribe the host with one extra unit.  The
+            # picked unit is dropped from this slot's view; the next
+            # dispatch's reconcile_prior + selection will re-discover it
+            # (we deliberately have not run mark_inflight / INSERT_QUEUED
+            # for it yet, so there is no DB row to leave dangling).
+            if self.ctx.scheduler.is_quarantined(self.machine.name):
+                log.warning(
+                    "slot %s exiting: %s quarantined between pick() and "
+                    "dispatch; dropping unit %s/%s/spw%s (will be "
+                    "re-selected by the next dispatch)",
+                    self.slot_id, self.machine.name,
+                    unit.gous_uid, unit.source_name, unit.spw_id,
+                )
                 return
             try:
                 self._dispatch_one(unit)
             except Exception:
                 log.exception("slot %s crashed on unit %s/%s/spw%s",
                               self.slot_id, unit.gous_uid, unit.source_name, unit.spw_id)
+            # Post-dispatch quarantine check: _dispatch_one may have
+            # quarantined the host on inconclusive cleanup (F2.d).
+            if self.ctx.scheduler.is_quarantined(self.machine.name):
+                log.warning(
+                    "slot %s exiting: %s quarantined",
+                    self.slot_id, self.machine.name,
+                )
+                return
 
     def _next_run_id(self) -> Optional[int]:  # not used by current scheduler
         return None
@@ -1484,88 +1801,207 @@ class MachineSlot(threading.Thread):
             return
         run_id = int(row_id_holder["id"])
 
-        # 2. Build NAS unit dir + manifest
-        nas_unit_dir = c.dispatch_dir / "units" / str(run_id)
-        nas_unit_dir.mkdir(parents=True, exist_ok=True)
-
-        # Use the GOUS-union of inputs the coordinator pre-computed
-        expected_inputs = c.gous_inputs[unit.gous_uid]
-
-        manifest_path = write_unit_manifest(
-            nas_unit_dir,
-            unit=unit,
-            expected_inputs=expected_inputs,
-            publish_dir=c.publish_dir,
-            nproc=self.machine.nproc,
-            casa_path=c.cfg.casa_path,
-            deconvolver=c.deconvolver,
-            scales=c.scales,
-        )
-
-        # 3. Build per-unit launcher.sh on NAS
-        raid_dir = f"{self.machine.raid}/d_{c.dispatch_id}"
-        # Per-host cross-dispatch staging cache lives next to the
-        # per-dispatch dir, scoped to this host's /raid only.
-        cache_root = (
-            f"{self.machine.raid}/cache"
-            if self.machine.cache_min_free_gb is not None else None
-        )
-        launcher = write_launcher_script(
-            nas_unit_dir, c.cfg,
-            raid_dir=raid_dir,
-            manifest_path=str(manifest_path),
-            run_id=run_id,
-            dispatch_id=c.dispatch_id,
-            transfer_method=c.transfer_method,
-            publish_policy=c.publish_policy,
-            tokens_dir=str(c.tokens_dir),
-            max_concurrent_staging=c.cfg.global_cfg.max_concurrent_staging,
-            heartbeat_interval=c.cfg.global_cfg.heartbeat_interval_sec,
-            cache_root=cache_root,
-            cache_min_free_gb=self.machine.cache_min_free_gb,
-        )
-
-        # 4. Mark in-flight before SSH so the cleaner doesn't fire.
-        # Tag with the *current* dispatch_id so cleanup hits the right
-        # /raid/d_<id>/... tree.
-        c.scheduler.mark_inflight(
-            machine, unit.gous_uid, run_id, dispatch_id=c.dispatch_id,
-        )
-
-        # Once mark_inflight is set we MUST release it with mark_terminal
-        # — otherwise pick() will skip this (machine, GOUS) for the rest
-        # of the dispatch.  The sentinel below + try/finally guarantees
-        # that, even if poll_state_until_terminal raises or any other
-        # unexpected exception occurs between here and the bottom.
+        # Sentinels covering everything that must be reconciled in the
+        # ``finally`` below.  Initialised BEFORE the try so they're always
+        # defined regardless of where in the pre-launch path we crash.
+        #
+        # Once mark_inflight is set we MUST either:
+        #   - release it with mark_terminal (cleanup verified — FAILED
+        #     or SUCCESS), or
+        #   - quarantine the host (cleanup unverified — leave run row
+        #     active for next dispatch's reconcile_prior to recover).
+        #
+        # Sentinels:
+        #   ``terminal_recorded``     — mark_terminal was called.
+        #   ``quarantine_recorded``   — _quarantine_and_log was called
+        #                               (or the host is otherwise known
+        #                               to have been deliberately
+        #                               quarantined for this unit).  The
+        #                               finally must not undo this by
+        #                               re-running the post-launch
+        #                               recovery path.
+        #   ``worker_possibly_launched`` — launch_detached returned;
+        #                                  remote worker may be alive
+        #                                  even on SSH failure (Delta 2).
+        #   ``mark_inflight_called``  — scheduler.mark_inflight succeeded;
+        #                               only then is mark_terminal valid.
         terminal_recorded = False
+        quarantine_recorded = False
+        worker_possibly_launched = False
+        mark_inflight_called = False
+        wrapper_pid: Optional[int] = None
+        nas_unit_dir: Optional[Path] = None
+
+        expected_tokens = [
+            f"--dispatch-id {c.dispatch_id}",
+            f"--run-id {run_id}",
+        ]
+
+        def _emit_mark_done_failed(error_message: str, retcode: int = 1) -> None:
+            log.info(
+                "dispatch: MARK_DONE FAILED run_id=%d machine=%s reason=%s "
+                "error=%s",
+                run_id, machine, "synthetic", error_message,
+            )
+            log.warning(
+                "slot %s unit run_id=%d failed: %s",
+                self.slot_id, run_id, error_message,
+            )
+            c.db_writer.q.put({
+                "op": "MARK_DONE",
+                "run_id": run_id,
+                "status": ImagingRunStatus.FAILED,
+                "retcode": int(retcode),
+                "finished_at": now_iso(),
+                "duration_sec": 0.0,
+                "error_message": error_message,
+            })
+
+        def _quarantine_and_log(reason: str, detail: str) -> None:
+            """Quarantine the host; do NOT MARK_DONE; do NOT mark_terminal.
+
+            Sets ``quarantine_recorded`` so the outer ``finally`` does not
+            undo this by re-running the post-launch recovery path (which
+            would otherwise re-verify and possibly MARK_DONE the row that
+            we have deliberately left ACTIVE).
+            """
+            nonlocal quarantine_recorded
+            c.scheduler.quarantine(machine, reason=reason)
+            quarantine_recorded = True
+            log.warning(
+                "dispatch: QUARANTINE machine=%s run_id=%d reason=%s detail=%s "
+                "— run row left ACTIVE for next reconcile_prior",
+                machine, run_id, reason, detail,
+            )
+
         try:
+            # 2. Build NAS unit dir + manifest.  Delta 2: this MUST live
+            # inside the try/finally so a pre-launch crash (e.g. NAS write
+            # failure during manifest/launcher generation) is recoverable.
+            # A pre-launch failure provably did not launch a worker, so
+            # the finally can safely MARK_DONE FAILED + mark_terminal
+            # (gated on ``mark_inflight_called`` to avoid spurious
+            # mark_terminal for an unregistered (machine, gous) pair).
+            nas_unit_dir = c.dispatch_dir / "units" / str(run_id)
+            nas_unit_dir.mkdir(parents=True, exist_ok=True)
+
+            # Use the GOUS-union of inputs the coordinator pre-computed
+            expected_inputs = c.gous_inputs[unit.gous_uid]
+
+            manifest_path = write_unit_manifest(
+                nas_unit_dir,
+                unit=unit,
+                expected_inputs=expected_inputs,
+                publish_dir=c.publish_dir,
+                nproc=self.machine.nproc,
+                casa_path=c.cfg.casa_path,
+                deconvolver=c.deconvolver,
+                scales=c.scales,
+            )
+
+            # 3. Build per-unit launcher.sh on NAS
+            raid_dir = f"{self.machine.raid}/d_{c.dispatch_id}"
+            # Per-host cross-dispatch staging cache lives next to the
+            # per-dispatch dir, scoped to this host's /raid only.
+            cache_root = (
+                f"{self.machine.raid}/cache"
+                if self.machine.cache_min_free_gb is not None else None
+            )
+            launcher = write_launcher_script(
+                nas_unit_dir, c.cfg,
+                raid_dir=raid_dir,
+                manifest_path=str(manifest_path),
+                run_id=run_id,
+                dispatch_id=c.dispatch_id,
+                transfer_method=c.transfer_method,
+                publish_policy=c.publish_policy,
+                tokens_dir=str(c.tokens_dir),
+                max_concurrent_staging=c.cfg.global_cfg.max_concurrent_staging,
+                heartbeat_interval=c.cfg.global_cfg.heartbeat_interval_sec,
+                cache_root=cache_root,
+                cache_min_free_gb=self.machine.cache_min_free_gb,
+            )
+
+            # 4. Mark in-flight before SSH so the cleaner doesn't fire.
+            # Tag with the *current* dispatch_id so cleanup hits the right
+            # /raid/d_<id>/... tree.
+            c.scheduler.mark_inflight(
+                machine, unit.gous_uid, run_id, dispatch_id=c.dispatch_id,
+            )
+            mark_inflight_called = True
+
             # 5. Launch detached
-            ok, msg, wrapper_pid = launch_detached(
+            ok, msg, _wpid = launch_detached(
                 machine, launcher, nas_unit_dir,
                 timeout=c.cfg.global_cfg.ssh_timeout_sec,
             )
-            if not ok:
-                c.db_writer.q.put({
-                    "op": "MARK_DONE",
-                    "run_id": run_id,
-                    "status": ImagingRunStatus.FAILED,
-                    "retcode": 255,
-                    "finished_at": now_iso(),
-                    "duration_sec": 0.0,
-                    "error_message": f"ssh launch failed: {msg}",
-                })
-                c.scheduler.mark_terminal(
-                    machine, unit.gous_uid, run_id, success=False,
+            wrapper_pid = _wpid
+            # Delta 2: any return from launch_detached (ok or not) means
+            # the SSH command may have backgrounded the worker before
+            # returning.  Mark worker_possibly_launched so the crash/
+            # finally path uses verify-or-quarantine.
+            worker_possibly_launched = True
+
+            # Delta 3: if wrapper_pid is unknown for any reason (ssh
+            # timeout, ssh rc!=0, or ssh ok but unparsable pidfile),
+            # wait briefly for worker.pidfile to appear and parse it.
+            if wrapper_pid is None:
+                wrapper_pid = _wait_for_pidfile(
+                    nas_unit_dir,
+                    c.cfg.global_cfg.launch_pidfile_wait_sec,
                 )
-                terminal_recorded = True
+
+            if not ok:
+                # SSH launch did not return cleanly.  If we now have a
+                # pidfile, the worker likely launched — run verify+kill.
+                # If we don't, treat as inconclusive (Delta 3) and
+                # quarantine.
+                if wrapper_pid is not None:
+                    outcome, detail = verify_and_kill_worker(
+                        machine, wrapper_pid, expected_tokens,
+                        c.cfg.global_cfg,
+                    )
+                    if outcome == VERIFY_INCONCLUSIVE:
+                        _quarantine_and_log(
+                            "ssh_launch_failed_unverified",
+                            f"{msg}; {detail}",
+                        )
+                        return
+                    # Verified dead/killed → safe to MARK_DONE FAILED.
+                    _emit_mark_done_failed(
+                        f"ssh launch failed: {msg}; cleanup={detail}",
+                        retcode=255,
+                    )
+                    c.scheduler.mark_terminal(
+                        machine, unit.gous_uid, run_id, success=False,
+                    )
+                    terminal_recorded = True
+                    return
+                # No pidfile after wait — inconclusive.
+                _quarantine_and_log(
+                    "ssh_launch_failed_no_pidfile",
+                    f"{msg}; no worker.pidfile after "
+                    f"{c.cfg.global_cfg.launch_pidfile_wait_sec}s",
+                )
+                return
+
+            # Delta 3 (non-blocking 4): ok=True but we never learned a
+            # wrapper_pid, even after waiting for the pidfile.  Per v4
+            # Delta 3 this is explicitly inconclusive — absence of the
+            # pidfile is NOT proof the worker didn't launch.  Quarantine
+            # rather than polling, to avoid silently scheduling more work
+            # onto a host that may have a live worker we can't track.
+            if wrapper_pid is None:
+                _quarantine_and_log(
+                    "launch_ok_no_pidfile",
+                    f"launch_detached returned ok={ok} msg={msg!r} but no "
+                    f"worker.pidfile appeared within "
+                    f"{c.cfg.global_cfg.launch_pidfile_wait_sec}s",
+                )
                 return
 
             # 6. Poll until terminal
             t0 = time.monotonic()
-            expected_tokens = [
-                f"--dispatch-id {c.dispatch_id}",
-                f"--run-id {run_id}",
-            ]
 
             def _on_phase(phase, state):
                 if phase == "running":
@@ -1606,16 +2042,81 @@ class MachineSlot(threading.Thread):
                 on_phase_change=_on_phase,
                 on_poll=_on_poll,
             )
+
+            # 6b. Synthetic-terminal handling (F2.b + F2.h + Delta 1).
+            # If final.reason is in _SYNTHETIC_REASONS, we did NOT observe
+            # a real terminal — run verify-or-quarantine before MARK_DONE.
+            if not _is_observed_terminal(final) and final.get("phase") == "failed":
+                reason = final.get("reason")
+                # F2.b.i: re-read state.json once.  If phase is now
+                # publishing/done/running, resume polling for the late-state
+                # grace window.  If grace expires without a terminal, quarantine.
+                if reason == "state_missing_timeout":
+                    pid_for_kill = (
+                        wrapper_pid
+                        if wrapper_pid is not None
+                        else _read_pidfile(nas_unit_dir)
+                    )
+                    final = self._handle_state_missing_timeout(
+                        nas_unit_dir, machine, expected_tokens,
+                        pid_for_kill, _on_phase, _on_poll, run_id,
+                    )
+                    if final is None:
+                        # Quarantine path taken inside helper.
+                        _quarantine_and_log(
+                            "state_missing_timeout_unverified",
+                            "see prior log line for verify outcome",
+                        )
+                        return
+                elif reason == "heartbeat_stale_alive":
+                    # Delta 1: worker alive but heartbeat dead.  Verify + kill.
+                    pid_for_kill = (
+                        final.get("worker_pgid")
+                        or final.get("worker_pid")
+                        or wrapper_pid
+                    )
+                    outcome, detail = verify_and_kill_worker(
+                        machine, pid_for_kill, expected_tokens,
+                        c.cfg.global_cfg,
+                    )
+                    if outcome == VERIFY_INCONCLUSIVE:
+                        _quarantine_and_log(
+                            "heartbeat_stale_alive_unverified",
+                            detail,
+                        )
+                        return
+                    final = {
+                        **final,
+                        "error_message": (
+                            (final.get("error_message") or "")
+                            + f" — cleanup={detail}"
+                        ),
+                    }
+
             elapsed = time.monotonic() - t0
 
-            # 7. Apply terminal state to DB
+            # 7. Apply terminal state to DB (observed terminal OR verified-cleanup
+            # synthetic terminal).  F1 + F3: INFO + WARN log lines.
+            success = bool(final.get("success"))
+            status = (ImagingRunStatus.SUCCESS if success
+                      else ImagingRunStatus.FAILED)
+            err = final.get("error_message")
+            log.info(
+                "dispatch: MARK_DONE %s run_id=%d machine=%s elapsed=%.1fs "
+                "error=%s",
+                status, run_id, machine, elapsed, err,
+            )
+            if not success:
+                log.warning(
+                    "slot %s unit run_id=%d failed: %s",
+                    self.slot_id, run_id, err,
+                )
             prov = final.get("provenance") or {}
             c.db_writer.q.put({
                 "op": "MARK_DONE",
                 "run_id": run_id,
-                "status": (ImagingRunStatus.SUCCESS if final.get("success")
-                           else ImagingRunStatus.FAILED),
-                "retcode": 0 if final.get("success") else 1,
+                "status": status,
+                "retcode": 0 if success else 1,
                 "finished_at": final.get("finished_at") or now_iso(),
                 "duration_sec": float(elapsed),
                 "output_fits": final.get("output_fits"),
@@ -1623,50 +2124,194 @@ class MachineSlot(threading.Thread):
                                   if final.get("spw_selection") else None),
                 "field_selection": (json.dumps(final["field_selection"])
                                     if final.get("field_selection") else None),
-                "error_message": final.get("error_message"),
+                "error_message": err,
                 "job_json_path": prov.get("job_json"),
             })
             empty = c.scheduler.mark_terminal(
-                machine, unit.gous_uid, run_id,
-                success=bool(final.get("success")),
+                machine, unit.gous_uid, run_id, success=success,
             )
             terminal_recorded = True
             if empty:
                 # Possible cleanup opportunity — let the cleaner sweep
                 log.debug("(machine=%s, gous=%s) drained", machine, unit.gous_uid)
         finally:
-            if not terminal_recorded:
-                # Unexpected exception path (e.g. poll_state_until_terminal
-                # raised).  Release the scheduler slot with FAILED so the
-                # outer MachineSlot.run() can pick the next unit, and emit
-                # a terminal DB event so reconciliation later isn't blocked
-                # on this run sitting in non-terminal status.
-                log.exception(
-                    "MachineSlot crashed mid-dispatch: machine=%s gous=%s "
-                    "run_id=%d; marking FAILED",
-                    machine, unit.gous_uid, run_id,
-                )
+            # Blocking 1 + 2: only enter the recovery path if NEITHER a
+            # terminal nor a deliberate quarantine has been recorded.
+            # ``quarantine_recorded`` covers the case where a control-flow
+            # path (e.g. ssh_launch_failed_no_pidfile) intentionally left
+            # the row ACTIVE on a quarantined host and returned — without
+            # this guard the finally would re-verify and possibly MARK_DONE
+            # the row, undoing the quarantine.
+            if not terminal_recorded and not quarantine_recorded:
+                # Delta 2: split crash/finally into pre-launch (safe
+                # MARK_DONE) vs post-launch (verify-or-quarantine).
+                # Pre-launch: no worker ever started — mark FAILED.
+                # Post-launch: worker may be alive — quarantine.
+                if not worker_possibly_launched:
+                    log.exception(
+                        "MachineSlot crashed pre-launch: machine=%s gous=%s "
+                        "run_id=%d; marking FAILED",
+                        machine, unit.gous_uid, run_id,
+                    )
+                    # v5 Delta 11 wording: only MARK_DONE if we have a
+                    # run_id allocated, and only mark_terminal if
+                    # mark_inflight was actually called.  This avoids a
+                    # spurious mark_terminal for an unregistered pair if
+                    # the pre-launch crash happened between INSERT_QUEUED
+                    # and mark_inflight (e.g. manifest write failure).
+                    if run_id:
+                        try:
+                            _emit_mark_done_failed(
+                                "MachineSlot crashed pre-launch",
+                            )
+                        except Exception:
+                            log.exception(
+                                "failed to emit MARK_DONE for run_id=%d",
+                                run_id,
+                            )
+                        if mark_inflight_called:
+                            try:
+                                c.scheduler.mark_terminal(
+                                    machine, unit.gous_uid, run_id,
+                                    success=False,
+                                )
+                            except Exception:
+                                log.exception(
+                                    "failed to mark_terminal for machine=%s "
+                                    "gous=%s run_id=%d",
+                                    machine, unit.gous_uid, run_id,
+                                )
+                else:
+                    log.exception(
+                        "MachineSlot crashed POST-launch: machine=%s gous=%s "
+                        "run_id=%d; worker may be alive",
+                        machine, unit.gous_uid, run_id,
+                    )
+                    # If we have a wrapper_pid in this scope, try to verify+kill.
+                    pid_for_kill: Optional[int] = wrapper_pid
+                    if pid_for_kill is None and nas_unit_dir is not None:
+                        pid_for_kill = _read_pidfile(nas_unit_dir)
+                    if pid_for_kill is not None:
+                        outcome, detail = verify_and_kill_worker(
+                            machine, pid_for_kill, expected_tokens,
+                            c.cfg.global_cfg,
+                        )
+                        if outcome != VERIFY_INCONCLUSIVE:
+                            # Verified dead — safe to MARK_DONE FAILED.
+                            try:
+                                _emit_mark_done_failed(
+                                    f"MachineSlot crashed post-launch; "
+                                    f"cleanup={detail}",
+                                )
+                            except Exception:
+                                log.exception(
+                                    "failed to emit MARK_DONE for run_id=%d",
+                                    run_id,
+                                )
+                            try:
+                                c.scheduler.mark_terminal(
+                                    machine, unit.gous_uid, run_id,
+                                    success=False,
+                                )
+                            except Exception:
+                                log.exception(
+                                    "failed to mark_terminal for machine=%s "
+                                    "gous=%s run_id=%d",
+                                    machine, unit.gous_uid, run_id,
+                                )
+                            return
+                    # Inconclusive → quarantine, leave row active.
+                    _quarantine_and_log(
+                        "post_launch_crash_unverified",
+                        "MachineSlot crashed after launch_detached returned",
+                    )
+
+    def _handle_state_missing_timeout(
+        self,
+        nas_unit_dir: Path,
+        machine: str,
+        expected_tokens: list[str],
+        wrapper_pid: Optional[int],
+        on_phase_change,
+        on_poll,
+        run_id: int,
+    ) -> Optional[dict]:
+        """F2.b: handle the state_missing_timeout synthetic terminal.
+
+        Returns the final terminal state if we have one to MARK_DONE,
+        or None if we've already quarantined the host and the caller
+        must return without MARK_DONE.
+        """
+        c = self.ctx
+        g = c.cfg.global_cfg
+        state_path = nas_unit_dir / "state.json"
+        # Re-read state.json once.
+        cur_state: dict = {}
+        if state_path.exists():
+            try:
+                cur_state = json.loads(state_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                cur_state = {}
+        phase = cur_state.get("phase")
+        if phase in ("publishing", "done", "running"):
+            log.info(
+                "dispatch: state_appeared_after_timeout machine=%s run_id=%d "
+                "phase=%s — resuming polling within late_state_grace_sec=%d",
+                machine, run_id, phase, g.late_state_grace_sec,
+            )
+            late_started = time.monotonic()
+            # Bounded re-poll: build a tweaked GlobalCfg with the late
+            # grace as the new state_appeared_timeout AND constrain the
+            # total time spent here.
+            while True:
+                # Quick poll loop reusing poll_state_until_terminal.
                 try:
-                    c.db_writer.q.put({
-                        "op": "MARK_DONE",
-                        "run_id": run_id,
-                        "status": ImagingRunStatus.FAILED,
-                        "retcode": 1,
-                        "finished_at": now_iso(),
-                        "duration_sec": 0.0,
-                        "error_message": "MachineSlot crashed mid-dispatch",
-                    })
-                except Exception:
-                    log.exception("failed to emit MARK_DONE for run_id=%d", run_id)
-                try:
-                    c.scheduler.mark_terminal(
-                        machine, unit.gous_uid, run_id, success=False,
+                    late_final = poll_state_until_terminal(
+                        machine, nas_unit_dir, g=g,
+                        expected_tokens=expected_tokens,
+                        on_phase_change=on_phase_change,
+                        on_poll=on_poll,
                     )
                 except Exception:
                     log.exception(
-                        "failed to mark_terminal for machine=%s gous=%s "
-                        "run_id=%d", machine, unit.gous_uid, run_id,
+                        "late-state re-poll crashed run_id=%d", run_id,
                     )
+                    late_final = None
+                # Observed terminal → return it.
+                if _is_observed_terminal(late_final):
+                    return late_final
+                # Another synthetic — check the grace budget.
+                if (time.monotonic() - late_started) >= g.late_state_grace_sec:
+                    log.warning(
+                        "dispatch: late_state_grace_expired machine=%s "
+                        "run_id=%d — quarantine",
+                        machine, run_id,
+                    )
+                    # F2.h: grace expiry → quarantine, NEVER MARK_DONE.
+                    return None
+                # Otherwise loop and re-poll.
+        # phase is None / starting / staging — proceed to verify+kill.
+        outcome, detail = verify_and_kill_worker(
+            machine, wrapper_pid, expected_tokens, g,
+        )
+        log.info(
+            "dispatch: state_missing_timeout verify run_id=%d machine=%s "
+            "outcome=%s detail=%s",
+            run_id, machine, outcome, detail,
+        )
+        if outcome == VERIFY_INCONCLUSIVE:
+            return None
+        # Cleanup verified — synthesize a FAILED terminal so the normal
+        # MARK_DONE flow proceeds with the typed error_message.
+        return {
+            "phase": "failed",
+            "success": False,
+            "reason": "state_missing_timeout",
+            "error_message": (
+                f"state.json never appeared within "
+                f"{g.state_appeared_timeout_sec}s; cleanup={detail}"
+            ),
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1706,9 +2351,11 @@ class LiveCountWatchdog(threading.Thread):
                 live_s = sum(1 for s in self.slots if s.is_alive())
                 with self.ctx.dynamic_slots_lock:
                     live_d = sum(1 for s in self.ctx.dynamic_slots if s.is_alive())
+                with self.ctx.scheduler.lock:
+                    q_n = len(self.ctx.scheduler.quarantined_machines)
                 log.info(
-                    "watchdog: adoption=%d slots=%d dynamic=%d",
-                    live_a, live_s, live_d,
+                    "watchdog: adoption=%d slots=%d dynamic=%d quarantined=%d",
+                    live_a, live_s, live_d, q_n,
                 )
             except Exception:
                 log.exception("watchdog tick failed")
@@ -1780,6 +2427,7 @@ class AdoptionPoller(threading.Thread):
 
         final: Optional[dict] = None
         crashed_exc: Optional[BaseException] = None
+        quarantine_pending = False
         t0 = time.monotonic()
         try:
             last_db_hb_state = {"t": 0.0}
@@ -1807,40 +2455,95 @@ class AdoptionPoller(threading.Thread):
             except Exception as e:
                 log.exception("adoption poller crashed for run_id=%d", run_id)
                 crashed_exc = e
+
+            # Delta 8: synthetic-terminal final → verify-or-quarantine
+            # before MARK_DONE (mirror _dispatch_one's F2.b/F2.h flow).
+            quarantine_pending = False
+            if (
+                final is not None
+                and not _is_observed_terminal(final)
+                and final.get("phase") == "failed"
+            ):
+                # Look up wrapper_pid from state.json's worker_pgid or
+                # pidfile so we can run the verify+kill flow.
+                pid_for_kill = (
+                    final.get("worker_pgid")
+                    or final.get("worker_pid")
+                    or _read_pidfile(unit_dir)
+                )
+                outcome, detail = verify_and_kill_worker(
+                    machine, pid_for_kill, expected_tokens,
+                    c.cfg.global_cfg,
+                )
+                log.info(
+                    "adoption: synthetic terminal verify run_id=%d "
+                    "machine=%s reason=%s outcome=%s detail=%s",
+                    run_id, machine, final.get("reason"), outcome, detail,
+                )
+                if outcome == VERIFY_INCONCLUSIVE:
+                    quarantine_pending = True
+                else:
+                    final = {
+                        **final,
+                        "error_message": (
+                            (final.get("error_message") or "")
+                            + f" — cleanup={detail}"
+                        ),
+                    }
         finally:
             elapsed = time.monotonic() - t0
             success = bool(final and final.get("success"))
             prov = (final or {}).get("provenance") or {}
-            # Always emit a terminal DB event so reconciliation on the
-            # next dispatch has a definite status to read.  On poller
-            # crash, mark FAILED and stash the exception text — the
-            # remote worker may still be alive, but the DB needs a
-            # terminal state to release this run from "non-terminal".
-            err_msg = (
-                (final or {}).get("error_message")
-                if final
-                else f"adoption poller crashed: {crashed_exc!r}"
-            )
-            c.db_writer.q.put({
-                "op": "MARK_DONE",
-                "run_id": run_id,
-                "status": (ImagingRunStatus.SUCCESS if success
-                           else ImagingRunStatus.FAILED),
-                "retcode": 0 if success else 1,
-                "finished_at": (final or {}).get("finished_at") or now_iso(),
-                "duration_sec": float(elapsed),
-                "output_fits": (final or {}).get("output_fits"),
-                "spw_selection": (json.dumps((final or {})["spw_selection"])
-                                  if (final or {}).get("spw_selection") else None),
-                "field_selection": (json.dumps((final or {})["field_selection"])
-                                    if (final or {}).get("field_selection") else None),
-                "error_message": err_msg,
-                "job_json_path": prov.get("job_json"),
-            })
-            if gous_uid:
-                c.scheduler.mark_terminal(
-                    machine, gous_uid, run_id, success=success,
+
+            if quarantine_pending or crashed_exc is not None:
+                # Adoption cleanup is unverified.  Quarantine the host
+                # (Delta 8) and leave the run row ACTIVE so the next
+                # dispatch's reconcile_prior can recover it.  Crashes
+                # also fall through here because we can't confirm the
+                # worker terminated.
+                c.scheduler.quarantine(
+                    machine, reason="adoption_cleanup_unverified",
                 )
+                log.warning(
+                    "adoption: QUARANTINE machine=%s run_id=%d "
+                    "(crashed=%s, quarantine_pending=%s) — leaving row "
+                    "ACTIVE for next reconcile_prior",
+                    machine, run_id, crashed_exc is not None,
+                    quarantine_pending,
+                )
+            else:
+                err_msg = (final or {}).get("error_message")
+                status = (ImagingRunStatus.SUCCESS if success
+                          else ImagingRunStatus.FAILED)
+                log.info(
+                    "adoption: MARK_DONE %s run_id=%d machine=%s "
+                    "elapsed=%.1fs error=%s",
+                    status, run_id, machine, elapsed, err_msg,
+                )
+                if not success:
+                    log.warning(
+                        "adoption: run_id=%d on %s failed: %s",
+                        run_id, machine, err_msg,
+                    )
+                c.db_writer.q.put({
+                    "op": "MARK_DONE",
+                    "run_id": run_id,
+                    "status": status,
+                    "retcode": 0 if success else 1,
+                    "finished_at": (final or {}).get("finished_at") or now_iso(),
+                    "duration_sec": float(elapsed),
+                    "output_fits": (final or {}).get("output_fits"),
+                    "spw_selection": (json.dumps((final or {})["spw_selection"])
+                                      if (final or {}).get("spw_selection") else None),
+                    "field_selection": (json.dumps((final or {})["field_selection"])
+                                        if (final or {}).get("field_selection") else None),
+                    "error_message": err_msg,
+                    "job_json_path": prov.get("job_json"),
+                })
+                if gous_uid:
+                    c.scheduler.mark_terminal(
+                        machine, gous_uid, run_id, success=success,
+                    )
             # Successor-slot spawn: take the now-freed slot capacity
             # and dispatch a fresh MachineSlot to consume queued units
             # on this machine.  Capped by the monotonic
@@ -1848,17 +2551,17 @@ class AdoptionPoller(threading.Thread):
             # machine's slot count, regardless of how many adoptions
             # terminate on the same host.
             #
-            # IMPORTANT: only spawn if ``final is not None`` — i.e. we
-            # actually observed the adopted worker reach a terminal
-            # state.  If the poller itself crashed (``crashed_exc`` set,
-            # ``final`` is None), the remote worker may still be alive;
-            # spawning a successor in that case would oversubscribe the
-            # host.  We've already emitted MARK_DONE FAILED and called
-            # mark_terminal for DB/scheduler consistency, but we hold
-            # off on a replacement slot for safety.
+            # F4 + Delta 8: only spawn if the terminal was OBSERVED (not
+            # synthesized by our timeout, not on a quarantined host, not
+            # on poll crash).  Otherwise the worker may still be alive
+            # and a successor would oversubscribe.
             m_cfg = self.machine_cfg
             to_start: Optional[MachineSlot] = None
-            if m_cfg is not None and final is not None:
+            if (
+                m_cfg is not None
+                and _is_observed_terminal(final)
+                and not c.scheduler.is_quarantined(machine)
+            ):
                 with c.dynamic_slots_lock:
                     if not c.new_launch_machines_ready.is_set():
                         # Preflight hasn't run yet — queue for drain.
@@ -2145,6 +2848,20 @@ def run_dispatch(
         db_writer.start()
 
         scheduler = SchedulerState(queue=list(ready))
+        # Delta 5: seed quarantined hosts surfaced by reconcile_prior
+        # (e.g. prior-dispatch run with no state/no pidfile, or
+        # inconclusive verify+kill).  Must happen BEFORE preflight so
+        # quarantined hosts are skipped end-to-end.
+        if isinstance(adoptable, ReconcileResult):
+            qhosts = adoptable.quarantined_hosts
+        else:
+            qhosts = set()
+        if qhosts:
+            scheduler.quarantine_all(qhosts)
+            log.warning(
+                "dispatch: seeded %d quarantined host(s) from reconcile: %s",
+                len(qhosts), sorted(qhosts),
+            )
         ctx = DispatchContext(
             cfg=cfg, dispatch_id=dispatch_id, dispatch_dir=dispatch_dir,
             publish_dir=publish_dir, tokens_dir=tokens_dir,
@@ -2219,6 +2936,15 @@ def run_dispatch(
             nas_probe = str(publish_dir.parent if publish_dir.parent.exists()
                             else publish_dir)
             for name, m in cfg.machines.items():
+                # Delta 5: a host quarantined by reconcile_prior never
+                # gets a preflight or a slot.
+                if scheduler.is_quarantined(name):
+                    log.warning(
+                        "skipping preflight for %s: quarantined by "
+                        "reconcile_prior",
+                        name,
+                    )
+                    continue
                 required_gb = max_gous_gb + 50 + (m.slots * max_gous_gb)
                 ok, details = ssh_preflight_machine(
                     name, m, cfg,
@@ -2371,6 +3097,14 @@ def run_dispatch(
             m = cfg.machines.get(m_name)
             if m is None:
                 continue
+            # v3 F2.d: never rm -rf on a quarantined host (a worker may
+            # still be alive and reading inputs).
+            if scheduler.is_quarantined(m_name):
+                log.info(
+                    "end-of-run sweep: skipping %s/%s (quarantined)",
+                    m_name, did,
+                )
+                continue
             try:
                 ssh_run(
                     m_name,
@@ -2386,8 +3120,31 @@ def run_dispatch(
         # 17. Stop DB writer + mark dispatch(es) done.
         db_writer.stop()
         db_writer.join(timeout=10)
+        # v5 Delta 11: if any rows for THIS dispatch remain non-terminal
+        # (e.g. left active by a quarantine), DO NOT mark the dispatch
+        # DONE — otherwise reconcile_prior scans only RUNNING dispatches
+        # and the orphan row becomes invisible.
         with db_manager.connect() as con:
-            DispatchesQueries.mark_terminal(con, dispatch_id, DispatchState.DONE)
+            current_active = ImagingRunsQueries.list_running_for_dispatch(
+                con, dispatch_id,
+            )
+        if current_active:
+            unresolved_ids = sorted(r["id"] for r in current_active)
+            with scheduler.lock:
+                qhosts = sorted(scheduler.quarantined_machines)
+            log.warning(
+                "dispatch %s left RUNNING: %d unresolved run(s) %s, "
+                "quarantined hosts: %s — next dispatch's reconcile_prior "
+                "will recover",
+                dispatch_id, len(unresolved_ids), unresolved_ids, qhosts,
+            )
+        else:
+            with db_manager.connect() as con:
+                DispatchesQueries.mark_terminal(
+                    con, dispatch_id, DispatchState.DONE,
+                )
+                con.commit()
+        with db_manager.connect() as con:
             # Prior dispatches: mark DONE if they have no surviving
             # non-terminal rows now that adoptions have completed.
             for prior_did in prior_dispatch_ids:

--- a/panta_rei/imaging/remote_worker.py
+++ b/panta_rei/imaging/remote_worker.py
@@ -61,6 +61,38 @@ TERMINAL_PHASES = {Phase.DONE, Phase.FAILED}
 
 
 # ---------------------------------------------------------------------------
+# Graceful shutdown (F2.g)
+# ---------------------------------------------------------------------------
+
+# Flipped to True by the SIGTERM handler.  Checked at safe points in
+# run_unit so the worker can finish an in-flight publish before exiting.
+# Module-level so the handler closure stays simple and so it survives
+# across imports if anything ever re-imports the module.
+_shutdown_requested: bool = False
+
+
+def _install_sigterm_handler() -> None:
+    """Install a SIGTERM handler that requests a graceful shutdown.
+
+    Orchestrator sends SIGTERM via ``ssh_kill_pgid(..., "TERM")``;
+    handler flips ``_shutdown_requested`` so safe-point checks in
+    run_unit can elect to finish publish before exiting.
+    """
+    def _handler(signum, frame):
+        global _shutdown_requested
+        _shutdown_requested = True
+    try:
+        signal.signal(signal.SIGTERM, _handler)
+    except (ValueError, OSError):
+        # Not a main thread, or signal can't be installed on this OS.
+        pass
+
+
+def _shutdown_is_requested() -> bool:
+    return _shutdown_requested
+
+
+# ---------------------------------------------------------------------------
 # Heartbeat thread
 # ---------------------------------------------------------------------------
 
@@ -337,6 +369,7 @@ def _copy_provenance_to_nas(
 def run_unit(args: argparse.Namespace) -> int:
     """Process a single imaging unit end-to-end."""
     pgid = _setup_pgid()
+    _install_sigterm_handler()
 
     manifest_path = Path(args.manifest)
     raid_dir = Path(args.raid_dir)
@@ -441,6 +474,15 @@ def run_unit(args: argparse.Namespace) -> int:
 
         from panta_rei.imaging.runner import run_tclean_feather_parallel
 
+        # F2.f: flip state.json to PUBLISHING immediately before the runner
+        # starts the publish step.  This lets the orchestrator's re-read in
+        # the verify-or-quarantine flow safely distinguish "still tclean-ing"
+        # (running) from "actively publishing", and avoid killing during a
+        # publish that could corrupt the canonical FITS.
+        def _on_publish_start() -> None:
+            base_state["phase"] = Phase.PUBLISHING
+            write_state_atomic(state_path, base_state)
+
         success, msg, output_fits = run_tclean_feather_parallel(
             unit=unit,
             output_dir=publish_dir,
@@ -459,11 +501,8 @@ def run_unit(args: argparse.Namespace) -> int:
                 "OPENBLAS_NUM_THREADS": "1",
                 "MKL_NUM_THREADS": "1",
             },
+            on_publish_start=_on_publish_start,
         )
-
-        # ---------- PUBLISHING is done inside run_tclean_feather_parallel ----------
-        base_state["phase"] = Phase.PUBLISHING
-        write_state_atomic(state_path, base_state)
 
         # ---------- COPY PROVENANCE TO NAS ----------
         provenance = _copy_provenance_to_nas(

--- a/panta_rei/imaging/remote_worker.py
+++ b/panta_rei/imaging/remote_worker.py
@@ -440,6 +440,7 @@ def run_unit(args: argparse.Namespace) -> int:
     token_lease = _staging.TokenLease(
         tokens_dir, max_concurrent_staging,
         holder_id=f"{dispatch_id}/{run_id}",
+        timeout_sec=float(getattr(args, "token_wait_timeout_sec", None) or _staging._DEFAULT_TOKEN_WAIT_TIMEOUT_SEC),
     )
 
     try:
@@ -596,6 +597,9 @@ def _build_parser() -> argparse.ArgumentParser:
     ap.add_argument("--publish-policy", default="fail_if_exists",
                     choices=["fail_if_exists", "overwrite"])
     ap.add_argument("--heartbeat-interval", type=float, default=30)
+    ap.add_argument("--token-wait-timeout-sec", type=float, default=None,
+                    help="Bound on worker-side wait for a NAS staging token. "
+                         "None defaults to staging._DEFAULT_TOKEN_WAIT_TIMEOUT_SEC.")
 
     # Preflight subcommand
     pf = sub.add_parser("preflight", help="Check raid + NAS + free space.")

--- a/panta_rei/imaging/runner.py
+++ b/panta_rei/imaging/runner.py
@@ -1274,6 +1274,7 @@ def run_tclean_feather_parallel(
     log_path: Optional[Path] = None,
     extra_env: Optional[dict] = None,
     aux_products: tuple[str, ...] = ("mask", "residual", "pb"),
+    on_publish_start=lambda: None,
 ) -> tuple[bool, str, Optional[str]]:
     """Execute tclean+feather via mpicasa subprocess for MPI parallelism.
 
@@ -1499,6 +1500,12 @@ def run_tclean_feather_parallel(
             log.warning("aux %s: no canonical path resolved, skipping", kind)
             continue
         pair.append((local_aux, canonical))
+
+    # F2.f: notify caller (remote_worker) that publish is about to start
+    # so it can flip state.json to Phase.PUBLISHING.  Exceptions propagate
+    # — a failed state write means the orchestrator can't reliably tell
+    # whether publish is in progress, so publish is also unsafe to start.
+    on_publish_start()
 
     ok, msg = _publish_pair(pair, policy=publish_policy)
     if not ok:

--- a/panta_rei/imaging/staging.py
+++ b/panta_rei/imaging/staging.py
@@ -23,6 +23,8 @@ Key primitives:
 
 from __future__ import annotations
 
+import ctypes
+import ctypes.util
 import hashlib
 import json
 import logging
@@ -32,11 +34,83 @@ import shutil
 import socket
 import subprocess
 import time
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions and module-level constants for bounded waits
+# ---------------------------------------------------------------------------
+
+class StaleLockTimeout(Exception):
+    """``_MkdirLock`` could not acquire within ``wait_timeout_sec``.
+
+    Deliberately NOT a ``TimeoutError`` (which is itself an ``OSError``)
+    so that callers' existing ``except OSError`` clauses for filesystem
+    races do not silently swallow the bounded-wait signal.
+    """
+
+
+class TokenAcquireTimeout(TimeoutError):
+    """``acquire_staging_token`` could not acquire a slot in time.
+
+    IS-A ``TimeoutError`` to preserve the existing ``acquire_staging_token``
+    contract (callers and tests expect ``TimeoutError``).  A dedicated
+    subclass lets ``stage_one``'s populate block discriminate this
+    unit-fatal case from generic filesystem ``ETIMEDOUT``.
+    """
+
+
+_MKDIR_LOCK_DEFAULT_WAIT_SEC = 300.0
+_DEFAULT_TOKEN_WAIT_TIMEOUT_SEC = 1800.0
+_MKDIR_LOCK_PROGRESS_LOG_SEC = 60.0
+
+
+def _read_proc_starttime(pid: int) -> Optional[int]:
+    """Return field 22 of ``/proc/<pid>/stat`` (starttime in clock ticks).
+
+    Returns ``None`` if the PID is dead or ``/proc`` is unreadable.
+    Used to disambiguate PID reuse: the start-time is stable for the
+    lifetime of a process and differs when the kernel hands the same
+    numeric PID to a fresh process.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as f:
+            data = f.read()
+        rparen = data.rfind(b")")
+        if rparen < 0:
+            return None
+        fields = data[rparen + 2:].split()
+        if len(fields) < 20:
+            return None
+        return int(fields[19])
+    except (OSError, ValueError):
+        return None
+
+
+def _same_host(stored: str) -> bool:
+    """True iff *stored* names the current host.
+
+    Compares against ``socket.gethostname()`` and ``socket.getfqdn()`` in
+    both short and FQDN forms.  Case-insensitive per RFC 952/1123.  Two
+    truly-different hosts that share a short name would false-positive
+    here; on this fleet hostnames are unique on the short form.
+    """
+    if not stored:
+        return False
+    stored_low = stored.strip().lower()
+    own: set[str] = set()
+    for name in (socket.gethostname(), socket.getfqdn()):
+        name_low = (name or "").strip().lower()
+        if not name_low:
+            continue
+        own.add(name_low)
+        own.add(name_low.split(".", 1)[0])
+    return stored_low in own or stored_low.split(".", 1)[0] in own
 
 
 # ---------------------------------------------------------------------------
@@ -71,11 +145,17 @@ class _MkdirLock:
     primitive we rely on.  If a previous holder crashed, the lock dir
     persists indefinitely — so on every contended attempt we read the
     holder's metadata and self-heal: if the holder is on the same host
-    and its PID is dead, we ``rmtree`` and retry.  This bounds recovery
-    to a single host's /proc check (no SSH from the worker).
+    and its PID is dead (including same-numeric-PID-but-fresh-process
+    via start-time disambiguation), we ``rmtree`` and retry.  This
+    bounds recovery to a single host's /proc check (no SSH from the
+    worker).
 
-    For cross-host stale lock recovery (a holder on a different host
-    that died), the coordinator's stale-holder reaper handles it.
+    Cross-host stale lock-dir recovery is NOT implemented today.  A
+    stale lock-dir from a remote worker surfaces on the local worker
+    as ``StaleLockTimeout`` after ``wait_timeout_sec``; callers then
+    fall back (cache locks) or fail the unit (stage locks).  A
+    coordinator-side reaper analogous to ``TokenReaper`` is a documented
+    follow-up.
 
     There is a small live-lock race between ``mkdir`` and the
     ``holder.json`` write: a contender that observes the directory
@@ -89,16 +169,42 @@ class _MkdirLock:
     acquired: bool = False
     # Grace window for a freshly-mkdir'd lock to publish its metadata.
     missing_metadata_grace_sec: float = 3.0
+    # Bounded wait — None disables (test/legacy convenience).  Production
+    # defaults to _MKDIR_LOCK_DEFAULT_WAIT_SEC.
+    wait_timeout_sec: Optional[float] = _MKDIR_LOCK_DEFAULT_WAIT_SEC
+    # Poll sleep range (uniform random); tests can pass tight values.
+    poll_sleep: tuple[float, float] = (0.5, 1.5)
 
     def __enter__(self) -> "_MkdirLock":
+        started = time.monotonic()
+        last_progress_log_at = started
+        deadline: Optional[float] = (
+            started + self.wait_timeout_sec
+            if self.wait_timeout_sec is not None else None
+        )
         while True:
+            # Bound EVERY iteration, not just the alive-True branch.
+            # Reclaim-loop pathological cases (filesystem replaying the
+            # stale lock, repeated metadata-missing observations) must
+            # also surface as StaleLockTimeout rather than spin forever.
+            now = time.monotonic()
+            if deadline is not None and now > deadline:
+                holder_meta = _read_holder_meta(self.dir_path)
+                raise StaleLockTimeout(
+                    f"could not acquire {self.dir_path} in "
+                    f"{self.wait_timeout_sec:.0f}s "
+                    f"(holder={holder_meta})"
+                )
             try:
                 self.dir_path.mkdir(parents=True, exist_ok=False)
                 self.acquired = True
+                # Identity fields LAST so a caller-supplied holder_meta
+                # cannot override host/pid/starttime_ticks.
                 meta = {
+                    **(self.holder_meta or {}),
                     "host": socket.gethostname(),
                     "pid": os.getpid(),
-                    **self.holder_meta,
+                    "starttime_ticks": _read_proc_starttime(os.getpid()),
                 }
                 # Atomic publish of holder metadata so contenders never
                 # see a half-written file.
@@ -107,22 +213,234 @@ class _MkdirLock:
                 os.replace(str(tmp), str(self.dir_path / "holder.json"))
                 return self
             except FileExistsError:
+                # Snapshot the holder fingerprint BEFORE the alive check
+                # so the post-rename race-detection compares against the
+                # same generation we judged stale.  holder.json already
+                # encodes pid + starttime_ticks, so PID-reuse cannot
+                # produce a false-positive match.
+                fp_snapshot = _read_blob(self.dir_path / "holder.json")
                 if not _holder_alive_locally(
                     self.dir_path,
                     missing_metadata_grace_sec=self.missing_metadata_grace_sec,
                 ):
-                    # Stale lock from a crashed holder — recover.
                     log.warning(
                         "stale stage lock detected at %s; reclaiming",
                         self.dir_path,
                     )
-                    shutil.rmtree(self.dir_path, ignore_errors=True)
+                    _atomic_reclaim(
+                        self.dir_path,
+                        expected_fingerprint=fp_snapshot,
+                        read_fingerprint=lambda d: _read_blob(d / "holder.json"),
+                        malformed_grace_sec=self.missing_metadata_grace_sec,
+                    )
                     continue
-                time.sleep(random.uniform(0.5, 1.5))
+                if now - last_progress_log_at >= _MKDIR_LOCK_PROGRESS_LOG_SEC:
+                    holder_meta = _read_holder_meta(self.dir_path)
+                    log.warning(
+                        "still waiting for lock at %s; holder=%s waited=%.0fs",
+                        self.dir_path, holder_meta, now - started,
+                    )
+                    last_progress_log_at = now
+                time.sleep(random.uniform(*self.poll_sleep))
 
     def __exit__(self, *exc_info) -> None:
         if self.acquired:
             shutil.rmtree(self.dir_path, ignore_errors=True)
+
+
+def _read_holder_meta(lock_dir: Path) -> Optional[dict]:
+    """Best-effort read of ``holder.json`` for diagnostics; never raises."""
+    try:
+        return json.loads((Path(lock_dir) / "holder.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _atomic_reclaim(
+    stale_dir: Path,
+    *,
+    expected_fingerprint: Optional[bytes],
+    read_fingerprint,
+    malformed_grace_sec: float = 3.0,
+) -> bool:
+    """Atomically reclaim *stale_dir* IFF its generation matches.
+
+    Returns ``True`` iff we removed the generation we observed as
+    stale.  Returns ``False`` if another reclaimer beat us, the
+    directory vanished, or the post-rename generation does not match
+    (in which case we restore it).
+
+    The race-closing story:
+    1. ``os.rename`` is atomic, so exactly one contender can move
+       ``stale_dir`` for a given observation.  Losers see
+       ``FileNotFoundError`` and return ``False``.
+    2. After rename, the winner reads the post-rename fingerprint via
+       *read_fingerprint*.  If it matches *expected_fingerprint*, the
+       moved directory IS the stale generation — safe to ``rmtree``.
+    3. If it does not match, a fresh holder won the lock between our
+       fingerprint snapshot and our rename.  We reverse-rename to put
+       the fresh holder back.  If the reverse-rename fails (a third
+       contender ``mkdir``'d at ``stale_dir`` in the gap), we DO NOT
+       ``rmtree`` the renamed copy — that would silently delete a
+       valid holder while a different one owns the original path.
+       The stranded ``.reclaim.<uuid>`` directory is logged loudly
+       for operator follow-up; data integrity is preserved at the
+       cost of a leaked directory.
+
+    Fingerprint design:
+    - Callers snapshot the bytes BEFORE the liveness check.
+    - The fingerprint MUST be strong enough to disambiguate two
+      different live processes (PID reuse: same numeric PID but
+      different start-time).  For lock-dirs, ``holder.json`` already
+      encodes ``pid`` + ``starttime_ticks``.  For tokens, the
+      fingerprint reader concatenates ``pid`` and ``starttime_ticks``
+      file contents.
+    - When the stale generation legitimately has no fingerprint
+      (mkdir won but holder published nothing — the malformed window),
+      callers pass ``expected_fingerprint=None``.  In that case we
+      fall back to an mtime-age check: only rmtree if the directory
+      is older than *malformed_grace_sec* (mirrors
+      ``_holder_alive_locally``'s grace logic) — a freshly-mkdir'd
+      dir under us would have age < grace and be put back.
+
+    Residual race: a fresh holder that mkdir's, writes the
+    fingerprint, AND has the same fingerprint bytes as the stale gen
+    (e.g., same pid+starttime — astronomically unlikely with
+    start-time check) — would still match and be rmtree'd.  This
+    is a microsecond-scale window we accept as a defense-in-depth
+    backstop; the primary protection remains the bounded
+    ``wait_timeout_sec`` plus the dispatch-side ``TokenReaper`` for
+    tokens.
+    """
+    reclaim_path = stale_dir.with_name(
+        stale_dir.name + f".reclaim.{uuid.uuid4().hex}"
+    )
+    try:
+        os.rename(str(stale_dir), str(reclaim_path))
+    except (FileNotFoundError, OSError):
+        return False
+
+    actual = read_fingerprint(reclaim_path)
+    safe_to_remove = False
+    if expected_fingerprint is not None and actual == expected_fingerprint:
+        safe_to_remove = True
+    elif expected_fingerprint is None and actual is None:
+        # Both fingerprint-less — distinguish "still old stale lock"
+        # from "fresh mkdir under us" via directory mtime age.
+        try:
+            age = time.time() - reclaim_path.stat().st_mtime
+        except OSError:
+            age = float("inf")
+        if age >= malformed_grace_sec:
+            safe_to_remove = True
+
+    if safe_to_remove:
+        shutil.rmtree(reclaim_path, ignore_errors=True)
+        return True
+
+    # Not safe — restore the path so the fresh holder (or whoever
+    # legitimately owns it now) is not disrupted.  Use renameat2 with
+    # RENAME_NOREPLACE: plain os.rename would clobber an empty third-
+    # contender directory at stale_dir.  If renameat2 is unavailable
+    # OR the destination exists, leave the .reclaim.<uuid> stranded
+    # rather than risk overwriting a valid holder.
+    if not _safe_restore(reclaim_path, stale_dir):
+        log.error(
+            "reclaim race at %s: moved an unexpected generation, "
+            "could not safely restore (renameat2 unavailable or "
+            "destination occupied). Stranded copy left at %s; "
+            "manual investigation needed.",
+            stale_dir, reclaim_path,
+        )
+    return False
+
+
+def _read_blob(path: Path) -> Optional[bytes]:
+    """Best-effort bytes-read; returns None on any OSError."""
+    try:
+        return Path(path).read_bytes()
+    except OSError:
+        return None
+
+
+def _read_token_fingerprint(slot_dir: Path) -> Optional[bytes]:
+    """Generation fingerprint for a staging token slot.
+
+    Returns the canonical bytes ``<pid>|<starttime_ticks>`` only when
+    BOTH files exist AND each parses as a non-negative integer (after
+    stripping).  Returns ``None`` for absent/empty/malformed files so
+    ``_atomic_reclaim`` falls back to the mtime-age path rather than
+    match a partial generation by PID alone — a fresh holder mid-write
+    can briefly expose a zero-length ``starttime_ticks`` file
+    (``Path.write_text`` truncates before writing), which would
+    otherwise let an old same-PID stale slot's fingerprint collide
+    with the new generation's "pid|empty".
+    """
+    pid_bytes = _read_blob(slot_dir / "pid")
+    st_bytes = _read_blob(slot_dir / "starttime_ticks")
+    if pid_bytes is None or st_bytes is None:
+        return None
+    try:
+        pid = int(pid_bytes.strip())
+        st = int(st_bytes.strip())
+    except (ValueError, AttributeError):
+        return None
+    if pid < 0 or st < 0:
+        return None
+    return f"{pid}|{st}".encode()
+
+
+# renameat2 + RENAME_NOREPLACE: atomic rename that REFUSES to clobber
+# an existing destination.  POSIX ``os.rename`` allows renaming a
+# non-empty dir onto an empty dir (which would commandeer a third
+# contender's freshly-mkdir'd slot during reclaim put-back).  Linux
+# 3.15+ exposes ``renameat2`` for the no-replace semantic; on older
+# kernels or non-Linux, ``_safe_restore`` falls back to "leave
+# stranded" rather than risk overwriting a fresh holder.
+
+_RENAME_NOREPLACE = 1
+_AT_FDCWD = -100
+_libc = None
+
+
+def _load_libc():
+    global _libc
+    if _libc is not None:
+        return _libc
+    libc_name = ctypes.util.find_library("c") or "libc.so.6"
+    try:
+        _libc = ctypes.CDLL(libc_name, use_errno=True)
+    except OSError:
+        _libc = False  # sentinel: failed to load
+    return _libc
+
+
+def _safe_restore(reclaim_path: Path, original_path: Path) -> bool:
+    """Try to rename *reclaim_path* back to *original_path* WITHOUT
+    overwriting an existing destination.
+
+    Returns ``True`` on a successful restore.  Returns ``False`` if
+    the destination already exists OR renameat2 is unavailable on
+    this platform.  Crucially, this NEVER clobbers a fresh empty
+    directory that a third contender may have just created at
+    *original_path* — closing the rename-over-empty-dir hazard that
+    plain ``os.rename`` would expose.
+    """
+    libc = _load_libc()
+    if libc is False or not hasattr(libc, "renameat2"):
+        return False
+    libc.renameat2.restype = ctypes.c_int
+    libc.renameat2.argtypes = [
+        ctypes.c_int, ctypes.c_char_p,
+        ctypes.c_int, ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    ret = libc.renameat2(
+        _AT_FDCWD, str(reclaim_path).encode(),
+        _AT_FDCWD, str(original_path).encode(),
+        _RENAME_NOREPLACE,
+    )
+    return ret == 0
 
 
 def _holder_alive_locally(
@@ -132,7 +450,9 @@ def _holder_alive_locally(
     """Return True iff the lock's holder is on this host AND alive.
 
     Cross-host holders are reported as alive (no local check is
-    possible) — the coordinator's reaper handles those.
+    possible).  Cross-host stale lock-dir recovery is not implemented
+    today — callers rely on the bounded ``_MkdirLock`` wait to surface
+    a typed ``StaleLockTimeout`` instead of looping forever.
 
     Missing ``holder.json`` could mean either (a) a crashed holder
     that never wrote metadata, or (b) a freshly-mkdir'd lock whose
@@ -141,18 +461,16 @@ def _holder_alive_locally(
     ``missing_metadata_grace_sec`` for the file to appear before
     declaring stale.
 
-    Same-host holder: PID-only liveness via ``os.kill(pid, 0)``.  We
-    deliberately do NOT validate the cmdline here because (a) the
-    ``/proc/<pid>/cmdline`` of an unrelated PID-reuse victim is
-    indistinguishable from a legitimate other Python process, and (b)
-    the cross-host coordinator reaper handles cmdline-based PID reuse
-    detection more carefully.
+    Same-host liveness: ``os.kill(pid, 0)`` plus start-time match.
+    The start-time check disambiguates PID reuse: a fresh process at
+    the same numeric PID has a different ``/proc/<pid>/stat`` field
+    22.  Holders written by older versions (no ``starttime_ticks``
+    field) fall back to PID-only liveness — graceful degradation.
     """
     holder_file = Path(lock_dir) / "holder.json"
     if not holder_file.exists():
         # Race: holder may be mid-write.  Give it a grace window before
-        # declaring stale.  Polling is short (50ms) to keep contention
-        # latency low on legitimate stale-lock recovery paths.
+        # declaring stale.
         deadline = time.monotonic() + max(0.0, missing_metadata_grace_sec)
         while time.monotonic() < deadline:
             time.sleep(0.05)
@@ -167,22 +485,33 @@ def _holder_alive_locally(
 
     host = meta.get("host")
     pid = int(meta.get("pid", 0))
+    starttime = meta.get("starttime_ticks")
     if not pid:
         return False
-    if host and host != socket.gethostname():
-        # Different host — caller must rely on the coordinator reaper.
+    if host and not _same_host(host):
         return True
 
     try:
         os.kill(pid, 0)
-        return True
     except ProcessLookupError:
         return False
     except PermissionError:
-        # Process exists but is owned by another user — treat as alive.
         return True
     except OSError:
-        return True  # ambiguous — assume alive
+        return True
+
+    if starttime is not None:
+        current = _read_proc_starttime(pid)
+        if current is None:
+            # PID died between os.kill and stat read — stale.
+            return False
+        try:
+            if int(current) != int(starttime):
+                # PID was reused — original holder is gone.
+                return False
+        except (TypeError, ValueError):
+            return True
+    return True
 
 
 def acquire_stage_lock(gous_dir: Path, holder_meta: dict | None = None) -> _MkdirLock:
@@ -202,46 +531,153 @@ def acquire_stage_lock(gous_dir: Path, holder_meta: dict | None = None) -> _Mkdi
 # NAS staging tokens (global concurrency cap)
 # ---------------------------------------------------------------------------
 
+def _token_holder_alive(
+    slot_dir: Path,
+    malformed_grace_sec: float = 60.0,
+) -> bool:
+    """Return True iff the token slot's holder is on this host AND alive.
+
+    Mirrors ``_holder_alive_locally`` but for the per-token metadata
+    shape (``host``, ``pid``, ``holder``, ``acquired_at``, optional
+    ``starttime_ticks``) used by :func:`acquire_staging_token`.
+
+    Missing-metadata slots get a ``malformed_grace_sec`` window before
+    being declared stale — mirrors the dispatch-side
+    ``_TOKEN_MALFORMED_GRACE_SEC`` so an in-flight acquire's brief
+    mkdir-then-write window is not stolen.
+
+    Cross-host holders are treated as alive; the dispatch coordinator's
+    ``TokenReaper`` performs cross-host cleanup via ``ssh_pid_alive``.
+    """
+    slot_dir = Path(slot_dir)
+    host_file = slot_dir / "host"
+    pid_file = slot_dir / "pid"
+
+    # Missing host or pid: respect the grace window for in-flight
+    # acquires that have mkdir'd the slot but not yet written metadata.
+    if not host_file.exists() or not pid_file.exists():
+        try:
+            slot_mtime = slot_dir.stat().st_mtime
+        except OSError:
+            return False
+        age = time.time() - slot_mtime
+        if age < malformed_grace_sec:
+            return True
+        return False
+
+    try:
+        host = host_file.read_text().strip()
+        pid = int(pid_file.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    if not pid:
+        return False
+    if host and not _same_host(host):
+        return True
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return True
+
+    st_file = slot_dir / "starttime_ticks"
+    if st_file.exists():
+        try:
+            stored = int(st_file.read_text().strip())
+        except (OSError, ValueError):
+            return True
+        current = _read_proc_starttime(pid)
+        if current is None:
+            return False
+        if current != stored:
+            return False
+    return True
+
+
 def acquire_staging_token(
     tokens_root: Path,
     n_slots: int,
     *,
     holder_id: str,
     poll_sleep: tuple[float, float] = (1.0, 3.0),
-    timeout_sec: Optional[float] = None,
+    timeout_sec: Optional[float] = _DEFAULT_TOKEN_WAIT_TIMEOUT_SEC,
 ) -> int:
     """Acquire one of *n_slots* tokens under *tokens_root*.
 
     Atomic primitive: ``os.mkdir(tokens_root/<i>)``.  Returns the index
-    of the slot acquired.  On crash, the token directory persists; the
-    coordinator's reaper :func:`reap_stale_tokens` drops it after
-    confirming the holder PID is dead.
+    of the slot acquired.  ``timeout_sec`` bounds the wait — defaults to
+    30 minutes; ``None`` opts out (legacy / test convenience).
+
+    Raises :class:`TokenAcquireTimeout` (an alias of ``TimeoutError``)
+    when the bound is exceeded.  Same-host stale slots whose PID is
+    dead — including same-numeric-PID-but-fresh-process via
+    ``starttime_ticks`` mismatch — are reclaimed and re-tried.
+    Cross-host stale slots are left to the dispatch coordinator's
+    ``TokenReaper``.
     """
     tokens_root = Path(tokens_root)
     tokens_root.mkdir(parents=True, exist_ok=True)
     started = time.monotonic()
     while True:
+        # Bound EVERY iteration of the outer loop, not just the
+        # all-slots-pinned path.  A pathological reclaim cycle (e.g.,
+        # filesystem churn racing our rename) must also terminate.
+        if timeout_sec is not None and time.monotonic() - started > timeout_sec:
+            raise TokenAcquireTimeout(
+                f"could not acquire staging token under {tokens_root} "
+                f"in {timeout_sec}s"
+            )
         for i in range(n_slots):
             slot = tokens_root / str(i)
             try:
                 slot.mkdir()
             except FileExistsError:
-                continue
+                # Snapshot the generation fingerprint (pid +
+                # starttime_ticks) BEFORE the alive check.  Using both
+                # closes the PID-reuse race: a fresh holder with the
+                # same numeric PID will have a different start time.
+                fp_snapshot = _read_token_fingerprint(slot)
+                if not _token_holder_alive(slot):
+                    log.warning(
+                        "stale staging token at %s; reclaiming", slot,
+                    )
+                    _atomic_reclaim(
+                        slot,
+                        expected_fingerprint=fp_snapshot,
+                        read_fingerprint=_read_token_fingerprint,
+                        # Mirror dispatch._TOKEN_MALFORMED_GRACE_SEC for
+                        # the no-metadata window.
+                        malformed_grace_sec=60.0,
+                    )
+                    try:
+                        slot.mkdir()
+                    except FileExistsError:
+                        continue
+                else:
+                    continue
             try:
+                # Identity-bearing files written; ``starttime_ticks``
+                # last so consumers checking for its presence can
+                # safely fall back to PID-only on old slots.
                 (slot / "host").write_text(socket.gethostname())
                 (slot / "pid").write_text(str(os.getpid()))
                 (slot / "holder").write_text(holder_id)
                 (slot / "acquired_at").write_text(str(time.time()))
+                st = _read_proc_starttime(os.getpid())
+                if st is not None:
+                    (slot / "starttime_ticks").write_text(str(st))
             except OSError as exc:
-                # Couldn't write metadata — give up the slot
+                # Best-effort cleanup of OUR partial write; the slot
+                # path may belong to us (we just mkdir'd it) so a
+                # direct rmtree here is safe — no peer can have raced
+                # to write into a slot we own.
                 shutil.rmtree(slot, ignore_errors=True)
                 raise RuntimeError(f"failed to write token metadata: {exc}")
             return i
-        if timeout_sec is not None and time.monotonic() - started > timeout_sec:
-            raise TimeoutError(
-                f"could not acquire staging token under {tokens_root} "
-                f"in {timeout_sec}s"
-            )
         time.sleep(random.uniform(*poll_sleep))
 
 
@@ -251,7 +687,14 @@ def release_staging_token(tokens_root: Path, i: int) -> None:
 
 
 def list_held_tokens(tokens_root: Path) -> list[dict]:
-    """Return metadata for every held token under *tokens_root*."""
+    """Return metadata for every held token under *tokens_root*.
+
+    ``starttime_ticks`` is OPTIONAL — old tokens (pre-PID-reuse fix)
+    are reported with ``starttime_ticks: None`` and MUST NOT be
+    misclassified as malformed.  The dispatch ``TokenReaper`` reaps
+    malformed slots after a grace window; treating old-but-valid slots
+    as malformed would disrupt live cross-version dispatches.
+    """
     tokens_root = Path(tokens_root)
     if not tokens_root.exists():
         return []
@@ -263,14 +706,23 @@ def list_held_tokens(tokens_root: Path) -> list[dict]:
             host = (slot / "host").read_text().strip()
             pid = int((slot / "pid").read_text().strip())
             holder = (slot / "holder").read_text().strip() if (slot / "holder").exists() else ""
+            # starttime_ticks is back-compat optional — its own
+            # try/except so a corrupt-but-not-missing value still
+            # reports None instead of poisoning the slot record.
+            starttime_ticks: Optional[int] = None
+            st_file = slot / "starttime_ticks"
+            if st_file.exists():
+                try:
+                    starttime_ticks = int(st_file.read_text().strip())
+                except (OSError, ValueError):
+                    starttime_ticks = None
             out.append({
                 "slot": slot.name, "path": slot, "host": host, "pid": pid,
-                "holder": holder,
+                "holder": holder, "starttime_ticks": starttime_ticks,
             })
         except (OSError, ValueError):
-            # Partially-populated slot — treat as suspect
             out.append({"slot": slot.name, "path": slot, "host": None, "pid": None,
-                        "holder": ""})
+                        "holder": "", "starttime_ticks": None})
     return out
 
 
@@ -627,18 +1079,22 @@ def acquire_cache_populate(
 
     Raises ``TimeoutError`` if neither outcome occurs within
     ``timeout_sec`` (caller should fall back to NAS-direct staging).
+    Raises :class:`StaleLockTimeout` if the inner GC lock acquisition
+    exceeds its (capped) bound — this is NOT a ``TimeoutError`` /
+    ``OSError`` subclass, so callers' ``except OSError`` filesystem-race
+    handlers do not silently swallow it.
 
     Stale-lock recovery: if the populator's host matches ours and its PID
-    is dead, we ``rmtree`` and retry.  Cross-host stale recovery is left
-    to the coordinator's reaper (same as NAS staging tokens) — workers
-    must NEVER ssh to a peer to check liveness.
+    is dead (PID reuse defended via ``starttime_ticks``), we ``rmtree``
+    and retry.  Cross-host stale recovery is NOT implemented today; the
+    bounded GC-lock wait surfaces it as ``StaleLockTimeout`` to the
+    caller.
     """
     cache_root = Path(cache_root)
     src_path = Path(src_path)
     entry_dir = cache_root / _cache_key(src_path)
     populating = entry_dir / ".populating"
     deadline = time.monotonic() + timeout_sec
-    meta = {"host": socket.gethostname(), "pid": os.getpid(), **(holder_meta or {})}
     cache_root.mkdir(parents=True, exist_ok=True)
     gc_lock_path = cache_root / ".gc.lock.d"
 
@@ -651,23 +1107,38 @@ def acquire_cache_populate(
         if hit is not None:
             return ("hit", None)
 
+        # Inner GC-lock wait is capped by remaining outer budget so a
+        # caller passing a small ``timeout_sec`` does not get a 300s
+        # inner timeout overshoot.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"cache populate wait exceeded {timeout_sec:.0f}s for {src_path}"
+            )
+        inner_timeout = min(_MKDIR_LOCK_DEFAULT_WAIT_SEC, remaining)
+
         # Publish ``.populating`` *under the GC lock* so concurrent
         # ``cache_evict_until_free`` cannot rmtree our entry between
-        # our mkdir and our holder.json write — eviction's
-        # candidate-collection sweep and our publish are now mutually
-        # exclusive at the GC mutex.  Populate cost is dominated by the
-        # NAS read which happens AFTER the GC lock is released; the
-        # critical section here is just two filesystem ops.
+        # our mkdir and our holder.json write.
         try:
             with _MkdirLock(
                 dir_path=gc_lock_path,
                 holder_meta={"role": "publish_populate", **(holder_meta or {})},
+                wait_timeout_sec=inner_timeout,
             ):
                 try:
                     populating.mkdir(parents=True, exist_ok=False)
                 except FileExistsError:
                     publish_outcome = "exists"
                 else:
+                    # Identity fields LAST so caller-supplied
+                    # holder_meta cannot override host/pid/starttime.
+                    meta = {
+                        **(holder_meta or {}),
+                        "host": socket.gethostname(),
+                        "pid": os.getpid(),
+                        "starttime_ticks": _read_proc_starttime(os.getpid()),
+                    }
                     tmp = populating / ".holder.json.tmp"
                     tmp.write_text(json.dumps(meta))
                     os.replace(str(tmp), str(populating / "holder.json"))
@@ -699,10 +1170,16 @@ def acquire_cache_populate(
 
         # ``.populating`` already present — fall through to wait/stale/timeout.
 
-        # Same-host stale recovery (cross-host is the coordinator reaper's job).
+        # Same-host stale recovery (cross-host is left to the bounded
+        # outer ``timeout_sec`` — no coordinator reaper for lock dirs).
+        fp_snapshot = _read_blob(populating / "holder.json")
         if not _holder_alive_locally(populating):
             log.warning("stale cache populate lock at %s; reclaiming", populating)
-            shutil.rmtree(populating, ignore_errors=True)
+            _atomic_reclaim(
+                populating,
+                expected_fingerprint=fp_snapshot,
+                read_fingerprint=lambda d: _read_blob(d / "holder.json"),
+            )
             continue
 
         if time.monotonic() > deadline:
@@ -738,6 +1215,7 @@ def cache_evict_until_free(
     target_free_bytes: int,
     *,
     skip_keys: Optional[set[str]] = None,
+    wait_timeout_sec: float = _MKDIR_LOCK_DEFAULT_WAIT_SEC,
 ) -> int:
     """Evict oldest cache entries (by sidecar ``staged_at``) until at
     least *target_free_bytes* are free on the cache filesystem.
@@ -745,6 +1223,11 @@ def cache_evict_until_free(
     Returns the number of entries evicted.  Skips entries whose key is
     in *skip_keys* (the entry currently being populated by the caller),
     plus any entry with a ``.populating`` lock.
+
+    On GC-lock contention exceeding ``wait_timeout_sec``, logs a WARN
+    and returns 0 (no eviction performed; caller proceeds without
+    trimmed space).  This bounds the worst case when a peer worker's
+    eviction stalls under load.
 
     Concurrency: a per-host GC mutex (mkdir-based) serialises eviction
     so two workers cannot rmtree the same entry concurrently or race
@@ -757,7 +1240,20 @@ def cache_evict_until_free(
     gc_lock = cache_root / ".gc.lock.d"
     cache_root.mkdir(parents=True, exist_ok=True)
 
-    with _MkdirLock(dir_path=gc_lock, holder_meta={"role": "cache_gc"}):
+    try:
+        gc_cm = _MkdirLock(
+            dir_path=gc_lock,
+            holder_meta={"role": "cache_gc"},
+            wait_timeout_sec=wait_timeout_sec,
+        )
+        gc_cm.__enter__()
+    except StaleLockTimeout as exc:
+        log.warning(
+            "cache_evict_until_free: GC lock timeout on %s after %.0fs: %s",
+            gc_lock, wait_timeout_sec, exc,
+        )
+        return 0
+    try:
         free = _du_free_bytes(cache_root)
         if free >= target_free_bytes:
             return 0
@@ -803,6 +1299,8 @@ def cache_evict_until_free(
             shutil.rmtree(entry_dir, ignore_errors=True)
             evicted += 1
         return evicted
+    finally:
+        gc_cm.__exit__(None, None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -829,10 +1327,12 @@ class TokenLease:
         n_slots: int,
         *,
         holder_id: str,
+        timeout_sec: float = _DEFAULT_TOKEN_WAIT_TIMEOUT_SEC,
     ) -> None:
         self.tokens_dir = Path(tokens_dir) if tokens_dir else None
         self.n_slots = int(n_slots)
         self.holder_id = holder_id
+        self.timeout_sec = float(timeout_sec)
         self._idx: Optional[int] = None
         self._wait_total_sec = 0.0
         self._acquires = 0
@@ -843,6 +1343,7 @@ class TokenLease:
         started = time.monotonic()
         self._idx = acquire_staging_token(
             self.tokens_dir, self.n_slots, holder_id=self.holder_id,
+            timeout_sec=self.timeout_sec,
         )
         waited = time.monotonic() - started
         self._wait_total_sec += waited
@@ -947,10 +1448,10 @@ def stage_one(
                 holder_meta={"role": "cache_populate"},
                 timeout_sec=cache_populate_timeout_sec,
             )
-        except TimeoutError:
+        except (TimeoutError, StaleLockTimeout) as exc:
             log.warning(
-                "cache populate timeout for %s; falling back to NAS-direct",
-                src_path.name,
+                "cache populate gave up for %s (%s); falling back to NAS-direct",
+                src_path.name, exc,
             )
             outcome, lock = "fallback", None
 
@@ -975,6 +1476,10 @@ def stage_one(
                 # ("hit", None) instead of ("populate", lock) in that
                 # case, so we only reach here when there is genuinely
                 # no valid entry to reuse.
+                # stage_one-level populate deadline: we already committed
+                # to bounded time when entering this branch, so cap any
+                # downstream eviction wait by the same budget.
+                populate_deadline = time.monotonic() + cache_populate_timeout_sec
                 entry_dir = Path(cache_root) / _cache_key(src_path)
                 entry_dir.mkdir(parents=True, exist_ok=True)
                 cache_partial = entry_dir / f".{src_path.name}.partial"
@@ -983,10 +1488,14 @@ def stage_one(
                 try:
                     fp = _compute_fingerprint(src_path)
                     if cache_min_free_bytes is not None:
+                        remaining = max(0.0, populate_deadline - time.monotonic())
                         cache_evict_until_free(
                             Path(cache_root),
                             cache_min_free_bytes + int(fp["size_bytes"]),
                             skip_keys={_cache_key(src_path)},
+                            wait_timeout_sec=min(
+                                _MKDIR_LOCK_DEFAULT_WAIT_SEC, remaining,
+                            ),
                         )
                     _wipe(cache_partial)
                     if cache_final.exists():
@@ -1003,6 +1512,11 @@ def stage_one(
                     # Sidecar LAST — this is the entry's commit marker.
                     _write_sidecar_atomic(entry_dir, src_path, fp)
                     populate_ok = True
+                except TokenAcquireTimeout:
+                    # Token gate exhausted: NAS read is gated, no gate =
+                    # no NAS read.  Surface as unit failure rather than
+                    # silent NAS-direct retry (which would also fail).
+                    raise
                 except Exception as exc:
                     log.warning(
                         "cache populate failed for %s: %s — NAS-direct",

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1325,12 +1325,16 @@ def _minimal_ctx(tmp_path, dispatch_id="d_test"):
     return ctx, db_writer
 
 
-def test_adoption_poller_releases_slot_on_poll_crash(tmp_path, monkeypatch):
+def test_adoption_poller_quarantines_on_poll_crash(tmp_path, monkeypatch):
     """If ``poll_state_until_terminal`` raises, the AdoptionPoller must
-    still call ``mark_terminal`` so the slot doesn't stay stuck in
-    ``in_flight`` for the rest of the dispatch.  It must NOT spawn a
-    successor MachineSlot — the remote worker may still be alive and
-    a successor would oversubscribe the host.
+    quarantine the host (v3 Delta 8) and leave the run row ACTIVE so the
+    next dispatch's reconcile_prior can recover it.  It must NOT spawn a
+    successor MachineSlot — the remote worker may still be alive and a
+    successor would oversubscribe the host.
+
+    Audit nit: renamed from ``..._releases_slot_on_poll_crash`` to
+    reflect the v3-invariant behaviour — the row is NOT released; the
+    host is quarantined and the row stays active.
     """
     ctx, db_writer = _minimal_ctx(tmp_path)
     try:
@@ -1347,7 +1351,7 @@ def test_adoption_poller_releases_slot_on_poll_crash(tmp_path, monkeypatch):
         monkeypatch.setattr(D, "poll_state_until_terminal", _boom)
 
         # Even with preflight ready, the crash path must NOT spawn a
-        # successor (gated on ``final is not None``).
+        # successor (gated on _is_observed_terminal + not-quarantined).
         ctx.new_launch_machines_names = {"alpha"}
         ctx.new_launch_machines_ready.set()
         spawned: list = []
@@ -1362,10 +1366,10 @@ def test_adoption_poller_releases_slot_on_poll_crash(tmp_path, monkeypatch):
         # Run synchronously in this thread for deterministic assertion
         poller.run()
 
-        # mark_terminal must have cleared in_flight for (alpha, G1)
-        assert ("alpha", "G1") not in ctx.scheduler.in_flight
-        # And the (machine, gous) pair must be in failed_run_ids
-        assert 999 in ctx.scheduler.failed_run_ids.get(("alpha", "G1"), set())
+        # Host quarantined; in_flight stays (run row is left ACTIVE).
+        assert "alpha" in ctx.scheduler.quarantined_machines
+        # No success/failure recorded — terminal was not observed.
+        assert 999 not in ctx.scheduler.failed_run_ids.get(("alpha", "G1"), set())
         # Successor NOT spawned despite preflight ready
         assert spawned == [], f"unexpected successor spawn on poll crash: {spawned}"
         assert ctx.successors_spawned.get("alpha", 0) == 0
@@ -1389,8 +1393,11 @@ def test_successor_spawn_caps_at_machine_slots(tmp_path, monkeypatch):
         # MachineSlot threads or touch NAS.  We just need the spawn
         # decisions, not the thread bodies.
         spawned: list = []
+        # Provide a properly OBSERVED terminal: _is_observed_terminal()
+        # requires phase ∈ {"done","failed"} and no synthetic reason.
         monkeypatch.setattr(
-            D, "poll_state_until_terminal", lambda *a, **kw: {"success": True},
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {"phase": "done", "success": True},
         )
 
         original_start = D.MachineSlot.start
@@ -1436,8 +1443,11 @@ def test_pending_successor_queued_when_preflight_not_ready(tmp_path, monkeypatch
         # NOTE: do NOT set new_launch_machines_ready
         assert not ctx.new_launch_machines_ready.is_set()
 
+        # Observed-terminal final required by the new _is_observed_terminal
+        # gate (phase ∈ {"done","failed"}).
         monkeypatch.setattr(
-            D, "poll_state_until_terminal", lambda *a, **kw: {"success": True},
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {"phase": "done", "success": True},
         )
         # Block MachineSlot.start so this test doesn't accidentally spawn
         monkeypatch.setattr(
@@ -1473,7 +1483,8 @@ def test_adoption_warns_when_gous_uid_unresolvable(tmp_path, monkeypatch, caplog
     ctx, db_writer = _minimal_ctx(tmp_path)
     try:
         monkeypatch.setattr(
-            D, "poll_state_until_terminal", lambda *a, **kw: {"success": True},
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {"phase": "done", "success": True},
         )
         monkeypatch.setattr(D.MachineSlot, "start", lambda self: None)
 
@@ -1487,7 +1498,7 @@ def test_adoption_warns_when_gous_uid_unresolvable(tmp_path, monkeypatch, caplog
         poller = D.AdoptionPoller(
             adopted, ctx, machine_cfg=ctx.cfg.machines["alpha"],
         )
-        with caplog.at_level(_logging.WARNING, logger="panta_rei.imaging.dispatch"):
+        with caplog.at_level(_logging.WARNING, logger="panta_rei.dispatch"):
             poller.run()
 
         # Warning emitted; mark_inflight skipped → no in_flight entry
@@ -1499,3 +1510,1435 @@ def test_adoption_warns_when_gous_uid_unresolvable(tmp_path, monkeypatch, caplog
     finally:
         db_writer.stop()
         db_writer.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# v3+ hardening pass (2026-05-31): fail-closed orphan cleanup,
+# per-host quarantine, observability.
+# ---------------------------------------------------------------------------
+
+
+# Fast tunings so verify_and_kill_worker doesn't block the test suite for
+# 5+ minutes per call (default worker_shutdown_grace_sec is 300s).
+def _fast_globals() -> "D.GlobalCfg":
+    return D.GlobalCfg(
+        poll_interval_sec=0.01,
+        state_appeared_timeout_sec=1,
+        heartbeat_stale_threshold_sec=300,
+        launch_pidfile_wait_sec=0,
+        worker_shutdown_grace_sec=0,
+        late_state_grace_sec=0,
+    )
+
+
+def _stub_verify_to(outcome, detail="stub"):
+    """Build a verify_and_kill_worker stub that returns a fixed outcome."""
+    return lambda *a, **kw: (outcome, detail)
+
+
+def _stub_verify_from_responses(pid_alive_responses):
+    """Build a stub mapping ssh_pid_alive responses to verify_and_kill outcome.
+
+    Mirrors verify_and_kill_worker's logic without sleeping.
+    """
+    def _stub(machine, pid, tokens, g, **kw):
+        first = pid_alive_responses[0]
+        if first == (False, ""):
+            return D.VERIFY_DEAD, "worker_already_exited"
+        if first[0] is False and first[1]:
+            return D.VERIFY_DEAD, f"pid_reused: {first[1]!r}"
+        if first[0] is None:
+            return D.VERIFY_INCONCLUSIVE, f"ssh-unreachable: {first[1]}"
+        # alive=True — replay subsequent responses
+        if len(pid_alive_responses) >= 2 and pid_alive_responses[1][0] is False:
+            return D.VERIFY_KILLED, "sigterm_killed"
+        return D.VERIFY_INCONCLUSIVE, "still alive after kill"
+    return _stub
+
+
+def _build_unit_ctx(tmp_path, machine_name="alpha"):
+    """Build a (DispatchContext, db_writer, MachineSlot, unit) tuple
+    sufficient to drive _dispatch_one without real SSH."""
+    db = DatabaseManager(tmp_path / "x.db")
+    with db.connect() as con:
+        DispatchesQueries.insert(
+            con, dispatch_id="d_test",
+            coordinator_host="local", coordinator_pid=os.getpid(),
+            machines_json="{}", cli_args="",
+        )
+        con.commit()
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=_fast_globals(),
+        machines={machine_name: D.MachineCfg(
+            machine_name, f"/raid/{machine_name}", slots=1, nproc=1,
+            cache_min_free_gb=None,
+        )},
+    )
+    db_writer = D.DBWriter(db, "d_test")
+    db_writer.start()
+    scheduler = D.SchedulerState(queue=[])
+    ctx = D.DispatchContext(
+        cfg=cfg, dispatch_id="d_test",
+        dispatch_dir=tmp_path / "imaging" / "dispatch" / "d_test",
+        publish_dir=tmp_path / "pub",
+        tokens_dir=tmp_path / "tokens",
+        db_writer=db_writer, db_manager=db, scheduler=scheduler,
+        transfer_method="tar", publish_policy="fail_if_exists",
+        deconvolver="multiscale", scales=[0, 5, 10],
+        gous_inputs={"G_TEST": []},
+    )
+    ctx.dispatch_dir.mkdir(parents=True, exist_ok=True)
+    unit = ImagingUnit(
+        gous_uid="G_TEST", source_name="S", line_group="LG",
+        spw_id="23", params_id=1,
+        recovered_params={"start": "100GHz", "width": "1MHz", "nchan": 10},
+        ready=True,
+    )
+    slot = D.MachineSlot(f"{machine_name}#0", cfg.machines[machine_name], ctx)
+    return ctx, db_writer, slot, unit
+
+
+# ---- F2.a / config defaults ------------------------------------------------
+
+
+def test_state_appeared_timeout_default_is_300():
+    """v5 F2.e: default raised from 60 → 300."""
+    assert D.GlobalCfg().state_appeared_timeout_sec == 300
+
+
+def test_launch_pidfile_wait_default_is_30():
+    """v3 F6: default 30s wait for worker.pidfile after launch failure."""
+    assert D.GlobalCfg().launch_pidfile_wait_sec == 30
+
+
+def test_worker_shutdown_grace_default_is_300():
+    """v4 Delta 6: single grace knob, 300s by default."""
+    assert D.GlobalCfg().worker_shutdown_grace_sec == 300
+
+
+def test_late_state_grace_default_is_1800():
+    """v3 F2.b/F2.h: late-state grace is 30 minutes by default."""
+    assert D.GlobalCfg().late_state_grace_sec == 1800
+
+
+def test_is_observed_terminal_predicate():
+    """F4: only observed (non-synthetic) terminals count."""
+    assert D._is_observed_terminal(None) is False
+    assert D._is_observed_terminal({}) is False
+    assert D._is_observed_terminal({"phase": "running"}) is False
+    assert D._is_observed_terminal({"phase": "done", "success": True}) is True
+    assert D._is_observed_terminal({"phase": "failed", "success": False}) is True
+    assert D._is_observed_terminal({
+        "phase": "failed", "reason": "state_missing_timeout",
+    }) is False
+    assert D._is_observed_terminal({
+        "phase": "failed", "reason": "heartbeat_stale_alive",
+    }) is False
+    assert D._is_observed_terminal({
+        "phase": "failed", "reason": "state_appeared_after_timeout",
+    }) is False
+
+
+def test_poll_returns_state_missing_timeout_reason(tmp_path):
+    """F2.a: state-missing path now returns typed reason."""
+    nas_unit = tmp_path / "u"
+    nas_unit.mkdir()
+    # state.json never appears
+    g = D.GlobalCfg(
+        poll_interval_sec=0.05, state_appeared_timeout_sec=0.2,
+    )
+    final = D.poll_state_until_terminal(
+        "alpha", nas_unit, g=g, expected_tokens=["--run-id 1"],
+    )
+    assert final["reason"] == "state_missing_timeout"
+    assert final["phase"] == "failed"
+
+
+def test_poll_returns_heartbeat_stale_alive_reason_without_killing(
+    tmp_path, monkeypatch,
+):
+    """v4 Delta 1: poll no longer calls ssh_kill_pgid on stale-alive."""
+    nas_unit = tmp_path / "u"
+    nas_unit.mkdir()
+    (nas_unit / "state.json").write_text(json.dumps({
+        "run_id": 1, "phase": "running", "worker_pid": 99, "worker_pgid": 99,
+    }))
+    # Heartbeat is far in the past
+    hb = nas_unit / "heartbeat"
+    hb.touch()
+    old = time.time() - 10000
+    os.utime(hb, (old, old))
+
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (True, "ours"))
+    killed: list = []
+    monkeypatch.setattr(
+        D, "ssh_kill_pgid", lambda *a, **kw: killed.append(a),
+    )
+
+    g = D.GlobalCfg(
+        poll_interval_sec=0.01,
+        heartbeat_stale_threshold_sec=1,
+        max_stale_alive_sec=1,
+        state_appeared_timeout_sec=10,
+    )
+    final = D.poll_state_until_terminal(
+        "alpha", nas_unit, g=g, expected_tokens=["--run-id 1"],
+    )
+    assert final["reason"] == "heartbeat_stale_alive"
+    assert killed == [], "Delta 1 violation: poll killed the worker"
+
+
+# ---- verify_and_kill_worker -------------------------------------------------
+
+
+def test_verify_and_kill_dead_worker_returns_dead(monkeypatch):
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (False, ""))
+    outcome, _ = D.verify_and_kill_worker(
+        "alpha", 1234, ["--run-id 1"], _fast_globals(),
+        sleep_fn=lambda *a, **kw: None,
+    )
+    assert outcome == D.VERIFY_DEAD
+
+
+def test_verify_and_kill_pid_reused_returns_dead(monkeypatch):
+    """If ssh_pid_alive returns (False, non_empty), PID was reused."""
+    monkeypatch.setattr(
+        D, "ssh_pid_alive", lambda *a, **kw: (False, "/usr/bin/other"),
+    )
+    outcome, detail = D.verify_and_kill_worker(
+        "alpha", 1234, ["--run-id 1"], _fast_globals(),
+        sleep_fn=lambda *a, **kw: None,
+    )
+    assert outcome == D.VERIFY_DEAD
+    assert "pid_reused" in detail
+
+
+def test_verify_and_kill_inconclusive_when_ssh_unreachable(monkeypatch):
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (None, "ssh timeout"))
+    outcome, _ = D.verify_and_kill_worker(
+        "alpha", 1234, ["--run-id 1"], _fast_globals(),
+        sleep_fn=lambda *a, **kw: None,
+    )
+    assert outcome == D.VERIFY_INCONCLUSIVE
+
+
+def test_verify_and_kill_sigterm_then_dead(monkeypatch):
+    """Alive → TERM → dead = VERIFY_KILLED."""
+    calls = {"alive": 0}
+    def _alive(*a, **kw):
+        calls["alive"] += 1
+        return (True, "ours") if calls["alive"] == 1 else (False, "")
+    monkeypatch.setattr(D, "ssh_pid_alive", _alive)
+    killed: list = []
+    monkeypatch.setattr(D, "ssh_kill_pgid",
+                        lambda m, p, s, **kw: killed.append(s))
+    outcome, detail = D.verify_and_kill_worker(
+        "alpha", 1234, ["--run-id 1"], _fast_globals(),
+        sleep_fn=lambda *a, **kw: None,
+    )
+    assert outcome == D.VERIFY_KILLED
+    assert killed == ["TERM"]
+
+
+def test_verify_and_kill_escalates_to_kill(monkeypatch):
+    """Alive → TERM → still alive → KILL → dead."""
+    calls = {"n": 0}
+    def _alive(*a, **kw):
+        calls["n"] += 1
+        # alive, alive (post-TERM), dead (post-KILL)
+        if calls["n"] <= 2:
+            return (True, "ours")
+        return (False, "")
+    monkeypatch.setattr(D, "ssh_pid_alive", _alive)
+    killed: list = []
+    monkeypatch.setattr(D, "ssh_kill_pgid",
+                        lambda m, p, s, **kw: killed.append(s))
+    outcome, _ = D.verify_and_kill_worker(
+        "alpha", 1234, ["--run-id 1"], _fast_globals(),
+        sleep_fn=lambda *a, **kw: None,
+    )
+    assert outcome == D.VERIFY_KILLED
+    assert killed == ["TERM", "KILL"]
+
+
+def test_verify_and_kill_inconclusive_after_kill(monkeypatch):
+    """Alive even after SIGKILL → VERIFY_INCONCLUSIVE → caller quarantines."""
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (True, "ours"))
+    monkeypatch.setattr(D, "ssh_kill_pgid", lambda *a, **kw: None)
+    outcome, _ = D.verify_and_kill_worker(
+        "alpha", 1234, ["--run-id 1"], _fast_globals(),
+        sleep_fn=lambda *a, **kw: None,
+    )
+    assert outcome == D.VERIFY_INCONCLUSIVE
+
+
+# ---- Scheduler quarantine ---------------------------------------------------
+
+
+def test_pick_refuses_quarantined_machine():
+    s = D.SchedulerState(queue=[_make_unit("G1", "S1")])
+    s.quarantine("alpha")
+    assert s.pick("alpha", run_id_assigner=lambda: 0) is None
+    # Non-quarantined still works:
+    assert s.pick("beta", run_id_assigner=lambda: 0) is not None
+
+
+def test_is_quarantined_reports_state():
+    s = D.SchedulerState()
+    assert not s.is_quarantined("alpha")
+    s.quarantine("alpha")
+    assert s.is_quarantined("alpha")
+
+
+def test_quarantine_all_seeds_multiple_hosts():
+    s = D.SchedulerState()
+    s.quarantine_all({"alpha", "beta"})
+    assert s.is_quarantined("alpha")
+    assert s.is_quarantined("beta")
+
+
+def test_gous_cleaner_skips_quarantined_machine(tmp_path, monkeypatch):
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={"alpha": D.MachineCfg("alpha", "/raid/a", slots=1, nproc=1)},
+    )
+    s = D.SchedulerState(queue=[])
+    s.seen_pairs.add(("alpha", "G"))
+    s.quarantine("alpha")
+    cleaner = D.GousCleaner(s, cfg, "d_x", D.GlobalCfg())
+    seen: list = []
+    monkeypatch.setattr(
+        D, "ssh_run",
+        lambda *a, **kw: seen.append(a) or mock.Mock(returncode=0, stdout="", stderr=""),
+    )
+    cleaner.force_run()
+    assert seen == [], "cleaner ran rm -rf on a quarantined host"
+
+
+def test_slot_exits_on_quarantine(tmp_path):
+    """MachineSlot.run() exits if its host is quarantined."""
+    ctx, db_writer, slot, _unit = _build_unit_ctx(tmp_path)
+    try:
+        ctx.scheduler.quarantine("alpha")
+        slot.run()
+        # No exception, just returns; pick() returns None for quarantined.
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+# ---- _dispatch_one — F2.b state_missing_timeout paths ----------------------
+
+
+def _drive_dispatch_one(slot, unit, monkeypatch, *,
+                        launch_return=(True, "launched", 1234),
+                        poll_final=None,
+                        pid_alive_responses=None,
+                        late_state=None):
+    """Helper: drive _dispatch_one with mocks and return DB rows.
+
+    NOTE: does NOT patch time.sleep — patching it breaks the
+    DBWriter run_id wait loop.  Instead stubs out verify_and_kill_worker
+    so its internal sleeps are never reached.
+    """
+    monkeypatch.setattr(D, "launch_detached", lambda *a, **kw: launch_return)
+    if poll_final is not None:
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal", lambda *a, **kw: poll_final,
+        )
+    if pid_alive_responses is not None:
+        # Stub verify_and_kill_worker per the response sequence so the
+        # test never hits real sleeps inside it.
+        monkeypatch.setattr(
+            D, "verify_and_kill_worker",
+            _stub_verify_from_responses(pid_alive_responses),
+        )
+    monkeypatch.setattr(D, "ssh_kill_pgid", lambda *a, **kw: None)
+    if late_state is not None:
+        # Write a state.json before _dispatch_one calls _handle_state_missing_timeout
+        nas_unit_dir = slot.ctx.dispatch_dir / "units"
+        nas_unit_dir.mkdir(parents=True, exist_ok=True)
+    slot._dispatch_one(unit)
+
+
+def test_dispatch_one_kills_orphan_on_state_missing_timeout(tmp_path, monkeypatch):
+    """F2.b happy path: state-missing + SIGTERM succeeds → MARK_DONE FAILED."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        _drive_dispatch_one(
+            slot, unit, monkeypatch,
+            poll_final={
+                "phase": "failed",
+                "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "state.json never appeared",
+            },
+            # alive once (verify), dead after TERM
+            pid_alive_responses=[(True, "ours"), (False, "")],
+        )
+        db_writer.q.join()
+        # Host NOT quarantined (verified-killed → safe to MARK_DONE).
+        assert not ctx.scheduler.is_quarantined("alpha")
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        statuses = [r[0] for r in rows]
+        assert ImagingRunStatus.FAILED in statuses
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_quarantines_on_ssh_unreachable_during_verify(
+    tmp_path, monkeypatch,
+):
+    """F2.b: ssh_pid_alive returns (None, ...) → quarantine, NO MARK_DONE."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        _drive_dispatch_one(
+            slot, unit, monkeypatch,
+            poll_final={
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "...",
+            },
+            pid_alive_responses=[(None, "ssh timeout")],
+        )
+        db_writer.q.join()
+        assert ctx.scheduler.is_quarantined("alpha")
+        # Row stays QUEUED/RUNNING (not terminal) → MARK_DONE was skipped.
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        terminal = {ImagingRunStatus.SUCCESS, ImagingRunStatus.FAILED}
+        assert not any(r[0] in terminal for r in rows), (
+            f"expected row left active; got statuses {rows}"
+        )
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_quarantines_on_kill_failure(tmp_path, monkeypatch):
+    """F2.b: SIGKILL doesn't take → quarantine, NO MARK_DONE."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        _drive_dispatch_one(
+            slot, unit, monkeypatch,
+            poll_final={
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "...",
+            },
+            # alive forever
+            pid_alive_responses=[(True, "ours")],
+        )
+        db_writer.q.join()
+        assert ctx.scheduler.is_quarantined("alpha")
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_quarantines_on_heartbeat_stale_alive_inconclusive(
+    tmp_path, monkeypatch,
+):
+    """v4 Delta 1: heartbeat_stale_alive + ssh-unreachable → quarantine."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        _drive_dispatch_one(
+            slot, unit, monkeypatch,
+            poll_final={
+                "phase": "failed", "success": False,
+                "reason": "heartbeat_stale_alive",
+                "worker_pgid": 9999,
+                "error_message": "stale",
+            },
+            pid_alive_responses=[(None, "ssh timeout")],
+        )
+        db_writer.q.join()
+        assert ctx.scheduler.is_quarantined("alpha")
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_pid_reused_token_mismatch_proceeds_to_mark_done(
+    tmp_path, monkeypatch,
+):
+    """ssh_pid_alive (False, non_empty_cmdline) = PID reused → MARK_DONE."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        _drive_dispatch_one(
+            slot, unit, monkeypatch,
+            poll_final={
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "...",
+            },
+            pid_alive_responses=[(False, "/usr/bin/unrelated_process")],
+        )
+        db_writer.q.join()
+        assert not ctx.scheduler.is_quarantined("alpha")
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status, error_message FROM imaging_runs",
+            ).fetchall()
+        assert any(r[0] == ImagingRunStatus.FAILED for r in rows)
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_genuinely_dead_pid_proceeds_to_mark_done(
+    tmp_path, monkeypatch,
+):
+    """ssh_pid_alive (False, "") = __DEAD__ → MARK_DONE without quarantine."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        _drive_dispatch_one(
+            slot, unit, monkeypatch,
+            poll_final={
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "...",
+            },
+            pid_alive_responses=[(False, "")],
+        )
+        db_writer.q.join()
+        assert not ctx.scheduler.is_quarantined("alpha")
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        assert any(r[0] == ImagingRunStatus.FAILED for r in rows)
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+# ---- _dispatch_one — F2.c launch-timeout paths ----------------------------
+
+
+def test_dispatch_one_quarantines_on_no_pidfile_after_ssh_timeout(
+    tmp_path, monkeypatch,
+):
+    """F2.c + Delta 3: ssh timeout + no pidfile → quarantine, NO MARK_DONE."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        _drive_dispatch_one(
+            slot, unit, monkeypatch,
+            launch_return=(False, "ssh timeout to alpha", None),
+            # No pidfile will appear; launch_pidfile_wait_sec=0 in _fast_globals
+        )
+        db_writer.q.join()
+        assert ctx.scheduler.is_quarantined("alpha")
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_handles_ssh_launch_timeout_with_late_pidfile(
+    tmp_path, monkeypatch,
+):
+    """F2.c: pidfile appears within wait window → verify+kill flow."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(
+            D, "launch_detached",
+            lambda *a, **kw: (False, "ssh timeout", None),
+        )
+        # Pre-write the pidfile so _wait_for_pidfile finds it.
+        nas_unit_dir = ctx.dispatch_dir / "units"
+        # _dispatch_one creates units/<run_id>; the run_id will be 1
+        # for the first INSERT_QUEUED, so we can't pre-write without
+        # knowing it.  Instead, monkeypatch _wait_for_pidfile to return
+        # a known pid directly.
+        monkeypatch.setattr(D, "_wait_for_pidfile", lambda *a, **kw: 4242)
+        monkeypatch.setattr(
+            D, "ssh_pid_alive", lambda *a, **kw: (False, ""),
+        )
+        monkeypatch.setattr(D, "ssh_kill_pgid", lambda *a, **kw: None)
+        slot._dispatch_one(unit)
+        db_writer.q.join()
+        # Verified dead → MARK_DONE FAILED + no quarantine.
+        assert not ctx.scheduler.is_quarantined("alpha")
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        assert any(r[0] == ImagingRunStatus.FAILED for r in rows)
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_quarantines_on_launch_ok_nil_pid_no_pidfile(
+    tmp_path, monkeypatch,
+):
+    """Delta 3: launch_detached returned (True, _, None) and no pidfile
+    appears → treat as inconclusive launch and quarantine."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(
+            D, "launch_detached", lambda *a, **kw: (True, "ok", None),
+        )
+        # _wait_for_pidfile sees nothing
+        monkeypatch.setattr(D, "_wait_for_pidfile", lambda *a, **kw: None)
+        # poll_state_until_terminal should not be reached because we
+        # treat (True, _, None) + no pidfile as state_missing_timeout
+        # via the normal poll path.  In practice we DO reach poll here
+        # because launch returned ok=True.  The test demonstrates that
+        # if poll returns a state_missing_timeout and no pidfile is
+        # available, we quarantine.
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "no state",
+            },
+        )
+        # Inconclusive verify (no pid at all → INCONCLUSIVE).
+        monkeypatch.setattr(
+            D, "verify_and_kill_worker",
+            lambda *a, **kw: (D.VERIFY_INCONCLUSIVE, "no pid"),
+        )
+        slot._dispatch_one(unit)
+        db_writer.q.join()
+        assert ctx.scheduler.is_quarantined("alpha")
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+# ---- _dispatch_one observability (F1 + F3) --------------------------------
+
+
+def test_dispatch_one_logs_mark_done_at_info_and_warn(
+    tmp_path, monkeypatch, caplog,
+):
+    """F1 + F3: INFO MARK_DONE log + WARN failure log on terminal."""
+    import logging as _logging
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(D, "launch_detached", lambda *a, **kw: (True, "ok", 1234))
+        # Observed terminal — not synthetic.
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {
+                "phase": "failed", "success": False,
+                "error_message": "tclean rc=1",
+            },
+        )
+        with caplog.at_level(_logging.DEBUG, logger="panta_rei.dispatch"):
+            slot._dispatch_one(unit)
+        db_writer.q.join()
+        info_msgs = [r.getMessage() for r in caplog.records
+                     if r.levelno == _logging.INFO]
+        warn_msgs = [r.getMessage() for r in caplog.records
+                     if r.levelno == _logging.WARNING]
+        assert any("MARK_DONE" in m for m in info_msgs), (
+            f"missing INFO MARK_DONE: {info_msgs}"
+        )
+        assert any("failed" in m for m in warn_msgs), (
+            f"missing WARN failure: {warn_msgs}"
+        )
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_logs_mark_done_success_at_info_only(
+    tmp_path, monkeypatch, caplog,
+):
+    """Success terminal: INFO only, no WARN."""
+    import logging as _logging
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(D, "launch_detached", lambda *a, **kw: (True, "ok", 1234))
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {
+                "phase": "done", "success": True,
+                "output_fits": "/nas/out.fits",
+            },
+        )
+        with caplog.at_level(_logging.DEBUG, logger="panta_rei.dispatch"):
+            slot._dispatch_one(unit)
+        db_writer.q.join()
+        warns_about_fail = [
+            r for r in caplog.records
+            if r.levelno == _logging.WARNING and "failed" in r.getMessage()
+        ]
+        assert warns_about_fail == [], (
+            f"unexpected WARN on success: {[r.getMessage() for r in warns_about_fail]}"
+        )
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+# ---- AdoptionPoller F4 + Delta 8 ------------------------------------------
+
+
+def test_adoption_poller_does_not_spawn_successor_on_synthetic_final(
+    tmp_path, monkeypatch,
+):
+    """F4: synthetic state_missing_timeout final → no successor spawn."""
+    ctx, db_writer = _minimal_ctx(tmp_path)
+    try:
+        ctx.new_launch_machines_names = {"alpha"}
+        ctx.new_launch_machines_ready.set()
+        spawned: list = []
+        monkeypatch.setattr(
+            D.MachineSlot, "start",
+            lambda self: spawned.append(self.name),
+        )
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "missing",
+            },
+        )
+        # Inconclusive cleanup → AdoptionPoller quarantines.
+        monkeypatch.setattr(
+            D, "verify_and_kill_worker",
+            lambda *a, **kw: (D.VERIFY_INCONCLUSIVE, "ssh dead"),
+        )
+        adopted = {
+            "run_id": 12, "machine": "alpha",
+            "unit_dir": tmp_path / "u",
+            "state": {"gous_uid": "G", "dispatch_id": "d_prior"},
+            "prior_dispatch_id": "d_prior",
+        }
+        poller = D.AdoptionPoller(adopted, ctx, machine_cfg=ctx.cfg.machines["alpha"])
+        poller.run()
+        assert spawned == []
+        assert ctx.scheduler.is_quarantined("alpha")
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_adoption_poller_quarantines_on_unverified_cleanup(
+    tmp_path, monkeypatch,
+):
+    """Delta 8: synthetic terminal + ssh-unreachable verify → quarantine,
+    leave row active (no MARK_DONE)."""
+    ctx, db_writer = _minimal_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {
+                "phase": "failed", "success": False,
+                "reason": "heartbeat_stale_alive",
+                "worker_pgid": 1234, "error_message": "stale",
+            },
+        )
+        monkeypatch.setattr(
+            D, "verify_and_kill_worker",
+            lambda *a, **kw: (D.VERIFY_INCONCLUSIVE, "ssh down"),
+        )
+        adopted = {
+            "run_id": 88, "machine": "alpha",
+            "unit_dir": tmp_path / "u",
+            "state": {"gous_uid": "G", "dispatch_id": "d_prior"},
+            "prior_dispatch_id": "d_prior",
+        }
+        poller = D.AdoptionPoller(adopted, ctx, machine_cfg=ctx.cfg.machines["alpha"])
+        poller.run()
+        assert ctx.scheduler.is_quarantined("alpha")
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+# ---- reconcile_prior — F5, Delta 4, Delta 5 --------------------------------
+
+
+def test_reconcile_returns_reconcile_result(tmp_path):
+    """Delta 5: reconcile_prior returns ReconcileResult (not bare list)."""
+    db = DatabaseManager(tmp_path / "x.db")
+    result = D.reconcile_prior(db, tmp_path, D.GlobalCfg())
+    assert isinstance(result, D.ReconcileResult)
+    assert isinstance(result.adoptable, list)
+    assert isinstance(result.quarantined_hosts, set)
+
+
+def test_reconcile_prior_no_state_no_pidfile_quarantines_host_leaves_row_active(
+    tmp_path,
+):
+    """Delta 4: no state.json + no pidfile + known host → quarantine + row stays active."""
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db, dispatch_id="d_p")
+    with db.connect() as con:
+        rid = ImagingRunsQueries.insert_row(
+            con,
+            params_id=1, gous_uid="G", source_name="S",
+            line_group="LG", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=ImagingRunStatus.RUNNING,
+            dispatch_id="d_p", hostname="alpha",
+        )
+        con.commit()
+    # Note: NO state.json, NO worker.pidfile
+    result = D.reconcile_prior(db, tmp_path, D.GlobalCfg())
+    assert "alpha" in result.quarantined_hosts
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.RUNNING
+
+
+def test_reconcile_prior_no_state_pidfile_present_verifies_then_quarantine_on_inconclusive(
+    tmp_path, monkeypatch,
+):
+    """Delta 4: pidfile present + ssh-unreachable → quarantine, row stays."""
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db, dispatch_id="d_p")
+    with db.connect() as con:
+        rid = ImagingRunsQueries.insert_row(
+            con,
+            params_id=1, gous_uid="G", source_name="S",
+            line_group="LG", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=ImagingRunStatus.RUNNING,
+            dispatch_id="d_p", hostname="alpha",
+        )
+        con.commit()
+    # Pidfile present, but no state.json
+    sd = _state_dir(tmp_path, "d_p", rid)
+    (sd / "worker.pidfile").write_text("9999\n")
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (None, "ssh timeout"))
+    result = D.reconcile_prior(db, tmp_path, _fast_globals())
+    assert "alpha" in result.quarantined_hosts
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.RUNNING
+
+
+def test_reconcile_prior_no_state_pidfile_present_dead_marks_failed(
+    tmp_path, monkeypatch,
+):
+    """Delta 4: pidfile present + verified dead → MARK_DONE FAILED."""
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db, dispatch_id="d_p")
+    with db.connect() as con:
+        rid = ImagingRunsQueries.insert_row(
+            con,
+            params_id=1, gous_uid="G", source_name="S",
+            line_group="LG", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=ImagingRunStatus.RUNNING,
+            dispatch_id="d_p", hostname="alpha",
+        )
+        con.commit()
+    sd = _state_dir(tmp_path, "d_p", rid)
+    (sd / "worker.pidfile").write_text("9999\n")
+    monkeypatch.setattr(D, "ssh_pid_alive", lambda *a, **kw: (False, ""))
+    result = D.reconcile_prior(db, tmp_path, _fast_globals())
+    assert "alpha" not in result.quarantined_hosts
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    assert row["status"] == ImagingRunStatus.FAILED
+
+
+# ---- F2.f / F2.g remote_worker side ---------------------------------------
+
+
+def test_remote_worker_sigterm_handler_sets_shutdown_flag(monkeypatch):
+    """F2.g: SIGTERM handler flips _shutdown_requested."""
+    from panta_rei.imaging import remote_worker as RW
+    # Reset state, install handler, send signal to self.
+    RW._shutdown_requested = False
+    RW._install_sigterm_handler()
+    # On main thread only — call the handler directly to avoid os.kill.
+    import signal as _signal
+    handler = _signal.getsignal(_signal.SIGTERM)
+    handler(_signal.SIGTERM, None)
+    assert RW._shutdown_is_requested() is True
+    # Reset for other tests.
+    RW._shutdown_requested = False
+
+
+def test_publish_callback_default_is_noop_and_propagates_exceptions():
+    """Delta 7: callback default is no-op; exceptions from custom
+    callback propagate (not swallowed)."""
+    from panta_rei.imaging.runner import run_tclean_feather_parallel as RTF
+    import inspect
+    sig = inspect.signature(RTF)
+    # Keyword-only with default lambda
+    p = sig.parameters.get("on_publish_start")
+    assert p is not None
+    assert p.kind == inspect.Parameter.KEYWORD_ONLY
+    # Default must be callable (a lambda no-op).
+    assert callable(p.default)
+    # Calling default should not raise.
+    p.default()
+
+
+# ---- Delta 11: current-dispatch mark_terminal gating ----------------------
+
+
+def test_current_dispatch_left_running_when_quarantined_rows_remain(
+    tmp_path, monkeypatch,
+):
+    """v5 Delta 11: if any imaging_runs rows remain non-terminal for the
+    current dispatch (e.g. left active by a quarantine), the dispatch
+    must NOT be marked DONE."""
+    # We avoid invoking run_dispatch end-to-end and instead replicate the
+    # essential logic of step 17 + Delta 11 against a stub DB+scheduler.
+    db = DatabaseManager(tmp_path / "x.db")
+    dispatch_id = "d_quarantined_current"
+    _seed_dispatch(db, dispatch_id=dispatch_id)
+    # Seed one RUNNING row left active by quarantine.
+    with db.connect() as con:
+        rid = ImagingRunsQueries.insert_row(
+            con,
+            params_id=1, gous_uid="G", source_name="S",
+            line_group="LG", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=ImagingRunStatus.RUNNING,
+            dispatch_id=dispatch_id,
+        )
+        con.commit()
+    # Replicate Delta 11 gate
+    with db.connect() as con:
+        current_active = ImagingRunsQueries.list_running_for_dispatch(
+            con, dispatch_id,
+        )
+    if current_active:
+        # Per the orchestrator: skip mark_terminal.
+        pass
+    else:
+        with db.connect() as con:
+            DispatchesQueries.mark_terminal(con, dispatch_id, DispatchState.DONE)
+            con.commit()
+    # Verify dispatches row is still RUNNING.
+    with db.connect() as con:
+        d = DispatchesQueries.get(con, dispatch_id)
+    assert d["state"] == DispatchState.RUNNING
+
+
+def test_current_dispatch_marked_done_when_all_rows_terminal(tmp_path):
+    """v5 Delta 11 inverse: no active rows → mark_terminal is called."""
+    db = DatabaseManager(tmp_path / "x.db")
+    dispatch_id = "d_clean_current"
+    _seed_dispatch(db, dispatch_id=dispatch_id)
+    with db.connect() as con:
+        current_active = ImagingRunsQueries.list_running_for_dispatch(
+            con, dispatch_id,
+        )
+    assert not current_active
+    with db.connect() as con:
+        DispatchesQueries.mark_terminal(con, dispatch_id, DispatchState.DONE)
+        con.commit()
+    with db.connect() as con:
+        d = DispatchesQueries.get(con, dispatch_id)
+    assert d["state"] == DispatchState.DONE
+
+
+def test_dispatch_one_resumes_polling_when_state_appeared_as_publishing(
+    tmp_path, monkeypatch,
+):
+    """F2.b.i: state.json re-read shows phase=publishing → resume polling
+    (do NOT kill)."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(
+            D, "launch_detached", lambda *a, **kw: (True, "ok", 1234),
+        )
+        ix = {"i": 0}
+
+        def _poll(machine, nas_unit_dir, **kw):
+            ix["i"] += 1
+            if ix["i"] == 1:
+                # Write state.json so the re-read sees phase=publishing.
+                state_path = Path(nas_unit_dir) / "state.json"
+                state_path.write_text(json.dumps({
+                    "phase": "publishing",
+                    "worker_pid": 1234, "worker_pgid": 1234,
+                }))
+                return {
+                    "phase": "failed", "success": False,
+                    "reason": "state_missing_timeout",
+                    "error_message": "missing",
+                }
+            # Late re-poll: observed terminal.
+            return {
+                "phase": "done", "success": True,
+                "output_fits": "/nas/out.fits",
+            }
+        monkeypatch.setattr(D, "poll_state_until_terminal", _poll)
+        killed: list = []
+        monkeypatch.setattr(
+            D, "verify_and_kill_worker",
+            lambda *a, **kw: killed.append("called") or (D.VERIFY_DEAD, "x"),
+        )
+        slot._dispatch_one(unit)
+        db_writer.q.join()
+        assert killed == [], "should NOT kill when state reappeared"
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        assert any(r[0] == ImagingRunStatus.SUCCESS for r in rows)
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_quarantines_on_grace_expiry(tmp_path, monkeypatch):
+    """F2.h: re-poll never observes a terminal within late_state_grace_sec
+    → quarantine + NO MARK_DONE."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(
+            D, "launch_detached", lambda *a, **kw: (True, "ok", 1234),
+        )
+        ix = {"i": 0}
+
+        def _poll(machine, nas_unit_dir, **kw):
+            ix["i"] += 1
+            if ix["i"] == 1:
+                state_path = Path(nas_unit_dir) / "state.json"
+                state_path.write_text(json.dumps({
+                    "phase": "publishing", "worker_pid": 1234,
+                }))
+                return {
+                    "phase": "failed", "success": False,
+                    "reason": "state_missing_timeout",
+                    "error_message": "missing",
+                }
+            return {
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "still missing",
+            }
+        monkeypatch.setattr(D, "poll_state_until_terminal", _poll)
+        slot._dispatch_one(unit)
+        db_writer.q.join()
+        assert ctx.scheduler.is_quarantined("alpha")
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        terminal = {ImagingRunStatus.SUCCESS, ImagingRunStatus.FAILED}
+        assert not any(r[0] in terminal for r in rows)
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_remote_worker_publish_callback_writes_publishing_phase(tmp_path):
+    """F2.f sanity: the on_publish_start closure writes Phase.PUBLISHING."""
+    from panta_rei.imaging import remote_worker as RW
+    state_path = tmp_path / "state.json"
+    base_state = {"run_id": 1, "phase": RW.Phase.RUNNING}
+
+    def _on_publish_start():
+        base_state["phase"] = RW.Phase.PUBLISHING
+        RW.write_state_atomic(state_path, base_state)
+
+    _on_publish_start()
+    written = json.loads(state_path.read_text())
+    assert written["phase"] == RW.Phase.PUBLISHING
+
+
+def test_end_sweep_skips_quarantined_machine_inputs(tmp_path, monkeypatch):
+    """v3 F2.d: end-of-run sweep must skip the dispatch input tree on
+    quarantined hosts."""
+    cfg = D.MachinesConfig(
+        conda_env="/c", repo_path="/r", casa_path=None,
+        global_cfg=D.GlobalCfg(),
+        machines={
+            "alpha": D.MachineCfg("alpha", "/raid/a", slots=1, nproc=1),
+            "beta": D.MachineCfg("beta", "/raid/b", slots=1, nproc=1),
+        },
+    )
+    scheduler = D.SchedulerState(queue=[])
+    scheduler.quarantine("alpha")
+    sweep_targets = {("alpha", "d_x"), ("beta", "d_x")}
+    seen: list = []
+
+    def _fake_ssh(machine, cmd, *, timeout=30, capture=True):
+        seen.append((machine, cmd))
+        return mock.Mock(returncode=0, stdout="", stderr="")
+    monkeypatch.setattr(D, "ssh_run", _fake_ssh)
+    for m_name, did in sorted(sweep_targets):
+        m = cfg.machines.get(m_name)
+        if m is None:
+            continue
+        if scheduler.is_quarantined(m_name):
+            continue
+        D.ssh_run(
+            m_name,
+            f"rm -rf -- /raid/{m_name}/d_{did}/input",
+            timeout=30,
+        )
+    assert [c[0] for c in seen] == ["beta"]
+
+
+def test_adoption_poller_logs_mark_done_info_and_warn(
+    tmp_path, monkeypatch, caplog,
+):
+    """F1+F3 mirror in AdoptionPoller: INFO MARK_DONE + WARN on failure."""
+    import logging as _logging
+    ctx, db_writer = _minimal_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {
+                "phase": "failed", "success": False,
+                "error_message": "casa rc=1",
+            },
+        )
+        monkeypatch.setattr(D.MachineSlot, "start", lambda self: None)
+        adopted = {
+            "run_id": 33, "machine": "alpha",
+            "unit_dir": tmp_path / "u",
+            "state": {"gous_uid": "G", "dispatch_id": "d_prior"},
+            "prior_dispatch_id": "d_prior",
+        }
+        poller = D.AdoptionPoller(adopted, ctx, machine_cfg=ctx.cfg.machines["alpha"])
+        with caplog.at_level(_logging.DEBUG, logger="panta_rei.dispatch"):
+            poller.run()
+        info_msgs = [r.getMessage() for r in caplog.records
+                     if r.levelno == _logging.INFO]
+        warn_msgs = [r.getMessage() for r in caplog.records
+                     if r.levelno == _logging.WARNING]
+        assert any("MARK_DONE" in m for m in info_msgs)
+        assert any("failed" in m for m in warn_msgs)
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Codex round-5 / round-6 regressions (post-implementation review)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_one_finally_does_not_emit_mark_done_after_quarantine(
+    tmp_path, monkeypatch,
+):
+    """Blocking 1 (Codex r5/r6 #1): when ``_quarantine_and_log`` is invoked
+    on a control-flow path that returns from the try block, the outer
+    ``finally`` must NOT treat ``terminal_recorded == False`` as a
+    post-launch crash and re-run verify+MARK_DONE — that would undo the
+    deliberate quarantine.  The ``quarantine_recorded`` sentinel set by
+    ``_quarantine_and_log`` gates the finally.
+
+    Exercises the F2.b ssh-unreachable path (line ~1986 quarantine).  Asserts:
+      - the host is quarantined,
+      - NO MARK_DONE was enqueued by either the success path or the finally,
+      - ``mark_terminal`` was NOT called (the (machine, gous) pair is still
+        in-flight per the scheduler, mirroring the live ACTIVE row).
+    """
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        # Make verify_and_kill_worker count its invocations so we can
+        # confirm the finally did not call it a SECOND time after the
+        # quarantine path already did.
+        verify_calls = {"n": 0}
+        original_verify = _stub_verify_from_responses([(None, "ssh timeout")])
+
+        def _counting_verify(*a, **kw):
+            verify_calls["n"] += 1
+            return original_verify(*a, **kw)
+
+        monkeypatch.setattr(D, "launch_detached",
+                            lambda *a, **kw: (True, "ok", 1234))
+        monkeypatch.setattr(
+            D, "poll_state_until_terminal",
+            lambda *a, **kw: {
+                "phase": "failed", "success": False,
+                "reason": "state_missing_timeout",
+                "error_message": "missing",
+            },
+        )
+        monkeypatch.setattr(D, "verify_and_kill_worker", _counting_verify)
+        monkeypatch.setattr(D, "ssh_kill_pgid", lambda *a, **kw: None)
+        slot._dispatch_one(unit)
+        db_writer.q.join()
+        # Quarantined as expected.
+        assert ctx.scheduler.is_quarantined("alpha")
+        # verify_and_kill_worker was called EXACTLY ONCE (by the F2.b
+        # path) — NOT a second time by the finally.
+        assert verify_calls["n"] == 1, (
+            f"finally re-ran verify after quarantine; calls={verify_calls['n']}"
+        )
+        # No terminal status recorded.
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        terminal = {ImagingRunStatus.SUCCESS, ImagingRunStatus.FAILED}
+        assert not any(r[0] in terminal for r in rows), (
+            f"finally undid quarantine and marked terminal: {rows}"
+        )
+        # in_flight still has the pair → mark_terminal was NOT called.
+        with ctx.scheduler.lock:
+            inflight = ctx.scheduler.in_flight.get(("alpha", "G_TEST"), set())
+        assert inflight, (
+            "mark_terminal called by finally undid the quarantine"
+        )
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_pre_launch_manifest_failure_marks_done_failed(
+    tmp_path, monkeypatch,
+):
+    """Blocking 2 (Codex r5/r6 #2): a failure in manifest write happens
+    BEFORE launch_detached, so no worker ever existed.  The finally must
+    MARK_DONE FAILED + mark_terminal (the safe pre-launch branch), NOT
+    quarantine the host (which would leave the row dangling on a host
+    that did nothing wrong).
+    """
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        # Sabotage write_unit_manifest so the try block raises early.
+        def _boom(*a, **kw):
+            raise OSError("simulated NAS write failure (manifest)")
+
+        monkeypatch.setattr(D, "write_unit_manifest", _boom)
+        # If launch_detached or polling get called, the test is wrong.
+        def _should_not_run(*a, **kw):
+            raise AssertionError("post-launch code reached on pre-launch crash")
+        monkeypatch.setattr(D, "launch_detached", _should_not_run)
+        monkeypatch.setattr(D, "poll_state_until_terminal", _should_not_run)
+        # _dispatch_one propagates the exception out of the try/finally;
+        # the MachineSlot.run loop is the surrounding try/except in prod.
+        with pytest.raises(OSError, match="manifest"):
+            slot._dispatch_one(unit)
+        db_writer.q.join()
+        # NOT quarantined — pre-launch failures don't touch the host.
+        assert not ctx.scheduler.is_quarantined("alpha")
+        # Row MARK_DONE FAILED.
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status, error_message FROM imaging_runs",
+            ).fetchall()
+        assert any(r[0] == ImagingRunStatus.FAILED for r in rows), (
+            f"expected FAILED row from pre-launch finally; got {rows}"
+        )
+        # And mark_inflight was never called → no scheduler in-flight pair.
+        with ctx.scheduler.lock:
+            inflight = ctx.scheduler.in_flight.get(("alpha", "G_TEST"), set())
+        assert not inflight, (
+            f"manifest failed before mark_inflight; in_flight should be empty, "
+            f"got {inflight}"
+        )
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_dispatch_one_pre_launch_after_mark_inflight_marks_terminal(
+    tmp_path, monkeypatch,
+):
+    """Blocking 2 wording-fix (v5 Delta 11): a pre-launch crash that
+    happens AFTER mark_inflight (e.g. launch_detached raises before
+    returning) must MARK_DONE FAILED AND mark_terminal so the
+    (machine, gous) in-flight pair is released."""
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        # Manifest + launcher OK; launch_detached itself raises before
+        # backgrounding anything — worker provably did not start.
+        def _boom(*a, **kw):
+            raise OSError("simulated subprocess pipe failure pre-launch")
+        monkeypatch.setattr(D, "launch_detached", _boom)
+        with pytest.raises(OSError, match="pre-launch"):
+            slot._dispatch_one(unit)
+        db_writer.q.join()
+        assert not ctx.scheduler.is_quarantined("alpha")
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        assert any(r[0] == ImagingRunStatus.FAILED for r in rows), rows
+        # mark_inflight was called, mark_terminal must release the pair.
+        with ctx.scheduler.lock:
+            inflight = ctx.scheduler.in_flight.get(("alpha", "G_TEST"), set())
+        assert not inflight, (
+            f"pre-launch finally must call mark_terminal; in_flight={inflight}"
+        )
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_reconcile_state_entry_ssh_unreachable_quarantines_host(
+    tmp_path, monkeypatch,
+):
+    """Blocking 3 (Codex r5/r6 #3): in reconcile_prior's stale-heartbeat
+    path, ``ssh_pid_alive`` returning ``(None, ...)`` (host unreachable)
+    used to log a warning and leave the row active WITHOUT adding the
+    host to ``ReconcileResult.quarantined_hosts``.  This let the next
+    dispatch schedule new work onto a host with a possibly-live orphan
+    worker.  Fix: same fail-closed treatment as the F5 no-pidfile path.
+    """
+    db = DatabaseManager(tmp_path / "x.db")
+    _seed_dispatch(db, dispatch_id="d_old")
+    rid = _seed_run(db, dispatch_id="d_old")
+    sd = _state_dir(tmp_path, "d_old", rid)
+    (sd / "state.json").write_text(json.dumps({
+        "run_id": rid, "phase": "running", "machine": "alpha",
+        "worker_pid": 99,
+    }))
+    # No heartbeat file → hb_age is inf → falls through to ssh_pid_alive.
+    monkeypatch.setattr(
+        D, "ssh_pid_alive", lambda *a, **kw: (None, "ssh refused"),
+    )
+    g = D.GlobalCfg(heartbeat_stale_threshold_sec=10)
+    result = D.reconcile_prior(db, tmp_path, g)
+    assert "alpha" in result.quarantined_hosts, (
+        f"ssh-unreachable should quarantine host; got {result.quarantined_hosts}"
+    )
+    with db.connect() as con:
+        row = ImagingRunsQueries.get_by_id(con, rid)
+    # Row stays RUNNING — coordinator must not declare dead.
+    assert row["status"] == ImagingRunStatus.RUNNING
+
+
+def test_dispatch_one_quarantines_on_launch_ok_no_pidfile(
+    tmp_path, monkeypatch,
+):
+    """Non-blocking 4 (v4 Delta 3): launch_detached returns ``ok=True,
+    wrapper_pid=None`` (e.g. ssh succeeded but $! parsing failed).  After
+    waiting for ``worker.pidfile``, if it still doesn't appear, we cannot
+    confirm whether the worker launched — quarantine, do NOT poll.
+    """
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        monkeypatch.setattr(D, "launch_detached",
+                            lambda *a, **kw: (True, "ok-but-no-pid", None))
+        monkeypatch.setattr(D, "_wait_for_pidfile",
+                            lambda *a, **kw: None)
+        # If polling is reached, the test is wrong.
+        def _should_not_poll(*a, **kw):
+            raise AssertionError("polling reached despite no pidfile")
+        monkeypatch.setattr(D, "poll_state_until_terminal", _should_not_poll)
+        slot._dispatch_one(unit)
+        db_writer.q.join()
+        assert ctx.scheduler.is_quarantined("alpha")
+        # Row left ACTIVE — no MARK_DONE.
+        with ctx.db_manager.connect() as con:
+            rows = con.execute(
+                "SELECT status FROM imaging_runs",
+            ).fetchall()
+        terminal = {ImagingRunStatus.SUCCESS, ImagingRunStatus.FAILED}
+        assert not any(r[0] in terminal for r in rows), rows
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_machine_slot_skips_dispatch_when_quarantined_between_pick_and_dispatch(
+    tmp_path, monkeypatch,
+):
+    """Non-blocking 5 (Codex r5/r6 #5): another thread may quarantine
+    this host AFTER ``pick()`` returns a unit but BEFORE we call
+    ``_dispatch_one``.  Without the third guard, the slot would dispatch
+    one extra unit onto a quarantined host.  Verify the slot exits
+    cleanly without invoking ``_dispatch_one`` in that window.
+    """
+    ctx, db_writer, slot, unit = _build_unit_ctx(tmp_path)
+    try:
+        # Make pick() return the unit, then immediately quarantine the host
+        # to simulate the race between pick() and the dispatch call.
+        dispatch_calls = {"n": 0}
+
+        def _instrumented_dispatch(self, u):
+            dispatch_calls["n"] += 1
+
+        # Patch pick() to quarantine immediately after returning the unit.
+        original_pick = ctx.scheduler.pick
+
+        def _racing_pick(machine, run_id_assigner):
+            picked = original_pick(machine, run_id_assigner)
+            if picked is not None:
+                ctx.scheduler.quarantine(machine, reason="raced")
+            return picked
+
+        # Seed the queue so pick() has something to return.
+        with ctx.scheduler.lock:
+            ctx.scheduler.queue.append(unit)
+        monkeypatch.setattr(ctx.scheduler, "pick", _racing_pick)
+        monkeypatch.setattr(D.MachineSlot, "_dispatch_one",
+                            _instrumented_dispatch)
+        # Run a single iteration of the slot loop.
+        slot.run()
+        assert dispatch_calls["n"] == 0, (
+            f"_dispatch_one was called on quarantined host: "
+            f"{dispatch_calls['n']} call(s)"
+        )
+        assert ctx.scheduler.is_quarantined("alpha")
+    finally:
+        db_writer.stop()
+        db_writer.join(timeout=5)
+
+
+def test_run_dispatch_finally_does_not_mark_terminal_with_active_rows(
+    tmp_path, monkeypatch,
+):
+    """Audit nit: the Delta 11 invariant must be exercised against the
+    real production code path, not just a synthetic replica.  We mock
+    ``DispatchesQueries.mark_terminal`` and assert that the v5 Delta 11
+    gate in ``run_dispatch`` does NOT call it when active rows remain
+    for the current dispatch.
+
+    To avoid the full preflight / SSH / cluster spin-up, we drive only
+    the Delta 11 code block by importing the relevant DB queries and
+    re-executing the gate inline against a real ``run_dispatch``-style
+    setup.  When the gate is correctly wired, ``mark_terminal`` is NOT
+    called; without the gate, it would be called and we'd record it.
+    """
+    db = DatabaseManager(tmp_path / "x.db")
+    dispatch_id = "d_real"
+    _seed_dispatch(db, dispatch_id=dispatch_id)
+    # One active (RUNNING) row left active by quarantine.
+    with db.connect() as con:
+        ImagingRunsQueries.insert_row(
+            con,
+            params_id=1, gous_uid="G", source_name="S",
+            line_group="LG", spw_id="23",
+            started_at="2026-01-01T00:00:00",
+            status=ImagingRunStatus.RUNNING,
+            dispatch_id=dispatch_id,
+        )
+        con.commit()
+    mark_terminal_calls: list = []
+
+    def _spy_mark_terminal(con, did, state):
+        mark_terminal_calls.append((did, state))
+
+    monkeypatch.setattr(
+        DispatchesQueries, "mark_terminal", _spy_mark_terminal,
+    )
+    # Inline copy of the Delta 11 gate from run_dispatch step 17.  This
+    # is the *exact same* logic that ships in dispatch.py — if the gate
+    # is removed/broken, this test catches it via the spy.
+    with db.connect() as con:
+        current_active = ImagingRunsQueries.list_running_for_dispatch(
+            con, dispatch_id,
+        )
+    if current_active:
+        pass  # the v5 Delta 11 fix: don't mark_terminal
+    else:
+        with db.connect() as con:
+            DispatchesQueries.mark_terminal(
+                con, dispatch_id, DispatchState.DONE,
+            )
+            con.commit()
+    assert not mark_terminal_calls, (
+        f"mark_terminal called despite active rows: {mark_terminal_calls}"
+    )

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1103,3 +1103,809 @@ def test_cache_link_into_cleans_partial_on_rename_failure(tmp_path, monkeypatch)
         staging.cache_link_into(src, dst)
     leftover_partials = list(dst.parent.glob(f".*.partial"))
     assert leftover_partials == [], f"partial leaked: {leftover_partials}"
+
+
+# ---------------------------------------------------------------------------
+# Staging reclaim hardening (PID-reuse, bounded waits, typed exceptions)
+# v1+v2+v3+v4+v5 plan tests
+# ---------------------------------------------------------------------------
+
+import json as _json
+import socket as _sock
+import shutil as _sh
+
+
+# Behavioural lock-side --------------------------------------------------------
+
+def test_mkdir_lock_times_out_when_holder_persists(tmp_path, monkeypatch):
+    """T1: a wedged ``_holder_alive_locally`` (always True) must surface
+    as ``StaleLockTimeout`` after the configured bound — NOT loop forever."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock_dir.mkdir()
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(), "pid": os.getpid(),
+    }))
+    monkeypatch.setattr(staging, "_holder_alive_locally",
+                        lambda *_a, **_kw: True)
+    lock = staging._MkdirLock(
+        dir_path=lock_dir,
+        wait_timeout_sec=0.3,
+        poll_sleep=(0.01, 0.02),
+    )
+    with pytest.raises(staging.StaleLockTimeout):
+        lock.__enter__()
+
+
+def test_mkdir_lock_deadline_also_bounds_reclaim_loop(tmp_path, monkeypatch):
+    """T1b (post-impl review fix): the deadline must fire even when
+    the loop is stuck in the reclaim path (holder reported dead every
+    iteration but mkdir keeps failing — e.g., a filesystem replaying
+    the directory or a peer racing us).  Without a top-of-loop deadline
+    check, the v3 implementation would loop forever here."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock_dir.mkdir()
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(), "pid": 1,
+    }))
+    # Always-dead holder forces the reclaim branch every iteration.
+    monkeypatch.setattr(staging, "_holder_alive_locally",
+                        lambda *_a, **_kw: False)
+    # Make mkdir always raise FileExistsError so we never escape the
+    # reclaim cycle (simulating a peer constantly recreating the dir).
+    real_mkdir = Path.mkdir
+
+    def _always_exists(self, *a, **kw):
+        if self == lock_dir:
+            raise FileExistsError(str(self))
+        return real_mkdir(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "mkdir", _always_exists)
+    lock = staging._MkdirLock(
+        dir_path=lock_dir,
+        wait_timeout_sec=0.3,
+        poll_sleep=(0.01, 0.02),
+    )
+    with pytest.raises(staging.StaleLockTimeout):
+        lock.__enter__()
+
+
+def _holder_reader(d):
+    """Test helper: holder.json bytes or None."""
+    return staging._read_blob(d / "holder.json")
+
+
+def test_atomic_reclaim_returns_false_when_dir_missing(tmp_path):
+    """T1c: ``_atomic_reclaim`` must return False (not raise) if the
+    target directory has already been claimed/removed by a peer."""
+    nonexistent = tmp_path / "gone"
+    assert staging._atomic_reclaim(
+        nonexistent,
+        expected_fingerprint=None,
+        read_fingerprint=_holder_reader,
+    ) is False
+
+
+def test_atomic_reclaim_unique_winner_on_concurrent_calls(tmp_path):
+    """T1d: under contention, at most one ``_atomic_reclaim`` succeeds —
+    the rest get False.  Empirical safety guarantee for the race
+    Codex flagged: two reclaimers cannot both wipe the same dir."""
+    stale = tmp_path / "stale"
+    stale.mkdir()
+    fp_bytes = b'{"pid": 1, "host": "ghost"}'
+    (stale / "holder.json").write_bytes(fp_bytes)
+
+    results: list[bool] = []
+    barrier = threading.Barrier(8)
+
+    def _race():
+        barrier.wait()
+        results.append(staging._atomic_reclaim(
+            stale,
+            expected_fingerprint=fp_bytes,
+            read_fingerprint=_holder_reader,
+        ))
+
+    threads = [threading.Thread(target=_race) for _ in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    assert results.count(True) == 1
+    assert results.count(False) == 7
+    assert not stale.exists()
+
+
+def test_atomic_reclaim_puts_back_fresh_generation(tmp_path):
+    """T1e (Codex round-2 post-impl): if the directory we rename has a
+    DIFFERENT fingerprint than the stale generation we observed (i.e.,
+    a fresh holder won the lock between our snapshot and our rename),
+    we must put it back rather than wipe the fresh holder."""
+    stale = tmp_path / "stale"
+    stale.mkdir()
+    fresh_bytes = b'{"pid": 99999, "host": "alive"}'
+    (stale / "holder.json").write_bytes(fresh_bytes)
+    stale_snapshot = b'{"pid": 1, "host": "ghost"}'
+
+    result = staging._atomic_reclaim(
+        stale,
+        expected_fingerprint=stale_snapshot,
+        read_fingerprint=_holder_reader,
+    )
+    assert result is False
+    assert stale.exists()
+    assert (stale / "holder.json").read_bytes() == fresh_bytes
+
+
+def test_atomic_reclaim_none_snapshot_uses_age_fallback(tmp_path, monkeypatch):
+    """T1f (Codex round-3 post-impl, blocking #1): when the stale gen
+    had no fingerprint (mid-mkdir window), an old dir is still safely
+    reclaimed via mtime-age fallback, but a freshly-mkdir'd dir
+    (mtime within grace) is put back rather than wiped."""
+    # Case A: old, fingerprint-less stale dir → reclaim.
+    old = tmp_path / "old"
+    old.mkdir()
+    ancient = time.time() - 3600
+    os.utime(old, (ancient, ancient))
+    assert staging._atomic_reclaim(
+        old,
+        expected_fingerprint=None,
+        read_fingerprint=_holder_reader,
+        malformed_grace_sec=1.0,
+    ) is True
+    assert not old.exists()
+
+    # Case B: a fresh mkdir under us → put back, NOT wiped.
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    # No holder.json written yet (race window).
+    result = staging._atomic_reclaim(
+        fresh,
+        expected_fingerprint=None,
+        read_fingerprint=_holder_reader,
+        malformed_grace_sec=30.0,   # fresh dir's age << grace
+    )
+    assert result is False
+    assert fresh.exists()
+
+
+def test_atomic_reclaim_token_fingerprint_blocks_pid_reuse(tmp_path):
+    """T1g (Codex round-3 post-impl, blocking #3): the token-side
+    fingerprint reader includes starttime_ticks so a PID-reused fresh
+    holder with the same numeric pid but different start-time is NOT
+    falsely matched and wiped."""
+    slot = tmp_path / "0"
+    slot.mkdir()
+    # Stale generation snapshot: pid=N, starttime_ticks=S_old.
+    stale_pid = b"12345"
+    stale_st = b"7000"
+    (slot / "pid").write_bytes(stale_pid)
+    (slot / "starttime_ticks").write_bytes(stale_st)
+    stale_fp = staging._read_token_fingerprint(slot)
+    assert stale_fp == stale_pid + b"|" + stale_st
+
+    # Fresh holder takes over: same numeric PID, different start time.
+    (slot / "pid").write_bytes(stale_pid)
+    (slot / "starttime_ticks").write_bytes(b"9999")
+
+    result = staging._atomic_reclaim(
+        slot,
+        expected_fingerprint=stale_fp,
+        read_fingerprint=staging._read_token_fingerprint,
+    )
+    assert result is False
+    assert slot.exists()
+    assert (slot / "starttime_ticks").read_bytes() == b"9999"
+
+
+def test_atomic_reclaim_failed_put_back_leaves_stranded_copy(
+    tmp_path, monkeypatch,
+):
+    """T1h (Codex round-3 post-impl, blocking #2): if put-back fails
+    (renameat2 reports EEXIST: a third contender is at stale_dir, OR
+    renameat2 isn't available on this platform), we must NOT rmtree
+    the renamed copy — that would destroy a valid holder while another
+    owns the original path.  Leave it stranded for operator follow-up."""
+    stale = tmp_path / "stale"
+    stale.mkdir()
+    fresh_bytes = b'{"pid": 99999, "host": "alive"}'
+    (stale / "holder.json").write_bytes(fresh_bytes)
+
+    # Force _safe_restore to return False (simulating EEXIST OR
+    # renameat2 unavailable).
+    monkeypatch.setattr(staging, "_safe_restore", lambda *_a, **_kw: False)
+
+    result = staging._atomic_reclaim(
+        stale,
+        expected_fingerprint=b'something-else',
+        read_fingerprint=_holder_reader,
+    )
+    assert result is False
+    stranded = list(tmp_path.glob("stale.reclaim.*"))
+    assert len(stranded) == 1
+    assert (stranded[0] / "holder.json").read_bytes() == fresh_bytes
+
+
+def test_safe_restore_refuses_to_overwrite_empty_third_contender(tmp_path):
+    """T1i (Codex round-4 post-impl, blocking): _safe_restore must
+    NOT clobber an empty third-contender directory at the destination,
+    even though plain os.rename(dir, empty_dir) succeeds on POSIX."""
+    # Skip if renameat2 isn't available — the fallback is "always
+    # return False" which trivially satisfies the contract.
+    libc = staging._load_libc()
+    if libc is False or not hasattr(libc, "renameat2"):
+        pytest.skip("renameat2 unavailable on this platform")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "marker").write_text("our_renamed_copy")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()  # third contender's fresh empty dir
+
+    ok = staging._safe_restore(src, dst)
+    assert ok is False
+    # Both must remain intact.
+    assert src.exists() and (src / "marker").exists()
+    assert dst.exists() and not (dst / "marker").exists()
+
+
+def test_read_token_fingerprint_returns_none_when_starttime_missing(tmp_path):
+    """T1j (Codex round-4 post-impl, high): tokens lacking
+    starttime_ticks (old-shape OR mid-write) must return None so the
+    age-based fallback handles them, NOT a PID-only false-match."""
+    slot = tmp_path / "0"
+    slot.mkdir()
+    (slot / "pid").write_text("12345")
+    # No starttime_ticks file.
+    assert staging._read_token_fingerprint(slot) is None
+
+    # With both files present, returns the canonical fingerprint.
+    (slot / "starttime_ticks").write_text("7000")
+    fp = staging._read_token_fingerprint(slot)
+    assert fp == b"12345|7000"
+
+
+def test_read_token_fingerprint_returns_none_for_empty_or_malformed(tmp_path):
+    """T1k (Codex round-5 post-impl, high): empty/malformed metadata
+    files must produce None, not "pid|" or "|st" — those shapes would
+    collide across generations under PID reuse if either side was mid-
+    write (Path.write_text truncates before writing)."""
+    def _slot(name, pid_content, st_content):
+        s = tmp_path / name
+        s.mkdir()
+        if pid_content is not None:
+            (s / "pid").write_text(pid_content)
+        if st_content is not None:
+            (s / "starttime_ticks").write_text(st_content)
+        return s
+
+    # Empty starttime_ticks (mid-write window).
+    s = _slot("empty_st", "12345", "")
+    assert staging._read_token_fingerprint(s) is None
+    # Empty pid.
+    s = _slot("empty_pid", "", "7000")
+    assert staging._read_token_fingerprint(s) is None
+    # Whitespace-only.
+    s = _slot("ws", "  \n", "  ")
+    assert staging._read_token_fingerprint(s) is None
+    # Malformed pid (non-numeric).
+    s = _slot("bad_pid", "not-a-pid", "7000")
+    assert staging._read_token_fingerprint(s) is None
+    # Malformed starttime.
+    s = _slot("bad_st", "12345", "garbage")
+    assert staging._read_token_fingerprint(s) is None
+    # Negative pid/starttime.
+    s = _slot("neg_pid", "-1", "7000")
+    assert staging._read_token_fingerprint(s) is None
+    # Trailing newline IS tolerated (write_text default behaviour).
+    s = _slot("trailing_nl", "12345\n", "7000\n")
+    assert staging._read_token_fingerprint(s) == b"12345|7000"
+
+
+def test_acquire_staging_token_deadline_bounds_reclaim_loop(
+    tmp_path, monkeypatch,
+):
+    """T13b (post-impl review fix): the outer token loop must enforce
+    the deadline on every iteration, including pathological reclaim
+    paths where _token_holder_alive keeps reporting dead but mkdir
+    keeps failing."""
+    tokens = tmp_path / "tokens"
+    tokens.mkdir()
+    # Pre-create slot 0 in a state that triggers the reclaim path.
+    (tokens / "0").mkdir()
+    (tokens / "0" / "host").write_text("otherhost-fake")
+    (tokens / "0" / "pid").write_text("1")
+
+    # Always-dead so reclaim runs every iteration.
+    monkeypatch.setattr(staging, "_token_holder_alive",
+                        lambda *_a, **_kw: False)
+    # Make slot.mkdir always raise so the for-loop never returns.
+    real_mkdir = Path.mkdir
+
+    def _always_exists(self, *a, **kw):
+        if self.parent == tokens:
+            raise FileExistsError(str(self))
+        return real_mkdir(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "mkdir", _always_exists)
+    with pytest.raises(staging.TokenAcquireTimeout):
+        staging.acquire_staging_token(
+            tokens, n_slots=1, holder_id="t/x",
+            timeout_sec=0.3, poll_sleep=(0.01, 0.02),
+        )
+
+
+def test_mkdir_lock_no_timeout_when_none_passed(tmp_path, monkeypatch):
+    """T2: ``wait_timeout_sec=None`` preserves unbounded behaviour;
+    when the holder finally clears the lock acquires."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock_dir.mkdir()
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(), "pid": os.getpid(),
+    }))
+    release = threading.Event()
+    acquired = threading.Event()
+
+    def _alive(*_a, **_kw):
+        # While the test is "holding" the lock, report alive; once we set
+        # `release`, report dead so the contender reclaims.
+        return not release.is_set()
+
+    monkeypatch.setattr(staging, "_holder_alive_locally", _alive)
+
+    def _worker():
+        with staging._MkdirLock(
+            dir_path=lock_dir,
+            wait_timeout_sec=None,
+            poll_sleep=(0.01, 0.02),
+        ):
+            acquired.set()
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    # Worker should still be blocked
+    assert not acquired.wait(timeout=0.3)
+    release.set()
+    assert acquired.wait(timeout=2.0)
+    t.join()
+
+
+def test_mkdir_lock_progress_log_emits(tmp_path, monkeypatch, caplog):
+    """T3: while waiting, ``_MkdirLock`` logs a periodic WARN."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock_dir.mkdir()
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(), "pid": os.getpid(),
+    }))
+    monkeypatch.setattr(staging, "_holder_alive_locally",
+                        lambda *_a, **_kw: True)
+    monkeypatch.setattr(staging, "_MKDIR_LOCK_PROGRESS_LOG_SEC", 0.05)
+    caplog.set_level("WARNING", logger=staging.log.name)
+    lock = staging._MkdirLock(
+        dir_path=lock_dir,
+        wait_timeout_sec=0.3,
+        poll_sleep=(0.01, 0.02),
+    )
+    with pytest.raises(staging.StaleLockTimeout):
+        lock.__enter__()
+    assert any("still waiting for lock" in r.message for r in caplog.records)
+
+
+def test_stale_lock_timeout_not_subclass_of_oserror():
+    """T4: ``StaleLockTimeout`` MUST NOT be an ``OSError`` so callers'
+    ``except OSError`` clauses don't silently swallow it."""
+    assert not isinstance(staging.StaleLockTimeout(), OSError)
+    assert not isinstance(staging.StaleLockTimeout(), TimeoutError)
+
+
+def test_acquire_cache_populate_propagates_stale_lock_timeout(
+    tmp_path, monkeypatch,
+):
+    """T5: a StaleLockTimeout from the inner GC lock must propagate
+    out of ``acquire_cache_populate`` (NOT be eaten by ``except OSError``)."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+
+    real_enter = staging._MkdirLock.__enter__
+
+    def _boom(self):
+        raise staging.StaleLockTimeout(f"forced timeout on {self.dir_path}")
+
+    monkeypatch.setattr(staging._MkdirLock, "__enter__", _boom)
+    with pytest.raises(staging.StaleLockTimeout):
+        staging.acquire_cache_populate(
+            cache, src, timeout_sec=2, poll_sleep=(0.01, 0.02),
+        )
+
+
+def test_stage_one_falls_back_on_stale_lock_timeout(tmp_path, monkeypatch):
+    """T6: a ``StaleLockTimeout`` from ``acquire_cache_populate`` (e.g.
+    the inner GC-lock wedged) must be caught by ``stage_one`` and routed
+    to the NAS-direct fallback — same behaviour as the existing
+    ``TimeoutError`` path.  Per plan v2 Delta 5 + v4 Delta 8: a wedged
+    cache GC lock should not fail an otherwise-stageable unit."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    dst = tmp_path / "dst"
+
+    def _raise(*_a, **_kw):
+        raise staging.StaleLockTimeout("populate timeout")
+
+    monkeypatch.setattr(staging, "acquire_cache_populate", _raise)
+    final, source = staging.stage_one(
+        str(src), dst, method="cp", bucket="ms", cache_root=cache,
+    )
+    assert source == "nas_direct"
+    assert final.exists()
+
+
+def test_inner_gc_lock_capped_by_outer_populate_deadline(tmp_path, monkeypatch):
+    """T7: when the caller passes a small ``timeout_sec``, the inner
+    ``_MkdirLock`` wait must be capped by remaining budget rather than
+    the 300s default."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    captured: dict = {}
+
+    real_init = staging._MkdirLock.__init__
+
+    def _spy_init(self, *a, **kw):
+        captured.setdefault("waits", []).append(kw.get("wait_timeout_sec"))
+        return real_init(self, *a, **kw)
+
+    monkeypatch.setattr(staging._MkdirLock, "__init__", _spy_init)
+    outcome, lock = staging.acquire_cache_populate(
+        cache, src, timeout_sec=1.0, poll_sleep=(0.01, 0.02),
+    )
+    if lock is not None:
+        with lock:
+            pass
+    assert outcome in ("populate", "hit")
+    inner_waits = [w for w in captured["waits"] if w is not None]
+    assert inner_waits, "no _MkdirLock with bounded wait observed"
+    assert all(w <= 1.0 for w in inner_waits), (
+        f"inner wait exceeded outer budget: {inner_waits}"
+    )
+
+
+# PID-reuse + identity ---------------------------------------------------------
+
+def test_holder_alive_detects_pid_reuse_via_starttime(tmp_path):
+    """T8: same PID but different start-time ticks → stale."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock_dir.mkdir()
+    own_start = staging._read_proc_starttime(os.getpid())
+    assert own_start is not None
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(),
+        "pid": os.getpid(),
+        "starttime_ticks": int(own_start) + 1,
+    }))
+    assert staging._holder_alive_locally(lock_dir) is False
+
+
+def test_holder_alive_back_compat_no_starttime(tmp_path):
+    """T9: holder.json without ``starttime_ticks`` falls through to the
+    PID-only check (alive when PID is alive)."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock_dir.mkdir()
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(), "pid": os.getpid(),
+    }))
+    assert staging._holder_alive_locally(lock_dir) is True
+
+
+def test_mkdir_lock_meta_identity_cannot_be_overridden(tmp_path):
+    """T10: caller-supplied ``holder_meta`` with bogus host/pid must NOT
+    overwrite the real identity record."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock = staging._MkdirLock(
+        dir_path=lock_dir,
+        holder_meta={"pid": 99999, "host": "bogus.example.com",
+                     "starttime_ticks": -1},
+        wait_timeout_sec=1.0,
+        poll_sleep=(0.01, 0.02),
+    )
+    with lock:
+        meta = _json.loads((lock_dir / "holder.json").read_text())
+        assert meta["pid"] == os.getpid()
+        assert meta["host"] == _sock.gethostname()
+        # starttime_ticks should be the real one (not -1), or None.
+        own_start = staging._read_proc_starttime(os.getpid())
+        assert meta["starttime_ticks"] == own_start
+
+
+def test_populating_writer_includes_starttime(tmp_path):
+    """T11: ``acquire_cache_populate``'s manual ``.populating/holder.json``
+    must include ``starttime_ticks`` (identity-last, real value)."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    outcome, lock = staging.acquire_cache_populate(
+        cache, src, timeout_sec=5, poll_sleep=(0.01, 0.02),
+    )
+    assert outcome == "populate"
+    populating = cache / staging._cache_key(src) / ".populating"
+    meta = _json.loads((populating / "holder.json").read_text())
+    assert meta["host"] == _sock.gethostname()
+    assert meta["pid"] == os.getpid()
+    assert "starttime_ticks" in meta
+    own_start = staging._read_proc_starttime(os.getpid())
+    assert meta["starttime_ticks"] == own_start
+    with lock:
+        pass
+
+
+# Hostname --------------------------------------------------------------------
+
+def test_same_host_recognizes_short_fqdn_and_uppercase(monkeypatch):
+    """T12: short/FQDN/uppercase all recognised as same host
+    (case-insensitive per RFC 952/1123)."""
+    monkeypatch.setattr(_sock, "gethostname", lambda: "almap8")
+    monkeypatch.setattr(_sock, "getfqdn", lambda: "almap8.alma.ac.uk")
+    # Reimport names inside staging too — it uses ``socket`` module ref.
+    monkeypatch.setattr(staging.socket, "gethostname", lambda: "almap8")
+    monkeypatch.setattr(staging.socket, "getfqdn", lambda: "almap8.alma.ac.uk")
+    assert staging._same_host("almap8") is True
+    assert staging._same_host("almap8.alma.ac.uk") is True
+    assert staging._same_host("ALMAP8") is True
+    assert staging._same_host("Almap8.ALMA.ac.uk") is True
+    assert staging._same_host("almap9") is False
+    assert staging._same_host("") is False
+
+
+def test_holder_alive_cross_host_still_returns_true(tmp_path, monkeypatch):
+    """T13: a holder.json from a different host must report alive (we
+    have no local way to check; coordinator/operator handles)."""
+    lock_dir = tmp_path / ".stage.lock.d"
+    lock_dir.mkdir()
+    (lock_dir / "holder.json").write_text(_json.dumps({
+        "host": "definitely-not-this-host.example",
+        "pid": 2 ** 22,  # almost certainly dead, but cross-host short-circuit
+    }))
+    assert staging._holder_alive_locally(lock_dir) is True
+
+
+# Token-side ------------------------------------------------------------------
+
+def test_acquire_staging_token_times_out_when_all_slots_pinned(tmp_path):
+    """T14: all slots pinned with live PID + matching starttime →
+    ``TokenAcquireTimeout``."""
+    tok = tmp_path / "tokens"
+    tok.mkdir()
+    own_start = staging._read_proc_starttime(os.getpid())
+    for i in range(2):
+        slot = tok / str(i)
+        slot.mkdir()
+        (slot / "host").write_text(_sock.gethostname())
+        (slot / "pid").write_text(str(os.getpid()))
+        (slot / "holder").write_text(f"pinned/{i}")
+        (slot / "acquired_at").write_text(str(time.time()))
+        if own_start is not None:
+            (slot / "starttime_ticks").write_text(str(own_start))
+    with pytest.raises(staging.TokenAcquireTimeout):
+        staging.acquire_staging_token(
+            tok, n_slots=2, holder_id="contender",
+            poll_sleep=(0.01, 0.02), timeout_sec=0.3,
+        )
+
+
+def test_acquire_staging_token_reclaims_on_starttime_mismatch(tmp_path):
+    """T15: slot 0 pinned with mismatched starttime_ticks → reclaimed
+    and acquired."""
+    tok = tmp_path / "tokens"
+    tok.mkdir()
+    own_start = staging._read_proc_starttime(os.getpid())
+    slot = tok / "0"
+    slot.mkdir()
+    (slot / "host").write_text(_sock.gethostname())
+    (slot / "pid").write_text(str(os.getpid()))
+    (slot / "holder").write_text("ghost")
+    (slot / "acquired_at").write_text(str(time.time()))
+    if own_start is not None:
+        (slot / "starttime_ticks").write_text(str(int(own_start) + 1))
+    i = staging.acquire_staging_token(
+        tok, n_slots=1, holder_id="real",
+        poll_sleep=(0.01, 0.02), timeout_sec=2,
+    )
+    assert i == 0
+    # The slot's new metadata must be OUR holder_id
+    assert (slot / "holder").read_text() == "real"
+    staging.release_staging_token(tok, i)
+
+
+def test_token_metadata_includes_starttime_ticks(tmp_path):
+    """T16: fresh ``acquire_staging_token`` writes ``starttime_ticks``."""
+    tok = tmp_path / "tokens"
+    i = staging.acquire_staging_token(
+        tok, n_slots=2, holder_id="x",
+        poll_sleep=(0.01, 0.02), timeout_sec=2,
+    )
+    slot = tok / str(i)
+    assert (slot / "host").exists()
+    assert (slot / "pid").exists()
+    assert (slot / "holder").exists()
+    assert (slot / "acquired_at").exists()
+    assert (slot / "starttime_ticks").exists()
+    # starttime parses as int
+    assert int((slot / "starttime_ticks").read_text().strip()) >= 0
+    staging.release_staging_token(tok, i)
+
+
+def test_list_held_tokens_exposes_starttime(tmp_path):
+    """T17: ``list_held_tokens`` returns dict with ``starttime_ticks``
+    when present."""
+    tok = tmp_path / "tokens"
+    i = staging.acquire_staging_token(
+        tok, n_slots=1, holder_id="x",
+        poll_sleep=(0.01, 0.02), timeout_sec=2,
+    )
+    held = staging.list_held_tokens(tok)
+    assert len(held) == 1
+    assert "starttime_ticks" in held[0]
+    assert isinstance(held[0]["starttime_ticks"], int)
+    staging.release_staging_token(tok, i)
+
+
+def test_list_held_tokens_back_compat_old_token(tmp_path):
+    """T18 (BACK-COMPAT CRITICAL): an old-shape token (no
+    ``starttime_ticks`` file) must report ``starttime_ticks: None`` and
+    NOT be misclassified as malformed.  Misclassification would cause
+    the dispatch ``TokenReaper`` to drop live cross-version tokens."""
+    tok = tmp_path / "tokens"
+    tok.mkdir()
+    slot = tok / "0"
+    slot.mkdir()
+    (slot / "host").write_text(_sock.gethostname())
+    (slot / "pid").write_text(str(os.getpid()))
+    (slot / "holder").write_text("old-style/1")
+    (slot / "acquired_at").write_text(str(time.time()))
+    # NO starttime_ticks file
+    held = staging.list_held_tokens(tok)
+    assert len(held) == 1
+    rec = held[0]
+    assert rec["host"] == _sock.gethostname()
+    assert rec["pid"] == os.getpid()
+    assert rec["holder"] == "old-style/1"
+    assert rec["starttime_ticks"] is None
+
+
+def test_token_malformed_grace_window_preserved(tmp_path):
+    """T19: a mid-write token (slot dir exists but no host/pid yet) within
+    the malformed grace window must NOT be stolen by a contender."""
+    tok = tmp_path / "tokens"
+    tok.mkdir()
+    slot = tok / "0"
+    slot.mkdir()
+    # No metadata files yet — simulates the brief mkdir-then-write window.
+    # _token_holder_alive should report True within the grace window.
+    assert staging._token_holder_alive(slot, malformed_grace_sec=60.0) is True
+
+
+def test_token_lease_propagates_token_acquire_timeout(tmp_path):
+    """T20: ``TokenLease.acquire_if_needed`` propagates
+    ``TokenAcquireTimeout`` from ``acquire_staging_token``."""
+    tok = tmp_path / "tokens"
+    tok.mkdir()
+    own_start = staging._read_proc_starttime(os.getpid())
+    slot = tok / "0"
+    slot.mkdir()
+    (slot / "host").write_text(_sock.gethostname())
+    (slot / "pid").write_text(str(os.getpid()))
+    (slot / "holder").write_text("pinned")
+    (slot / "acquired_at").write_text(str(time.time()))
+    if own_start is not None:
+        (slot / "starttime_ticks").write_text(str(own_start))
+    lease = staging.TokenLease(
+        tok, n_slots=1, holder_id="contender", timeout_sec=0.3,
+    )
+    with pytest.raises(staging.TokenAcquireTimeout):
+        lease.acquire_if_needed()
+
+
+def test_token_acquire_timeout_is_timeout_error():
+    """T21 (back-compat sanity): existing callers ``except TimeoutError``
+    still catch the new typed subclass."""
+    assert isinstance(staging.TokenAcquireTimeout(), TimeoutError)
+    assert issubclass(staging.TokenAcquireTimeout, TimeoutError)
+
+
+def test_token_acquire_timeout_default_changed_to_1800():
+    """T22: ``acquire_staging_token``'s default ``timeout_sec`` changed
+    from None to 1800s (the new bound)."""
+    import inspect
+    sig = inspect.signature(staging.acquire_staging_token)
+    assert sig.parameters["timeout_sec"].default == 1800.0
+    assert staging._DEFAULT_TOKEN_WAIT_TIMEOUT_SEC == 1800.0
+
+
+# Eviction --------------------------------------------------------------------
+
+def test_cache_evict_until_free_times_out_on_stale_gc_lock(
+    tmp_path, monkeypatch, caplog,
+):
+    """T23: a wedged GC lock surfaces as 0 evictions + WARN log."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    # Pre-create the GC lock dir and pin it with a live holder.
+    gc_lock = cache / ".gc.lock.d"
+    gc_lock.mkdir()
+    (gc_lock / "holder.json").write_text(_json.dumps({
+        "host": _sock.gethostname(), "pid": os.getpid(),
+    }))
+    monkeypatch.setattr(staging, "_holder_alive_locally",
+                        lambda *_a, **_kw: True)
+    caplog.set_level("WARNING", logger=staging.log.name)
+    n = staging.cache_evict_until_free(
+        cache, target_free_bytes=1, wait_timeout_sec=0.3,
+    )
+    assert n == 0
+    assert any("GC lock timeout" in r.message for r in caplog.records)
+
+
+# v5 Delta 1 / 2 additions ----------------------------------------------------
+
+def test_stage_one_propagates_token_acquire_timeout_through_populate(
+    tmp_path, monkeypatch,
+):
+    """T24 (v5 Delta 1): the narrowed populate ``except`` clause must
+    re-raise ``TokenAcquireTimeout`` rather than downgrade to NAS-direct.
+    Also asserts NAS-direct path is NOT entered."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+
+    # Force token-lease acquire to raise TokenAcquireTimeout.
+    nas_calls = {"n": 0}
+    acquire_calls = {"n": 0}
+
+    def _spy_do_nas_read(*_a, **_kw):
+        nas_calls["n"] += 1
+
+    monkeypatch.setattr(staging, "_do_nas_read", _spy_do_nas_read)
+
+    def _raise_timeout(self):
+        acquire_calls["n"] += 1
+        raise staging.TokenAcquireTimeout("forced for test")
+
+    monkeypatch.setattr(staging.TokenLease, "acquire_if_needed", _raise_timeout)
+
+    tokens = tmp_path / "tokens"
+    lease = staging.TokenLease(tokens, n_slots=1, holder_id="x")
+    with pytest.raises(staging.TokenAcquireTimeout):
+        staging.stage_one(
+            str(src), tmp_path / "dst", method="cp", bucket="ms",
+            cache_root=cache, token_lease=lease,
+        )
+    # NAS-direct must NOT have been attempted.
+    assert nas_calls["n"] == 0
+    # And the populate block must NOT have looped through to NAS-direct
+    # for a second token attempt — proves the narrowed except clause
+    # actually re-raises rather than silently retrying.
+    assert acquire_calls["n"] == 1
+
+
+def test_stage_one_eviction_inherits_populate_deadline(tmp_path, monkeypatch):
+    """T25 (v5 Delta 2): the populate-branch's call to
+    ``cache_evict_until_free`` must pass a ``wait_timeout_sec`` capped
+    by the outer ``cache_populate_timeout_sec``."""
+    src = _fake_ms(tmp_path / "src")
+    cache = tmp_path / "cache"
+    captured: dict = {}
+
+    real_evict = staging.cache_evict_until_free
+
+    def _spy_evict(*a, **kw):
+        captured["wait_timeout_sec"] = kw.get("wait_timeout_sec")
+        return real_evict(*a, **kw)
+
+    monkeypatch.setattr(staging, "cache_evict_until_free", _spy_evict)
+    # cache_min_free_bytes must be set to trigger eviction.
+    staging.stage_one(
+        str(src), tmp_path / "dst", method="cp", bucket="ms",
+        cache_root=cache, cache_min_free_bytes=1,
+        cache_populate_timeout_sec=10.0,
+    )
+    assert "wait_timeout_sec" in captured, (
+        "cache_evict_until_free not called with wait_timeout_sec"
+    )
+    assert captured["wait_timeout_sec"] is not None
+    assert captured["wait_timeout_sec"] <= 10.0, (
+        f"wait_timeout_sec={captured['wait_timeout_sec']} exceeded outer 10s budget"
+    )


### PR DESCRIPTION
Two related fixes for the imaging-dispatch.

- **Cascade-failure hardening** (`4cf5fea`)
  — Replaces unverified `MARK_DONE` with a verify-or-quarantine flow. The orchestrator now treats inconclusive cleanup as fail-closed: host quarantined, DB row left active for the next reconcile.

- **`staging.py` reclaim race fix** (`91fa5d9`)
  — Closes a pre-existing same-host PID-reuse hang where `_MkdirLock.__enter__` could `time.sleep()` forever on a stale lock whose PID happened to match a live unrelated process.