### PR TITLE
infra: increase staging-token acquire cap to 24h

### DIFF
--- a/panta_rei/imaging/dispatch.py
+++ b/panta_rei/imaging/dispatch.py
@@ -73,6 +73,12 @@ WORKER_MODULE = "panta_rei.imaging.remote_worker"
 @dataclass
 class GlobalCfg:
     max_concurrent_staging: int = 4
+    # Worker staging-token acquire wait.  24h backstop (NOT a tight bound):
+    # token contention with a live holder must be waited out — a single unit
+    # can stage+image for hours, and historical cache-miss units waited 2-8h
+    # for a token and succeeded.  Forwarded to the worker as
+    # --token-wait-timeout-sec; see staging._DEFAULT_TOKEN_WAIT_TIMEOUT_SEC.
+    token_wait_timeout_sec: float = 86400.0
     heartbeat_interval_sec: int = 30
     heartbeat_stale_threshold_sec: int = 300
     max_stale_alive_sec: int = 3600
@@ -745,6 +751,7 @@ def write_launcher_script(
     tokens_dir: str,
     max_concurrent_staging: int,
     heartbeat_interval: int,
+    token_wait_timeout_sec: float,
     cache_root: Optional[str] = None,
     cache_min_free_gb: Optional[int] = None,
 ) -> Path:
