### PR TITLE
Fix broken weblog links: no URL fabrication + guarded self-healing

### DIFF
--- a/panta_rei/alma/staging.py
+++ b/panta_rei/alma/staging.py
@@ -19,6 +19,7 @@ from typing import Dict, List, Optional, Tuple
 
 from panta_rei.core.text import now_iso
 from panta_rei.core.uid import UID_CORE_RE, canonical_uid, sanitize_uid
+from panta_rei.core.urlmap import path_to_url as _path_to_url
 
 log = logging.getLogger(__name__)
 
@@ -48,13 +49,12 @@ def find_mous_directory(archive_path: Path) -> Optional[Path]:
 
 
 def path_to_url(path: Path, url_mappings: Dict[str, str]) -> Optional[str]:
-    """Convert a filesystem path to a public URL via configured mappings."""
-    path_str = str(path.resolve())
-    for fs_prefix, url_prefix in url_mappings.items():
-        if path_str.startswith(fs_prefix):
-            rel_path = path_str[len(fs_prefix):].lstrip("/")
-            return f"{url_prefix.rstrip('/')}/{rel_path}"
-    return None
+    """Convert a filesystem path to a public URL via configured mappings.
+
+    Delegates to the shared component-boundary-safe implementation in
+    :mod:`panta_rei.core.urlmap`.
+    """
+    return _path_to_url(path, url_mappings)
 
 
 def make_world_readable(path: Path) -> None:

