### PR TITLE
github: replace re-imaging/re-calibration columns with 'Needs attention'

### DIFF
--- a/panta_rei/github/project.py
+++ b/panta_rei/github/project.py
@@ -22,8 +22,7 @@ PROJECT_STATUS_IN_PROGRESS = "In progress"
 PROJECT_STATUS_DELIVERED = "Delivered"
 PROJECT_STATUS_WEBLOG_QA = "Weblog QA"
 PROJECT_STATUS_NEEDS_DISCUSSION = "Needs discussion"
-PROJECT_STATUS_RECALIBRATION = "Needs re-calibration"
-PROJECT_STATUS_REIMAGING = "Needs re-imaging"
+PROJECT_STATUS_NEEDS_ATTENTION = "Needs attention"
 PROJECT_STATUS_DONE = "Done"
 
 
@@ -303,8 +302,7 @@ class GitHubProjectManager:
         manual_states = {
             PROJECT_STATUS_WEBLOG_QA,
             PROJECT_STATUS_NEEDS_DISCUSSION,
-            PROJECT_STATUS_RECALIBRATION,
-            PROJECT_STATUS_REIMAGING,
+            PROJECT_STATUS_NEEDS_ATTENTION,
             PROJECT_STATUS_DONE,
         }
         return current_status in manual_states

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -14,9 +14,8 @@ from panta_rei.github.project import (
     PROJECT_STATUS_DELIVERED,
     PROJECT_STATUS_DONE,
     PROJECT_STATUS_IN_PROGRESS,
+    PROJECT_STATUS_NEEDS_ATTENTION,
     PROJECT_STATUS_NEEDS_DISCUSSION,
-    PROJECT_STATUS_RECALIBRATION,
-    PROJECT_STATUS_REIMAGING,
     PROJECT_STATUS_WEBLOG_QA,
     GitHubProjectManager,
 )
@@ -32,8 +31,7 @@ def manager() -> GitHubProjectManager:
     [
         PROJECT_STATUS_WEBLOG_QA,
         PROJECT_STATUS_NEEDS_DISCUSSION,
-        PROJECT_STATUS_RECALIBRATION,
-        PROJECT_STATUS_REIMAGING,
+        PROJECT_STATUS_NEEDS_ATTENTION,
         PROJECT_STATUS_DONE,
     ],
 )
@@ -52,3 +50,8 @@ def test_auto_managed_states_are_not_protected(manager, status):
 def test_needs_discussion_constant_matches_board_label():
     # Must match the GitHub column name byte-for-byte or the guard never fires.
     assert PROJECT_STATUS_NEEDS_DISCUSSION == "Needs discussion"
+
+
+def test_needs_attention_constant_matches_board_label():
+    # Must match the GitHub column name byte-for-byte or the guard never fires.
+    assert PROJECT_STATUS_NEEDS_ATTENTION == "Needs attention"


### PR DESCRIPTION
Upstream the GitHub project board merged the 'Needs re-imaging' and 'Needs re-calibration' columns into a single 'Needs attention' column. Update the status constants and the manual-state protection guard to match.