@@ -782,6 +789,7 @@ def write_launcher_script(
         f"--publish-policy {shlex.quote(publish_policy)} "
         f"--tokens-dir {shlex.quote(tokens_dir)} "
         f"--max-concurrent-staging {int(max_concurrent_staging)} "
+        f"--token-wait-timeout-sec {float(token_wait_timeout_sec)} "
         f"--heartbeat-interval {int(heartbeat_interval)} "
         f"{cache_args}"
         f">{shlex.quote(str(launch_log))} 2>&1 "
@@ -2250,6 +2258,7 @@ class MachineSlot(threading.Thread):
                 publish_policy=c.publish_policy,
                 tokens_dir=str(c.tokens_dir),
                 max_concurrent_staging=c.cfg.global_cfg.max_concurrent_staging,
+                token_wait_timeout_sec=c.cfg.global_cfg.token_wait_timeout_sec,
                 heartbeat_interval=c.cfg.global_cfg.heartbeat_interval_sec,
                 cache_root=cache_root,
                 cache_min_free_gb=self.machine.cache_min_free_gb,

--- a/panta_rei/imaging/staging.py
+++ b/panta_rei/imaging/staging.py
@@ -66,7 +66,17 @@ class TokenAcquireTimeout(TimeoutError):
 
 
 _MKDIR_LOCK_DEFAULT_WAIT_SEC = 300.0
-_DEFAULT_TOKEN_WAIT_TIMEOUT_SEC = 1800.0
+# 24h backstop, NOT a tight bound.  An earlier 1800s (30min) default
+# (commit 91fa5d9) regressed dispatch reliability: historically, cache-miss
+# units routinely waited 2-8h (observed max ~29,700s) for one of only 2
+# staging tokens and SUCCEEDED, because a held token implies a LIVE worker
+# making staging progress and a single unit can stage+image for hours.  The
+# 30min cap converted those long-but-successful waits into hard failures.
+# Dead holders are reclaimed by the DB-backed TokenReaper, so an effectively
+# unbounded wait is safe; this 24h value is only a final valve against an
+# unforeseen stuck-but-alive holder (which a cap cannot free anyway — it can
+# only fail innocent waiters).  See .tmp/REGRESSION_REPORT_token_timeout_2026-06-02.md.
+_DEFAULT_TOKEN_WAIT_TIMEOUT_SEC = 86400.0
 _MKDIR_LOCK_PROGRESS_LOG_SEC = 60.0
 
 
@@ -631,8 +641,9 @@ def acquire_staging_token(
     """Acquire one of *n_slots* tokens under *tokens_root*.
 
     Atomic primitive: ``os.mkdir(tokens_root/<i>)``.  Returns the index
-    of the slot acquired.  ``timeout_sec`` bounds the wait — defaults to
-    30 minutes; ``None`` opts out (legacy / test convenience).
+    of the slot acquired.  ``timeout_sec`` bounds the wait — defaults to a
+    24h backstop (see ``_DEFAULT_TOKEN_WAIT_TIMEOUT_SEC``); ``None`` opts out
+    entirely (truly unbounded).
 
     Raises :class:`TokenAcquireTimeout` (an alias of ``TimeoutError``)
     when the bound is exceeded.  Same-host stale slots whose PID is

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -62,6 +62,22 @@ def test_load_machines_config_happy(tmp_path):
     assert cfg.machines["beta"].slots == 2
 
 
+def test_global_cfg_token_wait_timeout_default_and_parse(tmp_path):
+    """token_wait_timeout_sec defaults to the 24h backstop and is parsed
+    from the machines.json ``global`` block when present."""
+    # Default when absent.
+    assert D.GlobalCfg().token_wait_timeout_sec == 86400.0
+    cfg = D.load_machines_config(_write_machines_json(tmp_path))
+    assert cfg.global_cfg.token_wait_timeout_sec == 86400.0
+    # Override honored.
+    p = _write_machines_json(
+        tmp_path, **{"global": {"max_concurrent_staging": 3,
+                                "token_wait_timeout_sec": 43200.0}},
+    )
+    cfg2 = D.load_machines_config(p)
+    assert cfg2.global_cfg.token_wait_timeout_sec == 43200.0
+
+
 def test_load_machines_config_missing_required(tmp_path):
     p = tmp_path / "m.json"
     p.write_text(json.dumps({"conda_env": "/x"}))
@@ -558,6 +574,7 @@ def test_write_launcher_script_quotes_paths(tmp_path):
         transfer_method="tar", publish_policy="fail_if_exists",
         tokens_dir="/nas/tokens",
         max_concurrent_staging=3,
+        token_wait_timeout_sec=86400.0,
         heartbeat_interval=30,
     )
     text = p.read_text()
@@ -566,6 +583,8 @@ def test_write_launcher_script_quotes_paths(tmp_path):
     assert "panta_rei.imaging.remote_worker" in text
     assert "--run-id 42" in text
     assert "--dispatch-id d_x" in text
+    # Token wait is forwarded so the worker doesn't fall back to a tight bound.
+    assert "--token-wait-timeout-sec 86400.0" in text
     assert os.access(p, os.X_OK)
     # Cache args ABSENT when not requested
     assert "--cache-root" not in text
@@ -583,6 +602,7 @@ def test_write_launcher_script_includes_cache_args(tmp_path):
         run_id=1, dispatch_id="d",
         transfer_method="tar", publish_policy="fail_if_exists",
         tokens_dir="/t", max_concurrent_staging=2,
+        token_wait_timeout_sec=86400.0,
         heartbeat_interval=30,
         cache_root="/raid/cache",
         cache_min_free_gb=512,

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1807,13 +1807,17 @@ def test_token_acquire_timeout_is_timeout_error():
     assert issubclass(staging.TokenAcquireTimeout, TimeoutError)
 
 
-def test_token_acquire_timeout_default_changed_to_1800():
-    """T22: ``acquire_staging_token``'s default ``timeout_sec`` changed
-    from None to 1800s (the new bound)."""
+def test_token_acquire_timeout_default_is_24h_backstop():
+    """The 30min (1800s) token-acquire bound from commit 91fa5d9 regressed
+    dispatch reliability: it failed legitimate multi-hour staging waits that
+    historically succeeded (observed waits up to ~29,700s).  The default is
+    now a 24h backstop, not a tight bound — dead holders are reclaimed by the
+    DB-backed TokenReaper, so an effectively unbounded wait is safe.  See
+    .tmp/REGRESSION_REPORT_token_timeout_2026-06-02.md."""
     import inspect
     sig = inspect.signature(staging.acquire_staging_token)
-    assert sig.parameters["timeout_sec"].default == 1800.0
-    assert staging._DEFAULT_TOKEN_WAIT_TIMEOUT_SEC == 1800.0
+    assert sig.parameters["timeout_sec"].default == 86400.0
+    assert staging._DEFAULT_TOKEN_WAIT_TIMEOUT_SEC == 86400.0
 
 
 # Eviction --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Reverts a reliability regression introduced by #172 (`91fa5d9`), which capped
staging-token acquisition at a hard **1800 s (30 min)** and failed the unit on
timeout. 

## Change
- `staging._DEFAULT_TOKEN_WAIT_TIMEOUT_SEC`: **1800 → 86400** (24 h backstop,
  not a tight bound; `None` still opts out entirely).
- Plumb `token_wait_timeout_sec` through `GlobalCfg → write_launcher_script →`
  the worker's `--token-wait-timeout-sec`. 