--- a/panta_rei/core/urlmap.py
+++ b/panta_rei/core/urlmap.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from pathlib import Path, PurePosixPath
 from typing import Dict, Optional
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 # Default mapping used across the pipeline (see PipelineConfig.url_mappings).
 DEFAULT_URL_MAPPINGS: Dict[str, str] = {
@@ -44,13 +44,18 @@ def url_to_path(url: str, url_mappings: Dict[str, str]) -> Optional[Path]:
     """Convert a public URL back to its filesystem path.
 
     Scheme-insensitive (http/https treated as equivalent) and
-    component-boundary safe on the URL path. Returns None if the URL
-    does not match any configured mapping.
+    component-boundary safe on the URL path. URLs containing dot
+    segments (``.`` or ``..``, plain or percent-encoded) are rejected
+    outright so a mapped path can never escape its prefix. Returns None
+    if the URL does not match any configured mapping.
     """
     if not url:
         return None
     target = urlsplit(url)
     if target.scheme not in ("http", "https") or not target.netloc:
+        return None
+    target_path = unquote(target.path)
+    if any(part in (".", "..") for part in target_path.split("/")):
         return None
     for fs_prefix, url_prefix in url_mappings.items():
         base = urlsplit(url_prefix)
@@ -58,7 +63,7 @@ def url_to_path(url: str, url_mappings: Dict[str, str]) -> Optional[Path]:
             continue
         base_path = PurePosixPath(base.path or "/")
         try:
-            rel = PurePosixPath(target.path).relative_to(base_path)
+            rel = PurePosixPath(target_path).relative_to(base_path)
         except ValueError:
             continue
         return Path(fs_prefix) / Path(*rel.parts)

--- a/panta_rei/core/urlmap.py
+++ b/panta_rei/core/urlmap.py
@@ -1,0 +1,65 @@
+"""Bidirectional filesystem-path <-> public-URL mapping.
+
+Centralizes the conversion between NAS filesystem paths (e.g.
+``/scratch/almanas/...``) and their public web URLs (e.g.
+``https://www.alma.ac.uk/nas/...``) so that all callers share one
+validated implementation.
+
+Matching is component-boundary safe: ``/scratch/almanas-other`` does
+NOT match the ``/scratch/almanas`` prefix. URL matching is
+scheme-insensitive (``http://`` and ``https://`` are equivalent).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import Dict, Optional
+from urllib.parse import urlsplit
+
+# Default mapping used across the pipeline (see PipelineConfig.url_mappings).
+DEFAULT_URL_MAPPINGS: Dict[str, str] = {
+    "/scratch/almanas": "https://www.alma.ac.uk/nas",
+}
+
+
+def path_to_url(path: Path, url_mappings: Dict[str, str]) -> Optional[str]:
+    """Convert a filesystem path to its public URL via configured mappings.
+
+    Returns None if the path is not under any mapped prefix. Prefix
+    matching respects path-component boundaries.
+    """
+    resolved = Path(path).resolve()
+    for fs_prefix, url_prefix in url_mappings.items():
+        try:
+            rel = resolved.relative_to(fs_prefix)
+        except ValueError:
+            continue
+        rel_str = rel.as_posix()
+        base = url_prefix.rstrip("/")
+        return base if rel_str == "." else f"{base}/{rel_str}"
+    return None
+
+
+def url_to_path(url: str, url_mappings: Dict[str, str]) -> Optional[Path]:
+    """Convert a public URL back to its filesystem path.
+
+    Scheme-insensitive (http/https treated as equivalent) and
+    component-boundary safe on the URL path. Returns None if the URL
+    does not match any configured mapping.
+    """
+    if not url:
+        return None
+    target = urlsplit(url)
+    if target.scheme not in ("http", "https") or not target.netloc:
+        return None
+    for fs_prefix, url_prefix in url_mappings.items():
+        base = urlsplit(url_prefix)
+        if target.netloc.lower() != base.netloc.lower():
+            continue
+        base_path = PurePosixPath(base.path or "/")
+        try:
+            rel = PurePosixPath(target.path).relative_to(base_path)
+        except ValueError:
+            continue
+        return Path(fs_prefix) / Path(*rel.parts)
+    return None

--- a/panta_rei/github/issues.py
+++ b/panta_rei/github/issues.py
@@ -217,7 +217,9 @@ class GitHubIssueManager:
         self.dry_run = dry_run
         self.limit = limit
         self.weblog_dir = Path(weblog_dir) if weblog_dir else None
-        self.url_mappings = url_mappings or dict(DEFAULT_URL_MAPPINGS)
+        self.url_mappings = (
+            dict(DEFAULT_URL_MAPPINGS) if url_mappings is None else url_mappings
+        )
         self.gh_project_number = gh_project_number
         self.update_project_status = update_project_status
         self.update_targets = update_targets
@@ -715,13 +717,17 @@ class GitHubIssueManager:
         return True
 
     def _under_weblog_dir(self, path: Path) -> bool:
-        """Check whether a path lies under the configured weblog directory."""
+        """Check whether a path lies under the configured weblog directory.
+
+        Both sides are resolved so symlinks and dot segments cannot make
+        an outside path appear contained (or vice versa).
+        """
         if not self.weblog_dir:
             return False
         try:
-            path.relative_to(self.weblog_dir)
+            path.resolve().relative_to(self.weblog_dir.resolve())
             return True
-        except ValueError:
+        except (ValueError, OSError):
             return False
 
     def _repair_weblog_link(

--- a/panta_rei/github/issues.py
+++ b/panta_rei/github/issues.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from panta_rei.core.uid import canonical_uid
+from panta_rei.core.urlmap import DEFAULT_URL_MAPPINGS, url_to_path
 from panta_rei.github.project import (
     PROJECT_STATUS_DELIVERED,
     PROJECT_STATUS_IN_PROGRESS,
@@ -23,8 +25,11 @@ from panta_rei.github.project import (
 
 log = logging.getLogger(__name__)
 
-# Default weblog URL base (matches stage_weblogs.py configuration)
-DEFAULT_WEBLOG_BASE_URL = "http://www.alma.ac.uk/nas/dwalker2/panta-rei/weblogs"
+# Matches the checked weblog line in an issue body, capturing the URL.
+WEBLOG_LINK_LINE_RE = re.compile(
+    r"^\* \[x\] \[Weblog\]\((?P<url>[^)\s]+)\) available[ \t]*$",
+    re.MULTILINE,
+)
 
 # Label colors
 LABEL_COLORS = {
@@ -121,16 +126,17 @@ def normalize_weblog_url(url: Optional[str]) -> Optional[str]:
     return url
 
 
-def build_sb_issue_body(
-    sb: SchedulingBlock,
-    weblog_base_url: Optional[str] = None,
-    weblog_dir: Optional[Path] = None,
-    base_dir: Optional[Path] = None,
-) -> str:
+def build_sb_issue_body(sb: SchedulingBlock) -> str:
     """Build the full GitHub issue body for a scheduling block.
 
     This is a standalone pure function so it can be used by both the live
     issue manager and the zero-API GH_DRY_RUN path.
+
+    The weblog link comes exclusively from ``sb.weblog_url`` (recorded by
+    weblog staging). URLs are deliberately never fabricated from local
+    filesystem paths: mapping a local data-tree path onto the public
+    weblog base produced a URL that never existed on the webserver
+    (issue #21, Dec 2025).
     """
     targets_sorted = sorted(sb.targets)
     targets_text = "\n".join(f"  - `{t}`" for t in targets_sorted)
@@ -146,21 +152,7 @@ def build_sb_issue_body(
     if sb.weblog_url:
         weblog_line = f"* [x] [Weblog]({sb.weblog_url}) available"
     elif sb.weblog_path:
-        if weblog_base_url:
-            try:
-                if weblog_dir:
-                    rel_path = sb.weblog_path.relative_to(weblog_dir)
-                elif base_dir:
-                    rel_path = sb.weblog_path.relative_to(base_dir)
-                else:
-                    raise ValueError("no base for relative path")
-                weblog_url = f"{weblog_base_url.rstrip('/')}/{rel_path}/index.html"
-                weblog_url = normalize_weblog_url(weblog_url)
-                weblog_line = f"* [x] [Weblog]({weblog_url}) available"
-            except ValueError:
-                weblog_line = f"* [x] Weblog available at: `{sb.weblog_path}`"
-        else:
-            weblog_line = f"* [x] Weblog available at: `{sb.weblog_path}`"
+        weblog_line = f"* [x] Weblog available at: `{sb.weblog_path}`"
     else:
         weblog_line = "* [ ] Weblog available"
 
@@ -208,7 +200,6 @@ class GitHubIssueManager:
         gh_owner: str,
         gh_repo: str,
         gh_token: Optional[str] = None,
-        weblog_base_url: Optional[str] = None,
         weblog_dir: Optional[Path] = None,
         csv_path: Optional[Path] = None,
         dry_run: bool = False,
@@ -216,6 +207,7 @@ class GitHubIssueManager:
         gh_project_number: Optional[int] = None,
         update_project_status: bool = False,
         update_targets: bool = False,
+        url_mappings: Optional[Dict[str, str]] = None,
     ):
         self.project_code = project_code
         self.base_dir = Path(base_dir)
@@ -224,8 +216,8 @@ class GitHubIssueManager:
         self.csv_path = Path(csv_path) if csv_path else None
         self.dry_run = dry_run
         self.limit = limit
-        self.weblog_base_url = weblog_base_url or DEFAULT_WEBLOG_BASE_URL
         self.weblog_dir = Path(weblog_dir) if weblog_dir else None
+        self.url_mappings = url_mappings or dict(DEFAULT_URL_MAPPINGS)
         self.gh_project_number = gh_project_number
         self.update_project_status = update_project_status
         self.update_targets = update_targets
@@ -370,8 +362,10 @@ class GitHubIssueManager:
     ) -> Tuple[Optional[Path], Optional[str]]:
         """Find weblog directory and URL for a scheduling block.
 
-        Looks up staged weblogs from the database. Weblogs must be staged via
-        stage_weblogs.py to appear here.
+        Looks up staged weblogs from the database by exact canonical UID
+        match (compact MOUS IDs like ``X3833_X64d8`` expand to
+        ``uid://A001/<...>``). Weblogs must be staged via stage_weblogs.py
+        to appear here.
 
         Returns:
             Tuple of (weblog_path, weblog_url) - either or both may be None
@@ -379,15 +373,22 @@ class GitHubIssueManager:
         if not weblog_info:
             return (None, None)
 
+        by_canonical = {
+            canonical_uid(db_uid): entry
+            for db_uid, entry in weblog_info.items()
+        }
         for mous_id in sb.mous_ids_list:
-            # Convert compact MOUS ID to canonical form for lookup
-            mous_lower = mous_id.lower()
-            for db_uid, (path, url) in weblog_info.items():
-                if mous_lower in db_uid.lower() or mous_id.replace("_", "") in db_uid:
-                    weblog_path = Path(path) if path else None
-                    # Normalize the URL to ensure correct format
-                    weblog_url = normalize_weblog_url(url)
-                    return (weblog_path, weblog_url)
+            # MOUS IDs may be compact (X3833_X64d8) or full uid forms
+            key = canonical_uid(mous_id) or canonical_uid(
+                f"uid://A001/{mous_id.replace('_', '/')}"
+            )
+            entry = by_canonical.get(key) if key else None
+            if entry:
+                path, url = entry
+                weblog_path = Path(path) if path else None
+                # Normalize the URL to ensure correct format
+                weblog_url = normalize_weblog_url(url)
+                return (weblog_path, weblog_url)
 
         return (None, None)
 
@@ -484,12 +485,7 @@ class GitHubIssueManager:
 
     def build_issue_body(self, sb: SchedulingBlock) -> str:
         """Build the issue body with status checkboxes."""
-        return build_sb_issue_body(
-            sb,
-            weblog_base_url=self.weblog_base_url,
-            weblog_dir=self.weblog_dir,
-            base_dir=self.base_dir,
-        )
+        return build_sb_issue_body(sb)
 
     def create_issue(self, sb: SchedulingBlock) -> Optional[dict]:
         """Create a GitHub issue for a scheduling block."""
@@ -676,25 +672,19 @@ class GitHubIssueManager:
             self.ensure_label("Extracted")
             needs_update = True
 
-        # Update weblog link - prefer weblog_url from staging (already normalized)
+        # Update weblog link - the URL comes exclusively from staging (DB).
+        # URLs are never fabricated from local filesystem paths (issue #21).
         if (sb.weblog_url or sb.weblog_path) and "[ ] Weblog available" in body:
             if sb.weblog_url:
                 body = body.replace("[ ] Weblog available", f"[x] [Weblog]({sb.weblog_url}) available")
-            elif sb.weblog_path:
-                if self.weblog_base_url:
-                    try:
-                        if self.weblog_dir:
-                            rel_path = sb.weblog_path.relative_to(self.weblog_dir)
-                        else:
-                            rel_path = sb.weblog_path.relative_to(self.base_dir)
-                        weblog_url = f"{self.weblog_base_url.rstrip('/')}/{rel_path}/index.html"
-                        weblog_url = normalize_weblog_url(weblog_url)
-                        body = body.replace("[ ] Weblog available", f"[x] [Weblog]({weblog_url}) available")
-                    except ValueError:
-                        body = body.replace("[ ] Weblog available", f"[x] Weblog available at: `{sb.weblog_path}`")
-                else:
-                    body = body.replace("[ ] Weblog available", f"[x] Weblog available at: `{sb.weblog_path}`")
+            else:
+                body = body.replace("[ ] Weblog available", f"[x] Weblog available at: `{sb.weblog_path}`")
             needs_update = True
+        else:
+            repaired = self._repair_weblog_link(sb, body, existing.number)
+            if repaired is not None:
+                body = repaired
+                needs_update = True
 
         # Update project board status if enabled
         project_status_updated = False
@@ -723,6 +713,90 @@ class GitHubIssueManager:
                 return False
 
         return True
+
+    def _under_weblog_dir(self, path: Path) -> bool:
+        """Check whether a path lies under the configured weblog directory."""
+        if not self.weblog_dir:
+            return False
+        try:
+            path.relative_to(self.weblog_dir)
+            return True
+        except ValueError:
+            return False
+
+    def _repair_weblog_link(
+        self, sb: SchedulingBlock, body: str, issue_number: Any
+    ) -> Optional[str]:
+        """Replace a demonstrably broken weblog link with the staged URL.
+
+        Returns the updated body, or None if no repair is needed or safe.
+        A repair only fires when ALL of the following hold:
+
+        * the SB has a DB-derived staged URL (``sb.weblog_url``),
+        * the body contains exactly one checked weblog link line,
+        * the linked URL differs from the staged URL,
+        * the staged weblog directory is configured, mounted and non-empty,
+        * the linked URL maps to a path under the weblog directory that
+          does NOT exist (genuinely broken -- external or working links
+          are never touched),
+        * the staged URL maps to a path under the weblog directory that
+          DOES exist on disk.
+        """
+        if not sb.weblog_url:
+            return None
+        matches = WEBLOG_LINK_LINE_RE.findall(body)
+        if len(matches) != 1:
+            if len(matches) > 1:
+                log.warning(
+                    "Issue #%s has %d weblog link lines; not repairing",
+                    issue_number, len(matches),
+                )
+            return None
+        current_url = matches[0]
+        if current_url == sb.weblog_url:
+            return None
+
+        # The weblog dir must be configured and look mounted (non-empty).
+        if not self.weblog_dir or not self.weblog_dir.is_dir():
+            return None
+        try:
+            if not any(self.weblog_dir.iterdir()):
+                return None
+        except OSError:
+            return None
+
+        current_path = url_to_path(current_url, self.url_mappings)
+        if current_path is None or not self._under_weblog_dir(current_path):
+            log.info(
+                "Issue #%s weblog link is external/unmapped (%s); leaving as-is",
+                issue_number, current_url,
+            )
+            return None
+        if current_path.exists():
+            return None  # link target exists on disk; nothing to repair
+
+        new_path = url_to_path(sb.weblog_url, self.url_mappings)
+        if (
+            new_path is None
+            or not self._under_weblog_dir(new_path)
+            or not new_path.exists()
+        ):
+            log.warning(
+                "Issue #%s weblog link is broken (%s) but staged URL %s "
+                "is not verifiable on disk; not repairing",
+                issue_number, current_url, sb.weblog_url,
+            )
+            return None
+
+        log.info(
+            "Repairing broken weblog link on issue #%s: %s -> %s",
+            issue_number, current_url, sb.weblog_url,
+        )
+        return WEBLOG_LINK_LINE_RE.sub(
+            lambda m: f"* [x] [Weblog]({sb.weblog_url}) available",
+            body,
+            count=1,
+        )
 
     def _update_project_status(self, issue: Any, sb: SchedulingBlock) -> bool:
         """Update the project board status for an existing issue.

--- a/panta_rei/workflows/retrieval.py
+++ b/panta_rei/workflows/retrieval.py
@@ -235,6 +235,7 @@ class UpdateIssuesStep(Step):
                 gh_project_number=ctx.config.gh_project_number,
                 update_project_status=True,
                 update_targets=True,
+                url_mappings=ctx.config.url_mappings,
             )
             created, updated = manager.run()
 

--- a/tests/test_issue_weblog_repair.py
+++ b/tests/test_issue_weblog_repair.py
@@ -236,6 +236,27 @@ class TestRepairWeblogLink:
         body = _body_with_weblog_line("* [ ] Weblog available")
         assert mgr._repair_weblog_link(sb, body, 21) is None
 
+    def test_traversal_url_never_repaired(self, tmp_path, staged):
+        """A URL using dot segments to lexically sit under the weblog dir
+        while pointing outside it must be rejected, not repaired."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        traversal = f"{URL_PREFIX}/weblogs/../outside/html/index.html"
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(f"* [x] [Weblog]({traversal}) available")
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_symlink_escape_not_contained(self, tmp_path, staged):
+        """A symlink under the weblog dir pointing outside must not count
+        as contained once paths are resolved."""
+        outside = tmp_path / "outside-tree"
+        outside.mkdir()
+        link = staged["weblog_dir"] / "escape"
+        link.symlink_to(outside)
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        assert mgr._under_weblog_dir(link / "html" / "index.html") is False
+
     def test_http_https_scheme_mismatch_still_repairs(self, tmp_path, staged):
         """Bodies use http:// while mappings declare https:// (or vice
         versa); scheme differences must not block the repair."""

--- a/tests/test_issue_weblog_repair.py
+++ b/tests/test_issue_weblog_repair.py
@@ -1,0 +1,248 @@
+"""Tests for weblog link handling in GitHub issue bodies.
+
+Covers the removal of path-derived URL fabrication (the issue #21 root
+cause), exact-UID weblog lookup, and the guarded self-healing of broken
+weblog links in ``update_issue``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from panta_rei.github.issues import (
+    GitHubIssueManager,
+    SchedulingBlock,
+    build_sb_issue_body,
+)
+
+URL_PREFIX = "https://test.example/nas"
+
+
+def _make_manager(tmp_path: Path, weblog_dir: Path) -> GitHubIssueManager:
+    with patch("ghapi.all.GhApi"):
+        return GitHubIssueManager(
+            project_code="2025.1.00383.L",
+            base_dir=tmp_path,
+            gh_owner="owner",
+            gh_repo="repo",
+            gh_token="dummy-token",
+            weblog_dir=weblog_dir,
+            dry_run=True,
+            url_mappings={str(tmp_path): URL_PREFIX},
+        )
+
+
+def _sb(**kwargs) -> SchedulingBlock:
+    defaults = dict(
+        sb_name="AG000.00_a_00_TP",
+        array="TP",
+        gous_id="X1_X2",
+        mous_ids=["X3833_X64d8"],
+        targets={"AG000.00+0.00"},
+    )
+    defaults.update(kwargs)
+    return SchedulingBlock(**defaults)
+
+
+def _body_with_weblog_line(line: str) -> str:
+    return (
+        "## Scheduling Block: AG000.00_a_00_TP\n\n"
+        "### Data Status\n\n"
+        "* [x] Delivered\n"
+        "* [x] Downloaded\n"
+        "* [x] Extracted\n"
+        f"{line}\n\n"
+        "### Quality Assessment\n\n"
+        "* [ ] Weblog reviewed\n"
+    )
+
+
+@pytest.fixture
+def staged(tmp_path):
+    """A staged weblog tree with one valid and one absent pipeline dir."""
+    weblog_dir = tmp_path / "weblogs"
+    good = weblog_dir / "uid___A001_X3833_X64d8" / "pipeline-NEW" / "html"
+    good.mkdir(parents=True)
+    (good / "index.html").write_text("<html></html>")
+    return {
+        "weblog_dir": weblog_dir,
+        "good_url": f"{URL_PREFIX}/weblogs/uid___A001_X3833_X64d8/pipeline-NEW/html/index.html",
+        "bad_url": f"{URL_PREFIX}/weblogs/uid___A001_X3833_X64d8/pipeline-OLD/html/index.html",
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_sb_issue_body: no URL fabrication from paths
+# ---------------------------------------------------------------------------
+
+class TestNoUrlFabrication:
+    def test_weblog_url_used_verbatim(self):
+        sb = _sb(weblog_url="http://x/y/html/index.html")
+        assert "* [x] [Weblog](http://x/y/html/index.html) available" in (
+            build_sb_issue_body(sb)
+        )
+
+    def test_path_without_url_renders_plain_path(self):
+        sb = _sb(weblog_path=Path("/local/scratch/pipeline-123"))
+        body = build_sb_issue_body(sb)
+        assert "[Weblog](" not in body
+        assert "* [x] Weblog available at: `/local/scratch/pipeline-123`" in body
+
+    def test_no_weblog_renders_unchecked(self):
+        assert "* [ ] Weblog available" in build_sb_issue_body(_sb())
+
+
+# ---------------------------------------------------------------------------
+# find_weblog: exact canonical UID matching
+# ---------------------------------------------------------------------------
+
+class TestFindWeblogExactMatch:
+    def _weblog_info(self):
+        return {
+            "uid___a001_x3833_x64d80": ("/w/uid___A001_X3833_X64d80/p", "http://u/80"),
+            "uid___a001_x3833_x64d8": ("/w/uid___A001_X3833_X64d8/p", "http://u/8"),
+        }
+
+    def test_compact_id_matches_exactly(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(mous_ids=["X3833_X64d8"])
+        path, url = mgr.find_weblog(sb, self._weblog_info())
+        # Must match x64d8 exactly, never the x64d80 entry via substring
+        assert path == Path("/w/uid___A001_X3833_X64d8/p")
+        assert url == "http://u/8/html/index.html"
+
+    def test_full_uid_form_matches(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(mous_ids=["uid___A001_X3833_X64d8"])
+        path, _ = mgr.find_weblog(sb, self._weblog_info())
+        assert path == Path("/w/uid___A001_X3833_X64d8/p")
+
+    def test_no_match_returns_none(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(mous_ids=["X3833_Xffff"])
+        assert mgr.find_weblog(sb, self._weblog_info()) == (None, None)
+
+    def test_empty_info_returns_none(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        assert mgr.find_weblog(_sb(), {}) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _repair_weblog_link: guarded self-healing
+# ---------------------------------------------------------------------------
+
+class TestRepairWeblogLink:
+    def test_repairs_broken_link(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(
+            f"* [x] [Weblog]({staged['bad_url']}) available"
+        )
+        repaired = mgr._repair_weblog_link(sb, body, 21)
+        assert repaired is not None
+        assert staged["good_url"] in repaired
+        assert staged["bad_url"] not in repaired
+        # Only the weblog line changed
+        assert repaired.replace(staged["good_url"], staged["bad_url"]) == body
+
+    def test_working_link_never_touched(self, tmp_path, staged):
+        """A link whose target exists on disk is left alone, even if it
+        differs from the staged URL (protects deliberate manual edits)."""
+        other = staged["weblog_dir"] / "uid___A001_X9_X9" / "html"
+        other.mkdir(parents=True)
+        (other / "index.html").write_text("x")
+        other_url = f"{URL_PREFIX}/weblogs/uid___A001_X9_X9/html/index.html"
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(f"* [x] [Weblog]({other_url}) available")
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_external_url_never_touched(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(
+            "* [x] [Weblog](https://elsewhere.example/weblog.html) available"
+        )
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_url_outside_weblog_dir_never_touched(self, tmp_path, staged):
+        # Maps under the fs prefix but not under weblog_dir
+        url = f"{URL_PREFIX}/other-tree/foo/html/index.html"
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(f"* [x] [Weblog]({url}) available")
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_unverifiable_replacement_blocks_repair(self, tmp_path, staged):
+        missing = (
+            f"{URL_PREFIX}/weblogs/uid___A001_X3833_X64d8/"
+            "pipeline-MISSING/html/index.html"
+        )
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=missing)
+        body = _body_with_weblog_line(
+            f"* [x] [Weblog]({staged['bad_url']}) available"
+        )
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_missing_weblog_dir_blocks_repair(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, tmp_path / "not-mounted")
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(
+            f"* [x] [Weblog]({staged['bad_url']}) available"
+        )
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_empty_weblog_dir_blocks_repair(self, tmp_path):
+        """An empty weblog dir looks unmounted; repair must not fire."""
+        empty = tmp_path / "weblogs-empty"
+        empty.mkdir()
+        mgr = _make_manager(tmp_path, empty)
+        sb = _sb(weblog_url=f"{URL_PREFIX}/weblogs-empty/u/html/index.html")
+        body = _body_with_weblog_line(
+            f"* [x] [Weblog]({URL_PREFIX}/weblogs-empty/old/html/index.html) available"
+        )
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_duplicate_weblog_lines_block_repair(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        line = f"* [x] [Weblog]({staged['bad_url']}) available"
+        body = _body_with_weblog_line(line) + f"\n{line}\n"
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_no_staged_url_blocks_repair(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb()  # no weblog_url
+        body = _body_with_weblog_line(
+            f"* [x] [Weblog]({staged['bad_url']}) available"
+        )
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_identical_url_no_repair(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(
+            f"* [x] [Weblog]({staged['good_url']}) available"
+        )
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_no_weblog_line_no_repair(self, tmp_path, staged):
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line("* [ ] Weblog available")
+        assert mgr._repair_weblog_link(sb, body, 21) is None
+
+    def test_http_https_scheme_mismatch_still_repairs(self, tmp_path, staged):
+        """Bodies use http:// while mappings declare https:// (or vice
+        versa); scheme differences must not block the repair."""
+        bad_http = staged["bad_url"].replace("https://", "http://")
+        mgr = _make_manager(tmp_path, staged["weblog_dir"])
+        sb = _sb(weblog_url=staged["good_url"])
+        body = _body_with_weblog_line(f"* [x] [Weblog]({bad_http}) available")
+        repaired = mgr._repair_weblog_link(sb, body, 21)
+        assert repaired is not None
+        assert staged["good_url"] in repaired

--- a/tests/test_urlmap.py
+++ b/tests/test_urlmap.py
@@ -1,0 +1,64 @@
+"""Tests for the shared path<->URL mapping helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from panta_rei.core.urlmap import path_to_url, url_to_path
+
+MAPPINGS = {"/scratch/almanas": "https://www.alma.ac.uk/nas"}
+
+
+class TestPathToUrl:
+    def test_basic_mapping(self, tmp_path):
+        url = path_to_url(
+            Path("/scratch/almanas/dwalker2/panta-rei/weblogs/uid___A001_X1_X2"),
+            MAPPINGS,
+        )
+        assert url == (
+            "https://www.alma.ac.uk/nas/dwalker2/panta-rei/weblogs/uid___A001_X1_X2"
+        )
+
+    def test_component_boundary_not_matched(self):
+        # /scratch/almanas-other must NOT match the /scratch/almanas prefix
+        assert path_to_url(Path("/scratch/almanas-other/foo"), MAPPINGS) is None
+
+    def test_unmapped_path_returns_none(self):
+        assert path_to_url(Path("/data/elsewhere/foo"), MAPPINGS) is None
+
+    def test_prefix_itself_maps_to_base(self):
+        assert path_to_url(Path("/scratch/almanas"), MAPPINGS) == (
+            "https://www.alma.ac.uk/nas"
+        )
+
+
+class TestUrlToPath:
+    def test_basic_mapping(self):
+        p = url_to_path(
+            "https://www.alma.ac.uk/nas/dwalker2/panta-rei/weblogs/x/html/index.html",
+            MAPPINGS,
+        )
+        assert p == Path(
+            "/scratch/almanas/dwalker2/panta-rei/weblogs/x/html/index.html"
+        )
+
+    def test_scheme_insensitive(self):
+        # Issue bodies use http:// while the mapping is declared https://
+        p = url_to_path("http://www.alma.ac.uk/nas/dwalker2/foo", MAPPINGS)
+        assert p == Path("/scratch/almanas/dwalker2/foo")
+
+    def test_component_boundary_not_matched(self):
+        # /nastier must not match the /nas URL prefix
+        assert url_to_path("https://www.alma.ac.uk/nastier/foo", MAPPINGS) is None
+
+    def test_other_host_returns_none(self):
+        assert url_to_path("https://example.org/nas/foo", MAPPINGS) is None
+
+    def test_non_http_scheme_returns_none(self):
+        assert url_to_path("ftp://www.alma.ac.uk/nas/foo", MAPPINGS) is None
+        assert url_to_path("", MAPPINGS) is None
+        assert url_to_path(None, MAPPINGS) is None
+
+    def test_roundtrip(self):
+        original = Path("/scratch/almanas/dwalker2/panta-rei/weblogs/u/html/index.html")
+        assert url_to_path(path_to_url(original, MAPPINGS), MAPPINGS) == original

--- a/tests/test_urlmap.py
+++ b/tests/test_urlmap.py
@@ -62,3 +62,17 @@ class TestUrlToPath:
     def test_roundtrip(self):
         original = Path("/scratch/almanas/dwalker2/panta-rei/weblogs/u/html/index.html")
         assert url_to_path(path_to_url(original, MAPPINGS), MAPPINGS) == original
+
+    def test_dot_segment_traversal_rejected(self):
+        assert url_to_path(
+            "https://www.alma.ac.uk/nas/weblogs/../../etc/passwd", MAPPINGS
+        ) is None
+        assert url_to_path(
+            "https://www.alma.ac.uk/nas/weblogs/./x/index.html", MAPPINGS
+        ) is None
+
+    def test_percent_encoded_traversal_rejected(self):
+        assert url_to_path(
+            "https://www.alma.ac.uk/nas/weblogs/%2e%2e/%2e%2e/etc/passwd",
+            MAPPINGS,
+        ) is None


### PR DESCRIPTION
## Summary

Issue #21 : weblog link in the issue body 404s. Investigation, root cause, and fix:

### Root cause
- The link pointed at a **local ScriptForPI pipeline directory** (`pipeline-20251210T221047` under `.../calibrated/working/`) grafted onto the public weblog base URL — a URL that never existed on the webserver. It was written on 2025-12-11 by the legacy updater's filesystem-search fallback + `relative_to(base_dir)` URL fabrication.
- The properly staged weblog (`pipeline-20251112T194924`) went online 2026-02-02 with the correct URL in the DB, but `update_issue` only fills in unchecked `[ ] Weblog available` lines, so the already-ticked broken link was never repaired.

### Scope
Audited all 144 SB issues against the NAS filesystem and the state DB: **#21 was the only broken link**; the other 143 exactly match the DB-canonical URLs. #21's body has been repaired directly (surgical URL replacement, verified).

### Changes
- **`panta_rei/core/urlmap.py`** (new): shared path↔URL mapping — component-boundary safe, scheme-insensitive, rejects dot-segment/percent-encoded traversal. `alma/staging.path_to_url` now delegates to it.
- **`github/issues.py`**:
  - Removed both path-derived URL fabrication branches (the root-cause landmine). Weblog URLs now come exclusively from staging via the DB; plain-path text fallback otherwise.
  - `find_weblog`: exact canonical-UID matching (no more substring fuzz).
  - `update_issue`: guarded self-healing — replaces a weblog link only when it maps under the staged weblog dir but is **missing on disk**, the weblog dir looks mounted, and the replacement URL is **verified present on disk**. External or working links are never touched.
  - Containment checks resolve symlinks; `url_mappings` threaded from config.